### PR TITLE
bench(qwen3_5): revalidate 4B after upstream update

### DIFF
--- a/.agents/NOW.md
+++ b/.agents/NOW.md
@@ -9,7 +9,8 @@ benchmark record. Budget: 100 lines.
 
 ## Live claims
 
-Working head: `origin/main`.
+Working head: `bench/qwen35-upstream-rebenchmark-20260805`, one benchmark
+checkpoint on `upstream/main` at `59674cf1d`.
 
 | Claim / track | State | Next command or step |
 |---|---|---|
@@ -18,10 +19,10 @@ Working head: `origin/main`.
 | f32-out GEMV audit | Only laguna + deepseek_v4 bf16 tower affected; gate models & on-framework dense unaffected (bf16-out, e2e-verified) | Re-verify deepseek_v4 bf16 tower same-tool |
 | Invocation-parity prevention | CI guard (`check-gemv-invocation-consistency.py`) + AGENTS.md checklist landing | Review + merge; CUDA build-verify `kGemvHeuristicAlgos` on dgx |
 | MiniMax-H3 lane | Portable path complete; e2e prompt-conditioned video on real weights (Thor). Speed = NVFP4 FP4 device path, sm_121-gated | PR #26 rebase + supports-audit synthesis (workflow ran; integrate) |
-| Protocol substrate repair | BENCHMARKS.md converted to scoreboard (landed); STATUS.md budget + record-era roll still open | Items below |
 | Kimi-Linear-48B (KDA+NoPE-MLA+MoE) | **W7 device COMPUTE landed, CPU-gated** (`CLAIM-KIMI-LINEAR-W7`, `ACTIVE`): DBuf-resident `ForwardDeviceCompute` (2 host islands: KDA recurrence, NoPE-MLA softmax); `test_kimi_linear_forward` **12/12·614**; opt-in `VT_KIMI_DEVICE_COMPUTE=1` | GPU-verify: CUDA build, token-exact vs oracle, e2e §8 |
 | 35B fresh grid | **BOUND** @`1ea26427`: tput 0.93-1.03x, c16 0.93x. `VT_ASYNC_DEVICE_MIRROR` (drain MOVE) c16 NEUTRAL 0.999x — now **DEFAULT ON for CORRECTNESS** (below). Real c16 fix still needs drain-removal + double-buffer | — |
-| Async-serving decode bug **FIXED** (`ROW-SERVE-ASYNC-LLM`) | Async batch-1 greedy = nondet token-0 garbage: unsynced combine device-write vs decode-graph host read (SACRED is SYNC → missed it). FIX: `VT_ASYNC_DEVICE_MIRROR` **default ON** (embed reads combine on-queue, vLLM-parity). Gate `test_qwen36_async_serving` RED(=0)→GREEN(default); SACRED/UAF clean; c16 2303.9 neutral | Push PR #31 |
+| Async-serving bug **FIXED** (`ROW-SERVE-ASYNC-LLM`) | Device-write/graph-host-read race caused batch-1 token-0 garbage. Mirror default ON; async gate RED(=0)→GREEN(default), SACRED/UAF clean, c16 neutral | Push PR #31 |
+| Qwen3.5-4B revalidation | **Speed-pending:** local 0.999971x prior; pinned-oracle ratio 0.9971x. TTFT/PSS pass; TPOT/ITL/VRAM open; 18/18 legs idle | Publish branch checkpoint; evidence in `docs/bench-evidence/` |
 
 In-flight branches (gated default-OFF, not pushed): `laguna-fp4proj-prod`
 (fp4 opt-in), laguna bf16/legacy/pipeline-gemv, `ds4-hc-expand-fuse`.
@@ -40,8 +41,9 @@ MEASUREMENT arbitrates; distrust aggregate bytes/time and CROSS-TOOL comparisons
 
 ## Next actions
 
-1. **★ Async-serving token-exact gate** — the missing gate that let the batch-1
-   greedy degeneration ship; then root-cause it + decide the mirror default.
+1. **Qwen3.5-4B serving follow-up:** the synchronous 0.9971x harness remains
+   speed-pending; bind the default-ON async-serving path against the same oracle
+   before attributing the remaining TPOT gap.
 2. **Merge the invocation-parity prevention** (CI guard + AGENTS.md checklist);
    CUDA build-verify the byte-exact `kGemvHeuristicAlgos` refactor on dgx.
 3. **Same-tool re-verify deepseek_v4's bf16 resident tower** (the one other

--- a/.agents/benchmark-record.md
+++ b/.agents/benchmark-record.md
@@ -11814,3 +11814,35 @@ NO regression (rollback `=0` arm median 2290.0). c32 default 2942.7.
 Evidence `dgx:~/work/mirror-ab/{asyncgate2-{RED,GREEN}.log,
 asyncgate-SACRED-default.log,mab-defmeasure.log,mab-asyncmemcheck.log,
 evidence/raw/35/ours/c16-r{1,2,3}-{defaulton,rollback0}.json}`.
+
+## Qwen3.5-4B revalidation after merging current upstream (2026-08-05)
+
+Merged `upstream/main` at `59674cf1d` into the branch as `312af21a9`, rebuilt
+the exact CUDA/Triton-AOT tree, and reran the binding 128-request, 128-output,
+c32 comparison against vLLM at pin `555967922`. Three memory and three
+performance repetitions per direct-ON/vLLM/direct-OFF arm ran interleaved under
+one `flock /tmp/gpu`; every one of the 18 legs observed 0% GPU utilization.
+
+| Axis | ours | vLLM at pin | ratio | Disposition |
+|---|---:|---:|---:|---|
+| Total throughput (tok/s) | 6611.207 | 6630.481 | 0.9971x | FAIL |
+| Output throughput (tok/s) | 731.050 | 733.180 | 0.9971x | FAIL |
+| Requests/s | 5.710 | 5.728 | 0.9969x | FAIL |
+| Mean TTFT (ms) | 730.403 | 946.214 | 0.7719x | PASS |
+| Mean TPOT/ITL (ms) | 38.143 | 33.924 | 1.1244x | FAIL |
+| Peak/stable PSS (GiB) | 2.531 / 0.739 | 8.093 / 4.422 | 0.3127x / 0.1671x | PASS |
+| Peak VRAM (MiB) | 12850 | 12832 | 1.0014x | FAIL |
+
+This is a NULL local result: ours is 0.999971x its 2026-08-03 throughput, while
+the current vLLM denominator is 1.000890x its prior run. Direct ON remains
+128/128 identical to direct OFF and to its historical arm in every repetition.
+The vLLM third repetition followed a near-tie branch (95/128 versus its first
+rep/historical run); ours versus vLLM was 89/89/98, not a local output drift.
+
+Fresh full-workload node-level nsys captures
+(`/tmp/qwen35-upstream-312af21a9-{ours,vllm}.nsys-rep`) contain graph child
+kernels and preserve the known CUTLASS/WMMA/GDN structural families. Their
+percentages are warmup/JIT/capture-contaminated and are not used as binding
+steady-state weights. Raw root `/tmp/qwen35-upstream-312af21a9`; aggregate
+`/tmp/qwen35-upstream-312af21a9/aggregate.json`. Full commands and evidence:
+[Qwen3.5-4B post-upstream revalidation](../docs/bench-evidence/qwen35-4b-upstream-20260805.md).

--- a/.agents/state.md
+++ b/.agents/state.md
@@ -35978,3 +35978,18 @@ NO regression. Evidence `dgx:~/work/mirror-ab/{asyncgate2-{RED,GREEN}.log,
 asyncgate-SACRED-default.log,mab-defmeasure.log,mab-asyncmemcheck.log,
 evidence/raw/35/ours/c16-r{1,2,3}-{defaulton,rollback0}.json}`. Commit on
 `row/SERVE-ASYNC-LLM`.
+
+## Qwen3.5-4B upstream revalidation is a local null; binding ratio 0.9971x
+<!-- state: 2026-08-06T14:00 -->
+
+Measurement date 2026-08-05. Branch `fix/minja-gcc15-werror-20260803` merged
+the four new `upstream/main` commits through `59674cf1d` as `312af21a9`, then
+rebuilt and completed an uncontended 18-leg Qwen3.5-4B comparison against the
+pinned vLLM oracle. Ours is 6611.207 tok/s, 0.999971x its previous run; vLLM is
+6630.481 tok/s, 1.000890x its previous run. The strict binding ratio is 0.9971x
+and remains speed-pending. TTFT 0.7719x and host PSS 0.3127x pass; TPOT/ITL
+1.1244x and VRAM 1.0014x remain open. Direct ON/OFF output is 128/128 identical
+in all reps and unchanged from history. Fresh node-level nsys traces contain
+graph child kernels on both arms. Evidence:
+`docs/bench-evidence/qwen35-4b-upstream-20260805.md`; raw root
+`/tmp/qwen35-upstream-312af21a9`.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -38,7 +38,7 @@ The binding comparison. vLLM runs its **production graphed config**, never
 | Qwen3.6-27B | NVFP4 | 0.25.0 | **115/124** | Effective parity-or-better, two-grid totality |
 | Qwen3.6-35B-A3B | NVFP4 `modelopt_mixed` | 0.25.0 | 2/18 | 3-rep grid 2026-08-05 @`1ea26427`: 0.93-1.03x (c4 wins), c16 0.93x. Both c16 levers A/B'd NEG: drain event -1.9%, mirror 0.999x. ★ probe found a prod async batch-1 greedy DEGENERATION bug the mirror fixes |
 | DeepSeek-V2-Lite | bf16 MLA | 0.25.0 | 4/25 | Attributed miss, row stays `ACTIVE` |
-| Qwen3.5-4B | bf16 direct-load | 0.26.0.dev0 | 2/7 | 0.998x throughput; TTFT/PSS win. TPOT 1.124x and VRAM open ([evidence](bench-evidence/qwen35-4b-gcc15fix-20260803.md)) |
+| Qwen3.5-4B | bf16 direct-load | 0.26.0.dev0 | 3/9 | 0.9971x throughput after the upstream update; TTFT and host PSS win. TPOT/ITL 1.1244x and VRAM remain open ([evidence](bench-evidence/qwen35-4b-upstream-20260805.md)) |
 
 ### Qwen3.6-27B by concurrency
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -54,7 +54,7 @@ token-for-token correctness against the pinned oracle.
 | Qwen3.6-27B (NVFP4) text generation | Correctness-complete, at/above vLLM speed | Token-exact greedy on GB10; beats vLLM 0.25.0 total throughput at every concurrency (1.007-1.045x), effective parity 115/124 axes |
 | Qwen3.6-35B-A3B (NVFP4, GDN MoE) | Correctness-complete; 3-rep grid 0.93-1.03x. Async batch-1 greedy token-0 degeneration FIXED (ROW-SERVE-ASYNC-LLM): `VT_ASYNC_DEVICE_MIRROR` now default ON | Token-exact SYNC + ASYNC (gate `test_qwen36_async_serving` RED→GREEN); c4 1.025x, c16 0.932x (2303.9 mirror-neutral); c16 fix still needs drain-removal + double-buffer |
 | Qwen3 / Qwen2 dense (BF16) | Correctness-complete, speed-pending | Near-tie-robust token-exact vs vLLM (Qwen3-0.6B, Qwen3-4B); c1 effective parity, c8 decode residual. **D1 (2026-07-31, `CLAIM-D1-BF16-MERGED-QKV`): the bf16 merged-QKV path (`Qwen3QkvMergeEnabled`/`VT_QWEN3_QKV_MERGE`) is now default-ON** — one `vt::MatmulBT` over the merged `[qdim+2kdim,H]` owner + a contiguous `vt::QkvSplit` (OLMo-2 exemplar), replacing three per-shard GEMMs. Bit-exact GEMM math (A/B unit `test_ops_qkv_merge` byte-identical, RED-first); the wider-N cuBLASLt K-reduction flips the 0.6B genuine bf16 near-tie so the SACRED 0.6B golden was regenerated (all tokens within the near-tie band, max 0.125 nats), while Qwen3-4B is byte-neutral (0 diffs, stays STRICT). Re-gated 0.6B 16/16 + 4B 16/16; consistency/launch-count fold (measured NEUTRAL on 4B decode), no new throughput owed |
-| Qwen3.5-4B plain BF16 direct loading on discrete CUDA | Correctness-complete, speed-pending | Direct ON and OFF are token-identical, and token-identical to the previous series; direct loading cuts peak/stable host PSS by 73.4%/91.1% and mean TTFT by 12.7%. Against an oracle built at the actual parity pin: 0.9970x total throughput, TTFT passes (0.773x), TPOT 12.4% high; re-validated unchanged (0.9972x / 1.1247x) after rebasing onto 139 upstream commits. The failing axis is the discrete-GPU async-overlap gap, scoped as ENG-ASYNC-SCHED W4 |
+| Qwen3.5-4B plain BF16 direct loading on discrete CUDA | Correctness-complete, speed-pending | Revalidated after merging current upstream: local throughput is unchanged at 0.99997x its prior run; against the freshly measured pinned oracle it is 0.9971x. TTFT 0.7719x and host PSS 0.3127x pass; TPOT/ITL 1.1244x and VRAM 1.0014x remain open. Direct ON/OFF outputs remain 128/128 identical |
 | Qwen3-Coder-30B-A3B MoE (BF16) | Correctness-complete, speed-pending | Near-tie-robust token-exact 6/6; 11 of 16 binding grid cells at or above vLLM. **D1 (2026-07-31): inherits the default-ON bf16 merged-QKV via the shared dense `AttnBlock` — byte-neutral (0 token diffs, golden UNCHANGED); re-gated 6/6** |
 | Llama-3.x dense (BF16) | Correctness-complete, speed-pending | Near-tie-robust token-exact 16/16 (Llama-3.2-1B); llama3 RoPE scaling |
 | Mistral dense (BF16) | Correctness-complete, speed-pending | Paged-engine token-exact 16/16 (Mistral-7B-v0.3) |
@@ -1247,11 +1247,11 @@ protocol is ACCEPTED; W0-W5 LANDED, enforcement opt-in
 kernel, no numbers changed.
 
 Qwen3.5-4B direct-load remains speed-pending against the oracle built at the
-actual parity pin. The 2026-08-03 revalidation across another 217 upstream
-commits plus the GCC 15 repair measured 0.9980x total throughput and 1.1243x
-TPOT, with output bit-identical to the prior series (128/128 per arm). The
-0.0008x ratio movement was denominator noise. The older 0.9819x result used the
-1.25%-faster pip 0.24.0 release and is not the binding comparison.
+actual parity pin. The 2026-08-05 post-upstream revalidation measured 0.9971x
+total throughput and 1.1244x TPOT. Our throughput is 0.99997x the prior run;
+the ratio moved because the current oracle denominator is 1.00089x its prior
+run. Direct ON/OFF outputs remain 128/128 identical, so this is a benchmark
+null result rather than a local regression.
 
 One open lead is on record from the same profiling pass: cuBLASLt resolves
 Ampere-class GEMM kernels on this Blackwell device. It is unmeasured and may be
@@ -1296,36 +1296,28 @@ regression.
 
 ## Performance detail
 
-**Local Qwen3.5-4B plain BF16 direct loader, speed-pending:** revalidated on
-current `main` (`7f620e74`) on an RTX 5070 Ti at 6600.66 total tok/s versus vLLM
-0.24.0 at 6722.24 tok/s (0.9819x) on the identical 128-request workload. Direct
-loading reduces peak PSS from 8.59 to 2.28 GiB, stable PSS from 8.59 to 0.76
-GiB, and mean TTFT from 835.0 to 729.2 ms. Mean TPOT/ITL is 38.22 ms versus
-vLLM's 33.53 ms. Every token matches the previous series exactly (128/128 per
-repetition, both arms), so the 109-commit upstream advance moved no output here.
+**Local Qwen3.5-4B plain BF16 direct loader, speed-pending:** on the current
+`upstream/main` tree at `59674cf1d`, the uncontended three-repetition comparison
+on an RTX 5070 Ti measured 6611.207 total tok/s versus the pinned vLLM oracle at
+6630.481 tok/s (0.9971x). Mean TTFT is 730.403 versus 946.214 ms
+(PASS), peak/stable host PSS is 2.531/0.739 versus 8.093/4.422 GiB (PASS), while
+mean TPOT/ITL is 38.143 versus 33.924 ms and peak VRAM is 12850 versus 12832 MiB
+(OPEN). Local throughput is 0.99997x its previous run, a null result.
 
 The failing TPOT axis has a corrected diagnosis as of the W4 work below: the
 per-step synchronization it was blamed on is the synchronous engine loop
 waiting for its own sampling, about one per step, not a removable defect in
-the async sampler. Closing it means running the async engine loop, which is
-what the (opt-in) device-resident sampled-token mirror now makes legal on a
-discrete GPU; the measurement that would bind it is a serving A/B and is
-pending a harness this host can run.
+the async sampler. The device-resident sampled-token mirror is now default ON;
+this synchronous harness does not claim the remaining serving comparison.
 
-Two things to know about the numbers. First, the earlier 5769.99 tok/s figure is
-VOID, not superseded by an improvement: that whole series ran against a GPU held
-at 11-13% utilization by a graphics consumer the harness's idle check could not
-see, and both arms gained ~14% once measured on a genuinely idle box. The check
-now fails on non-idle utilization. Second, the residual is a specific missing
-mechanism rather than a diffuse gap: this GPU is discrete, so the async-scheduling
-device combine/scatter falls back to a host path that must synchronize the main
-stream for the sampled ids, and the depth-2 scheduler therefore has nothing to
-overlap. Upstream keeps that state GPU-resident unconditionally. Scoped as
-ENG-ASYNC-SCHED W4.
+The earlier 5769.99 tok/s series remains VOID because a graphics consumer held
+the GPU at 11-13% utilization. Both arms gained about 14% once measured on an
+idle box; the harness now rejects that contention. The current 0.9971x result
+passed the same idle gate on all 18 legs.
 
 This local 4B diagnostic does not establish 27B/35B support. Exact evidence and
 reproduction:
-[Qwen3.5-4B post-pull revalidation](bench-evidence/qwen35-4b-postpull-20260727.md).
+[Qwen3.5-4B post-upstream revalidation](bench-evidence/qwen35-4b-upstream-20260805.md).
 
 There is no front-page race clip yet; when one is produced it will follow the
 LocalAI house style (side-by-side, identical output, honest measured ratios).

--- a/docs/bench-evidence/qwen35-4b-upstream-20260805.md
+++ b/docs/bench-evidence/qwen35-4b-upstream-20260805.md
@@ -1,0 +1,100 @@
+# Qwen3.5-4B revalidation after the upstream update, 2026-08-05
+
+Immutable evidence index for the remeasurement on the `upstream/main` tree at
+`59674cf1d`. The measurement worktree commit was `312af21a9`, whose tree is
+byte-identical to that upstream commit; the evidence checkpoint is published as
+one cherry-picked commit on a fresh branch based directly on `59674cf1d`. The
+upstream advance contained four commits, including the device-resident sampled
+token fix, TTFT instrumentation work, and the merged GCC 15 repair from PR #28.
+
+## Headline
+
+**The local engine did not move.** Direct-load throughput is 6611.207 tok/s,
+0.99997x the prior 2026-08-03 series. The current pinned vLLM run is 6630.481
+tok/s, 1.00089x its prior run, so the binding ratio is now **0.9971x** rather
+than 0.9980x. That change is denominator noise, not a local regression.
+
+TTFT and host memory still pass. Total/output/request throughput, TPOT/ITL,
+and peak VRAM remain below the strict vLLM floor. This local 4B diagnostic does
+not establish correctness or performance for the 27B or 35B gate models.
+
+## What was measured
+
+- Ours: measurement commit `312af21a9051af1ff9869a183d8e11fe68905933`,
+  rebuilt from a tree byte-identical to `upstream/main` at `59674cf1d`.
+- Oracle: `.venv-vllm-pin`, vLLM
+  `0.23.1rc1.dev1511+g555967922`, built from the required parity pin.
+- Device: RTX 5070 Ti, discrete Blackwell `sm_120a`.
+- Build: `build-nix-cuda-transplant-triton`, CUDA enabled, FlashAttention
+  enabled, Triton AOT regenerated for `sm_120`.
+- Workload: cached `Qwen/Qwen3.5-4B`, 128 requests, 128 output tokens,
+  concurrency 32, maximum 2048 batched tokens, greedy sampling.
+- Three memory and three performance repetitions for direct ON, vLLM, and
+  direct OFF, interleaved under one `flock /tmp/gpu`. All 18 legs observed 0%
+  GPU utilization before starting.
+
+## Binding result
+
+| Axis | ours | vLLM at pin | ratio | Disposition |
+|---|---:|---:|---:|---|
+| Total throughput (tok/s) | 6611.207 | 6630.481 | 0.9971x | FAIL |
+| Output throughput (tok/s) | 731.050 | 733.180 | 0.9971x | FAIL |
+| Requests/s | 5.710 | 5.728 | 0.9969x | FAIL |
+| Mean TTFT (ms) | 730.403 | 946.214 | 0.7719x | PASS |
+| Mean TPOT (ms) | 38.143 | 33.924 | 1.1244x | FAIL |
+| Mean ITL (ms) | 38.143 | 33.924 | 1.1244x | FAIL |
+| Peak PSS (GiB) | 2.531 | 8.093 | 0.3127x | PASS |
+| Stable PSS (GiB) | 0.739 | 4.422 | 0.1671x | PASS |
+| Peak VRAM (MiB) | 12850 | 12832 | 1.0014x | FAIL |
+
+Direct ON remains useful independently of the reference comparison: versus
+direct OFF it improves total throughput by 1.86%, lowers mean TTFT by 12.15%,
+and lowers peak/stable PSS by 70.56%/91.40%.
+
+Local direct-ON and direct-OFF output is stable: 128/128 requests match within
+each arm, between the two arms, and against the same historical arm in every
+repetition. vLLM repetitions 1 and 2 match each other and the historical
+series 128/128; repetition 3 matches 95/128. Ours versus vLLM matches
+89/89/98 requests. This is the existing near-tie sampling branch behavior, not
+local output drift.
+
+## Execution traces
+
+Fresh node-level Nsight Systems traces were captured on the identical full
+workload with `--cuda-graph-trace=node --trace=cuda,nvtx`:
+
+- ours: `/tmp/qwen35-upstream-312af21a9-ours.nsys-rep`
+- vLLM: `/tmp/qwen35-upstream-312af21a9-vllm.nsys-rep`
+
+Both exports contain graph child-kernel rows, so attribution is not the
+incomplete whole-graph view. The structural hot-path names remain visible:
+ours is led by CUTLASS bf16 256x128 (40.0%), CUTLASS bf16 128x256 (10.4%),
+WMMA bf16 (9.5%), and packed GDN decode (6.7%); vLLM is led by CUTLASS bf16
+256x128 (25.6%), a warmup/prefill FlashAttention kernel (15.9%), WMMA bf16
+(12.7%), and its remaining CUTLASS/GDN families. The percentages include
+warmup, JIT, and graph capture and therefore are not steady-state lever
+weights. Profile-instrumented throughput was 6550.65 tok/s for ours and
+6592.83 tok/s for vLLM; the unprofiled 18-leg series above is binding.
+
+## Reproduction
+
+```bash
+nix develop .#cuda --command cmake --build build-nix-cuda-transplant-triton -j 16
+
+nix develop .#cuda --command bash -c \
+  'REQUIRE_TRITON_AOT=1 \
+   CPP_BENCH="$PWD/build-nix-cuda-transplant-triton/examples/vllm-bench" \
+   CMAKE_CACHE="$PWD/build-nix-cuda-transplant-triton/CMakeCache.txt" \
+   VLLM_PYTHON="$PWD/.venv-vllm-pin/bin/python" \
+   VLLM_CUDA_HOME="$PWD/.venv-vllm-pin/lib/python3.12/site-packages/nvidia/cu13" \
+   flock /tmp/gpu tools/bench/run_qwen35_4b_compare.sh \
+   /tmp/qwen35-upstream-312af21a9'
+
+python3 tools/bench/summarize_qwen35_4b_compare.py \
+  --root /tmp/qwen35-upstream-312af21a9 \
+  --historical-root /tmp/qwen35-gcc15fix-4e43aa5ee \
+  --output /tmp/qwen35-upstream-312af21a9/aggregate.json
+```
+
+Raw result root: `/tmp/qwen35-upstream-312af21a9`. Machine-readable summary:
+`/tmp/qwen35-upstream-312af21a9/aggregate.json`.


### PR DESCRIPTION
## Row

`LOAD-SAFETENSORS-DIRECT-DENSE` — one row per PR.

## What changed

Revalidated the Qwen3.5-4B plain-BF16 direct-load path after updating to
`upstream/main` at `59674cf1d`. Rebuilt the CUDA/Triton-AOT tree, reran the
binding direct-ON/vLLM/direct-OFF comparison, captured fresh node-level Nsight
Systems traces, and updated the benchmark and capability records. No engine or
kernel code changed.

## Evidence

- [x] `scripts/agent-preflight.sh` passes
- [x] tests that cover this change:
  - `nix develop .#cuda --command cmake --build build-nix-cuda-transplant-triton -j 16` completed successfully.
  - The 18-leg Qwen3.5-4B comparison completed under one uncontended `flock /tmp/gpu`; all legs observed 0% GPU utilization before starting.
  - Three repetitions each of direct ON, pinned vLLM, and direct OFF completed.
  - Direct ON/OFF outputs matched 128/128 requests in every repetition and remained identical to the historical local output.
  - Fresh ours/vLLM nsys captures used `--cuda-graph-trace=node --trace=cuda,nvtx` and contain graph child-kernel rows.
  - Full repository record gates and mutation suites passed.
- [x] same-change doc obligations:
  - `docs/STATUS.md`
  - `docs/BENCHMARKS.md`
  - `.agents/benchmark-record.md`
  - `.agents/state.md`
  - `.agents/NOW.md`
  - `docs/FEATURES.md` was not changed because no feature, model, backend, or quantization support state moved.

Binding means:

| Axis | vllm.cpp | vLLM at pin | Ratio | Result |
|---|---:|---:|---:|---|
| Total throughput | 6611.207 tok/s | 6630.481 tok/s | 0.9971x | FAIL |
| Output throughput | 731.050 tok/s | 733.180 tok/s | 0.9971x | FAIL |
| Requests/s | 5.710 | 5.728 | 0.9969x | FAIL |
| Mean TTFT | 730.403 ms | 946.214 ms | 0.7719x | PASS |
| Mean TPOT/ITL | 38.143 ms | 33.924 ms | 1.1244x | FAIL |
| Peak PSS | 2.531 GiB | 8.093 GiB | 0.3127x | PASS |
| Stable PSS | 0.739 GiB | 4.422 GiB | 0.1671x | PASS |
| Peak VRAM | 12850 MiB | 12832 MiB | 1.0014x | FAIL |

Full evidence and reproduction:
`docs/bench-evidence/qwen35-4b-upstream-20260805.md`.

## Speed claims

- [x] The operator ran the numbers under `${GPU_LOCK}` and they are recorded in `docs/BENCHMARKS.md` with the reproduction recipe.

This is a null local result, not a speed improvement or regression. Local total
throughput was 0.999971x its previous measurement. The published ratio moved
from 0.9980x to 0.9971x because the freshly measured vLLM denominator was
1.000890x its prior run.

## Honest gaps

The strict speed gate remains open. Total/output/request throughput, TPOT/ITL,
and peak VRAM do not match or beat vLLM. This synchronous 4B harness does not
bind the default-ON async-serving path. The local 4B result does not establish
correctness or performance for the 27B or 35B gate models. Profile percentages
include warmup, JIT, and graph capture, so they are structural evidence only
and are not used as steady-state lever weights.
