### PR TITLE
fix(gemma4/rocm): multi-EOS, host expert LRU, safer device expert admit

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -160,12 +160,12 @@ VRAM allows; host-stream paths remain for small-VRAM / debug.
 | `VT_GEMMA4_EXPERT_VRAM_MB` | off (`unset` or `0`) | Device expert-cache LRU in MiB. `unset`/`0` disables device expert upload (host path / resident stacks only). `N>0` admits up to N MiB of fill-only device experts (evict only with `VT_GEMMA4_EXPERT_EVICT=1`). Free VRAM is probed via `Backend::DeviceMemoryInfo` before Alloc |
 | `VT_GEMMA4_EXPERT_EVICT` | off | `=1` allows hipFree eviction from the device expert LRU under pressure. Default off — eviction under load has hung ROCm (`kfd_wait`) on gfx1201 |
 | `VT_GEMMA4_HOST_EXPERT_MB` | `2048` | Caps permanent host BF16 expert dequant packs (MiB). Unbounded cache OOM'd ~30G hosts under pollution. `0` = ephemeral dequant only (no retained packs) |
-| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads MoE experts resident on GPU(s) at prepare. Dual-GPU default packs **BF16** stacks (fast hipBLAS). No-op without `-DVLLM_CPP_HIP` |
+| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads MoE experts resident on GPU(s). Default packs **native FP8** (fast fused ExpertGeGLU + ½ VRAM). No-op without `-DVLLM_CPP_HIP` |
 | `VT_GEMMA4_RESIDENT_GPUS` | `2` | GPUs used to spread resident experts; clamped to device count. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
 | `VT_GEMMA4_RESIDENT_MAX_LAYERS` | (all) | Caps how many MoE layers get resident-preloaded. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
-| `VT_GEMMA4_RESIDENT_NATIVE` | off | `=1` packs **native FP8** expert weights+scales (~½ VRAM vs BF16 expand). Single-GPU auto-enables native unless `VT_GEMMA4_RESIDENT_BF16=1` |
-| `VT_GEMMA4_RESIDENT_BF16` | off | `=1` force BF16 expand resident even on single GPU |
-| `VT_GEMMA4_FP8_NATIVE` | off | `=1` decode via FP8 channel GEMV (needs device FP8 packs or LRU). Default off — prefer BF16 resident hipBLAS |
+| `VT_GEMMA4_RESIDENT_NATIVE` | on | `=0` disables native FP8 packs. Default on: u8 weights + channel scales on device |
+| `VT_GEMMA4_RESIDENT_BF16` | off | `=1` force BF16 expand resident (hipBLAS A/B; ~2× VRAM, usually slower than fused FP8) |
+| `VT_GEMMA4_FP8_NATIVE` | on | `=0` disables fused FP8 expert decode path. Default on when FP8 packs present |
 | `VT_GEMMA4_PREFILL_BATCH_MOE` | off | `=1` enables experimental group-by-expert prefill MoE (chunked GEMM + host scatter). Default off on ROCm until fully proven |
 | `VT_GEMMA4_LAYER_TRACE` | off | `=2` logs per-layer attn/moe wall times (and MoE hoist markers). Debug only |
 | `VT_ENGINE_STEP_LOG` | off | `=1` logs EngineCore step begin/end wall times (also enabled by `VT_SERVER_VERBOSE=1`) |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -150,17 +150,22 @@ Read-only observability; none change output.
 | `VT_H3_ACT_DUMP` | unset | Path to which ONE MiniMax-H3 device DiT forward writes a per-STAGE activation FINGERPRINT: mean/rms/absmax/finite plus a fixed set of positional sample values, for every stage and for the input-independent weight classes (islands, biases, output heads). Two weight arms running the SAME graph on the SAME inputs (e.g. an NVFP4-bf16 stream vs a GGUF-bf16 control) can then be diffed layer by layer: a JUMP at a stage names the guilty tensor class, and a scramble/transpose is caught by the positional samples even when rms matches. This is the instrument that REFUTED a #94 load-path defect (spec §8.12). Byte-identical to production when unset (no file is opened) |
 | `VT_H3_ACT_CALL` | 0 | Which forward `VT_H3_ACT_DUMP` captures, as a 0-based call index within the process. Only that one forward dumps, so a single small render (`--denoise-only --steps 1`) yields exactly one clean fingerprint file instead of 50 overwrites. Read only when `VT_H3_ACT_DUMP` is set |
 
-## ROCm + Gemma-4 residency (contributor #140)
+## ROCm + Gemma-4 residency (contributor #140 + long-prompt lab)
 
-Discrete-ROCm (gfx1201) bring-up knobs from PR #140. Off by default; no effect
-on CUDA/CPU builds beyond the documented behavior.
+Discrete-ROCm (gfx1201) bring-up knobs. Defaults favor GPU-resident MoE when
+VRAM allows; host-stream paths remain for small-VRAM / debug.
 
 | Variable | Default | What it does |
 |---|---|---|
-| `VT_GEMMA4_EXPERT_VRAM_MB` | unlimited (unset or `0`) | A positive MiB value caps the device expert-cache LRU; unset or `0` leaves the cache unlimited |
-| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads the Gemma-4 MoE experts resident on the GPU(s) after the first use instead of streaming them per step (discrete-ROCm optimization). No-op (with a stderr note) on a binary built without `-DVLLM_CPP_HIP` |
-| `VT_GEMMA4_RESIDENT_GPUS` | `2` | Number of GPUs across which resident Gemma-4 experts are spread; clamped to the ROCm device count. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
-| `VT_GEMMA4_RESIDENT_MAX_LAYERS` | (all) | Caps how many MoE layers get resident-preloaded, to fit a smaller VRAM budget. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
+| `VT_GEMMA4_EXPERT_VRAM_MB` | off (`unset` or `0`) | Device expert-cache LRU in MiB. `unset`/`0` disables device expert upload (host path / resident stacks only). `N>0` admits up to N MiB of fill-only device experts (evict only with `VT_GEMMA4_EXPERT_EVICT=1`). Free VRAM is probed via `Backend::DeviceMemoryInfo` before Alloc |
+| `VT_GEMMA4_EXPERT_EVICT` | off | `=1` allows hipFree eviction from the device expert LRU under pressure. Default off — eviction under load has hung ROCm (`kfd_wait`) on gfx1201 |
+| `VT_GEMMA4_HOST_EXPERT_MB` | `2048` | Caps permanent host BF16 expert dequant packs (MiB). Unbounded cache OOM'd ~30G hosts under pollution. `0` = ephemeral dequant only (no retained packs) |
+| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads MoE experts resident on GPU(s) at prepare (FP8→BF16 stacks today). Preferred path on dual discrete ROCm. No-op without `-DVLLM_CPP_HIP` |
+| `VT_GEMMA4_RESIDENT_GPUS` | `2` | GPUs used to spread resident experts; clamped to device count. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
+| `VT_GEMMA4_RESIDENT_MAX_LAYERS` | (all) | Caps how many MoE layers get resident-preloaded. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
+| `VT_GEMMA4_PREFILL_BATCH_MOE` | off | `=1` enables experimental group-by-expert prefill MoE (chunked GEMM + host scatter). Default off on ROCm until fully proven |
+| `VT_GEMMA4_LAYER_TRACE` | off | `=2` logs per-layer attn/moe wall times (and MoE hoist markers). Debug only |
+| `VT_ENGINE_STEP_LOG` | off | `=1` logs EngineCore step begin/end wall times (also enabled by `VT_SERVER_VERBOSE=1`) |
 | `VLLM_CPP_HTTP_FIXED_POOL` | `1` (fixed) | `=0` reverts the HTTP worker pool to the legacy dynamic mode. Production uses the capacity-derived fixed pool; the opt-out exists for same-binary A/B attribution |
 | `VT_ROCM_ATTN_CPU_REF` | unset | `=1` routes ROCm paged attention through the CPU reference kernel instead of the HIP kernel — a correctness A/B for the ROCm attention bring-up |
 | `VT_DEBUG_SAMPLED` | unset | `=1` prints the per-step sampled token id(s) to stderr (sampling-loop debug). Read-only; does not change output. Read once per token, so it does not stall the hot loop |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -160,9 +160,12 @@ VRAM allows; host-stream paths remain for small-VRAM / debug.
 | `VT_GEMMA4_EXPERT_VRAM_MB` | off (`unset` or `0`) | Device expert-cache LRU in MiB. `unset`/`0` disables device expert upload (host path / resident stacks only). `N>0` admits up to N MiB of fill-only device experts (evict only with `VT_GEMMA4_EXPERT_EVICT=1`). Free VRAM is probed via `Backend::DeviceMemoryInfo` before Alloc |
 | `VT_GEMMA4_EXPERT_EVICT` | off | `=1` allows hipFree eviction from the device expert LRU under pressure. Default off — eviction under load has hung ROCm (`kfd_wait`) on gfx1201 |
 | `VT_GEMMA4_HOST_EXPERT_MB` | `2048` | Caps permanent host BF16 expert dequant packs (MiB). Unbounded cache OOM'd ~30G hosts under pollution. `0` = ephemeral dequant only (no retained packs) |
-| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads MoE experts resident on GPU(s) at prepare (FP8→BF16 stacks today). Preferred path on dual discrete ROCm. No-op without `-DVLLM_CPP_HIP` |
+| `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads MoE experts resident on GPU(s) at prepare. Dual-GPU default packs **BF16** stacks (fast hipBLAS). No-op without `-DVLLM_CPP_HIP` |
 | `VT_GEMMA4_RESIDENT_GPUS` | `2` | GPUs used to spread resident experts; clamped to device count. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
 | `VT_GEMMA4_RESIDENT_MAX_LAYERS` | (all) | Caps how many MoE layers get resident-preloaded. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
+| `VT_GEMMA4_RESIDENT_NATIVE` | off | `=1` packs **native FP8** expert weights+scales (~½ VRAM vs BF16 expand). Single-GPU auto-enables native unless `VT_GEMMA4_RESIDENT_BF16=1` |
+| `VT_GEMMA4_RESIDENT_BF16` | off | `=1` force BF16 expand resident even on single GPU |
+| `VT_GEMMA4_FP8_NATIVE` | off | `=1` decode via FP8 channel GEMV (needs device FP8 packs or LRU). Default off — prefer BF16 resident hipBLAS |
 | `VT_GEMMA4_PREFILL_BATCH_MOE` | off | `=1` enables experimental group-by-expert prefill MoE (chunked GEMM + host scatter). Default off on ROCm until fully proven |
 | `VT_GEMMA4_LAYER_TRACE` | off | `=2` logs per-layer attn/moe wall times (and MoE hoist markers). Debug only |
 | `VT_ENGINE_STEP_LOG` | off | `=1` logs EngineCore step begin/end wall times (also enabled by `VT_SERVER_VERBOSE=1`) |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -309,4 +309,4 @@ mark on this page moved**. An inventoried backend is not a supported one, and th
 holds for the 31 architectures inventoried on 2026-08-05. A row's lifecycle state and its support mark
 are independent: see [STATUS.md](STATUS.md). Parakeet ASR (encoder + CTC/RNN-T/TDT) runs natively on CPU, 4 checkpoints token-exact vs HF.
 
-| Gemma4 MoE ROCm fused helpers (`vt::fused_ops`) | partial | Multi-EOS from generation_config; host expert LRU; device fill-only expert LRU; dual-GPU resident experts; step/layer debug envs. |
+| Gemma4 MoE ROCm fused helpers (`vt::fused_ops`) | partial | Multi-EOS; host expert LRU; dual-GPU resident BF16 (default) or native FP8 packs; fused top-k device MoE; step/layer debug. |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -309,4 +309,4 @@ mark on this page moved**. An inventoried backend is not a supported one, and th
 holds for the 31 architectures inventoried on 2026-08-05. A row's lifecycle state and its support mark
 are independent: see [STATUS.md](STATUS.md). Parakeet ASR (encoder + CTC/RNN-T/TDT) runs natively on CPU, 4 checkpoints token-exact vs HF.
 
-| Gemma4 MoE ROCm fused helpers (`vt::fused_ops`) | partial | Portable ROCm seam. Public: `VT_GEMMA4_EXPERT_VRAM_MB` (positive-MiB LRU cap; unset/0 unlimited) + `VT_SERVER_MAX_{PROMPT_CHARS,NEW_TOKENS}` (200000/4096; 0 disables). Nine tuning vars internal; defaults unchanged. |
+| Gemma4 MoE ROCm fused helpers (`vt::fused_ops`) | partial | Multi-EOS from generation_config; host expert LRU; device fill-only expert LRU; dual-GPU resident experts; step/layer debug envs. |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -184,6 +184,7 @@ to one built without video support. See
 export VT_GEMMA4_RESIDENT_EXPERTS=1
 export VT_GEMMA4_RESIDENT_GPUS=2   # spread BF16 expert stacks across cards
 export HIP_VISIBLE_DEVICES=0,1
+# optional VRAM saver (slower GEMV): export VT_GEMMA4_RESIDENT_NATIVE=1
 build-hip/examples/server --model /path/to/gemma-4-26B-A4B-it-fp8 \
   --host 127.0.0.1 --port 8010 --max-model-len 8192 --max-num-seqs 1 \
   --no-enable-thinking --verbose
@@ -191,8 +192,9 @@ build-hip/examples/server --model /path/to/gemma-4-26B-A4B-it-fp8 \
 
 Host BF16 expert packs (when not fully resident) are capped by
 `VT_GEMMA4_HOST_EXPERT_MB` (default 2048). Device expert LRU is off unless
-`VT_GEMMA4_EXPERT_VRAM_MB=N` with optional `VT_GEMMA4_EXPERT_EVICT=1`. See
-[ENVIRONMENT.md](ENVIRONMENT.md) for the full ROCm + Gemma-4 table.
+`VT_GEMMA4_EXPERT_VRAM_MB=N` with optional `VT_GEMMA4_EXPERT_EVICT=1`.
+Dual-GPU default packs BF16 (fast); `VT_GEMMA4_RESIDENT_NATIVE=1` packs native
+FP8 (~half VRAM). See [ENVIRONMENT.md](ENVIRONMENT.md) for the full table.
 
 For a production deployment, use [LocalAI](https://localai.io), which can embed
 engines like this behind a model gallery, multi-model serving, the full OpenAI

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -174,6 +174,26 @@ to one built without video support. See
 | `--cuda-profile-graph-batch N` | `16` when replays are armed | Batch size the profiler traces. Must not exceed `--max-num-seqs` |
 | `-h`, `--help` | | Print usage and exit |
 
+### Gemma-4 MoE on ROCm (long-prompt / dual-GPU)
+
+`LoadHfConfig` unions `eos_token_id` from **both** `config.json` and sibling
+`generation_config.json` (Gemma-4-26B needs stop ids `[1, 50, 106]` including
+`<turn|>`). Prefer GPU-resident experts when VRAM allows:
+
+```sh
+export VT_GEMMA4_RESIDENT_EXPERTS=1
+export VT_GEMMA4_RESIDENT_GPUS=2   # spread BF16 expert stacks across cards
+export HIP_VISIBLE_DEVICES=0,1
+build-hip/examples/server --model /path/to/gemma-4-26B-A4B-it-fp8 \
+  --host 127.0.0.1 --port 8010 --max-model-len 8192 --max-num-seqs 1 \
+  --no-enable-thinking --verbose
+```
+
+Host BF16 expert packs (when not fully resident) are capped by
+`VT_GEMMA4_HOST_EXPERT_MB` (default 2048). Device expert LRU is off unless
+`VT_GEMMA4_EXPERT_VRAM_MB=N` with optional `VT_GEMMA4_EXPERT_EVICT=1`. See
+[ENVIRONMENT.md](ENVIRONMENT.md) for the full ROCm + Gemma-4 table.
+
 For a production deployment, use [LocalAI](https://localai.io), which can embed
 engines like this behind a model gallery, multi-model serving, the full OpenAI
 API surface, auth, and metrics.

--- a/include/vllm/entrypoints/openai/request_logger.h
+++ b/include/vllm/entrypoints/openai/request_logger.h
@@ -38,9 +38,11 @@ void LogRequestReceived(const std::string& request_id, const std::string& endpoi
 void LogRequestStage(const std::string& request_id, const std::string& stage);
 
 // Completion of a request.
+// prefill_sec >= 0: also log decode_tok_s = completion / (elapsed - prefill).
 void LogRequestFinished(const std::string& request_id, int prompt_tokens,
                         int completion_tokens, const std::string& finish_reason,
-                        double elapsed_sec, const std::string& output_text);
+                        double elapsed_sec, const std::string& output_text,
+                        double prefill_sec = -1.0);
 
 // Errors.
 void LogRequestError(const std::string& request_id, const std::string& endpoint,

--- a/include/vllm/model_executor/models/gemma4_moe.h
+++ b/include/vllm/model_executor/models/gemma4_moe.h
@@ -49,6 +49,13 @@ struct Gemma4FusedExperts {
   // Optional device-resident BF16 fused stacks after Prepare.
   mutable void* gate_up_dev = nullptr;
   mutable void* down_dev = nullptr;
+  // Native FP8 layer packs (preferred for is_fp8 resident). Per-expert
+  // dev_fp8_* / dev_s_* point into these bases; free bases on teardown only.
+  mutable void* fp8_gu_base = nullptr;   // u8 [E, 2I, H]
+  mutable void* fp8_dn_base = nullptr;   // u8 [E, H, I]
+  mutable void* fp8_sgu_base = nullptr;  // bf16 [E, 2I]
+  mutable void* fp8_sdn_base = nullptr;  // bf16 [E, H]
+  mutable bool fp8_native_resident = false;
   mutable int dev_id = -1;
   bool Empty() const { return gate_up.Empty() && fp8.empty(); }
 };
@@ -80,12 +87,18 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
                                    int num_gpus);
 size_t UploadGemma4ExpertsResidentForWeights(Gemma4Weights& weights, int num_gpus);
 
-// Peer-copy one resident expert (fused stacks on src_dev) into dst buffers on
+// Peer-copy one resident expert (fused BF16 stacks on src_dev) into dst buffers on
 // compute_dev. Returns false if peer path unavailable.
 bool PeerCopyGemma4ExpertSlice(int src_dev, const void* gate_up_base,
                                const void* down_base, int expert_id, int64_t I,
                                int64_t H, int compute_dev, void* gate_up_dst,
                                void* down_dst);
+
+// Peer-copy one native FP8 expert (weights+scales) into compute_dev dsts.
+bool PeerCopyGemma4Fp8ExpertSlice(int src_dev, const void* fp8_gu, const void* fp8_dn,
+                                  const void* s_gu, const void* s_dn, int64_t I, int64_t H,
+                                  int compute_dev, void* fp8_gu_dst, void* fp8_dn_dst,
+                                  void* s_gu_dst, void* s_dn_dst);
 
 // hipHostRegister BF16 expert cache for faster H2D (no-op if already pinned).
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex);

--- a/include/vllm/model_executor/models/gemma4_moe.h
+++ b/include/vllm/model_executor/models/gemma4_moe.h
@@ -89,6 +89,8 @@ bool PeerCopyGemma4ExpertSlice(int src_dev, const void* gate_up_base,
 
 // hipHostRegister BF16 expert cache for faster H2D (no-op if already pinned).
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex);
+// hipHostUnregister before dropping host BF16 cache (no-op if not pinned).
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex);
 
 // Dequant one FP8 expert into host BF16 gate_up[2I,H] and down[H,I] (caller-owned).
 // Fills permanent host cache (decode path). Prefer Ephemeral for bulk upload.

--- a/include/vllm/transformers_utils/hf_config.h
+++ b/include/vllm/transformers_utils/hf_config.h
@@ -111,8 +111,11 @@ struct HfConfig {
   nlohmann::json raw;  // full doc for fields we don't type yet
 };
 
-// Loads and parses `path`. Throws std::runtime_error (message includes the
-// path) on missing file, malformed JSON, or missing required fields.
+// Loads and parses `path` (typically `<model_dir>/config.json`). Also unions
+// sibling `generation_config.json` `eos_token_id` into `raw["eos_token_id"]`
+// when present (HF layout; e.g. Gemma-4 adds `<turn|>` id 50). Throws
+// std::runtime_error (message includes the path) on missing file, malformed
+// JSON, or missing required fields.
 HfConfig LoadHfConfig(const std::string& path);
 
 // Cheap, non-throwing peek at config.json's `architectures` array — empty on

--- a/include/vllm/v1/engine/input_processor.h
+++ b/include/vllm/v1/engine/input_processor.h
@@ -31,7 +31,9 @@
 //   - update_from_generation_config: sets eos_token_id, adds the eos id(s) to
 //     all_stop_token_ids (for MinTokens masking) and merges the SECONDARY eos
 //     ids into stop_token_ids, matching sampling_params.py:627-655 (ROAD-V1-C7
-//     wired all_stop_token_ids; it was previously dropped).
+//     wired all_stop_token_ids; it was previously dropped). The eos list comes
+//     from HfConfig.raw["eos_token_id"], which LoadHfConfig unions with sibling
+//     generation_config.json (e.g. Gemma-4 [1,106] U [1,106,50]).
 //   - update_from_tokenizer tokenizes bad_words into bad_words_token_ids
 //     (sampling_params.py:659-698), ROAD-V1-C7 (previously a no-op stub while
 //     bad_words was deferred on SamplingParams).

--- a/include/vt/backend.h
+++ b/include/vt/backend.h
@@ -75,6 +75,13 @@ class Backend {
   // device pointer to a host memcpy and segfaults.
   virtual bool DeviceMemoryIsHostAddressable() const { return false; }
 
+  // Optional device free/total VRAM probe (bytes). Default false = unknown.
+  // ROCm/CUDA override with hipMemGetInfo/cudaMemGetInfo so model code can
+  // size LRU caches without including vendor headers (device-leakage).
+  virtual bool DeviceMemoryInfo(size_t* /*free_bytes*/, size_t* /*total_bytes*/) const {
+    return false;
+  }
+
   // --- Device compute capability (BACKEND-CUDA-ARCH-ADDITIVITY seam-gap #4) ---
   // The architecture the backend is actually running on, as the familiar
   // `(major, minor)` pair (GB10/sm_121 -> {12, 1}). Before this, the capability

--- a/include/vt/fused_ops.h
+++ b/include/vt/fused_ops.h
@@ -30,4 +30,9 @@ void MatmulBTFp8Channel(Queue& q, void* out, const void* a, const void* b_fp8,
 bool ExpertGeGLUBf16TopKM1(Queue& q, void* ysum, const void* x, const void* const* w_gu,
                            const void* const* w_dn, const float* wts, int G, int I, int H);
 
+// Fused FP8 expert GeGLU top-k (T=1). Uses hipBLASLt FP8 when available, else fast HIP.
+bool ExpertGeGLUFp8TopKM1(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                          const void* const* s_gu, const void* const* fp8_dn,
+                          const void* const* s_dn, const float* wts, int G, int I, int H);
+
 }  // namespace vt

--- a/include/vt/rocm/rocm_matmul_batch.h
+++ b/include/vt/rocm/rocm_matmul_batch.h
@@ -33,4 +33,12 @@ void MatmulBTFp8ChannelRocm(Queue& q, void* out, const void* a, const void* b_fp
                             const void* scale_bf16, int M, int N, int K, float alpha,
                             float beta);
 
+// Fused Expert GeGLU FP8 decode (T=1). Faster than 3× MatmulBTFp8Channel.
+bool ExpertGeGLUFp8M1Rocm(Queue& q, void* y, const void* x, const void* fp8_gu, const void* s_gu,
+                          const void* fp8_dn, const void* s_dn, int I, int H, float alpha,
+                          float beta);
+bool ExpertGeGLUFp8TopKM1Rocm(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                              const void* const* s_gu, const void* const* fp8_dn,
+                              const void* const* s_dn, const float* wts, int G, int I, int H);
+
 }  // namespace vt::rocm

--- a/src/vllm/entrypoints/model_loader.cpp
+++ b/src/vllm/entrypoints/model_loader.cpp
@@ -1057,6 +1057,14 @@ std::unique_ptr<LoadedEngine> LoadedEngine::FromModelDir(
     }
   }
   HfConfig config = vllm::LoadHfConfig(config_path);
+  // Surface the effective multi-EOS set (config.json U generation_config.json).
+  if (config.raw.is_object()) {
+    auto it = config.raw.find("eos_token_id");
+    if (it != config.raw.end() && !it->is_null()) {
+      std::cerr << "vllm.cpp: eos_token_id (config U generation_config) = "
+                << it->dump() << "\n";
+    }
+  }
   const ModelRegistration& registration = ModelRegistry::Resolve(config);
   tok::Tokenizer tokenizer = tok::Tokenizer::FromHfJson(tokenizer_path);
 

--- a/src/vllm/entrypoints/openai/request_logger.cpp
+++ b/src/vllm/entrypoints/openai/request_logger.cpp
@@ -92,7 +92,8 @@ void LogRequestStage(const std::string& request_id, const std::string& stage) {
 
 void LogRequestFinished(const std::string& request_id, int prompt_tokens,
                         int completion_tokens, const std::string& finish_reason,
-                        double elapsed_sec, const std::string& output_text) {
+                        double elapsed_sec, const std::string& output_text,
+                        double prefill_sec) {
   if (!g_cfg.enable_log_requests) return;
   std::ostringstream os;
   os << "Finished request " << request_id << " prompt_tokens=" << prompt_tokens
@@ -101,6 +102,13 @@ void LogRequestFinished(const std::string& request_id, int prompt_tokens,
      << " finish_reason=" << finish_reason << " elapsed_s=" << elapsed_sec;
   if (completion_tokens > 0 && elapsed_sec > 0.001) {
     os << " gen_tok_s=" << (static_cast<double>(completion_tokens) / elapsed_sec);
+  }
+  if (prefill_sec >= 0.0 && completion_tokens > 0) {
+    const double dec = elapsed_sec - prefill_sec;
+    if (dec > 0.001) {
+      os << " prefill_s=" << prefill_sec
+         << " decode_tok_s=" << (static_cast<double>(completion_tokens) / dec);
+    }
   }
   if (g_cfg.enable_log_outputs && !output_text.empty()) {
     os << " output: '" << LogPreview(output_text, g_cfg.max_log_len) << "'";

--- a/src/vllm/model_executor/models/gemma4.cpp
+++ b/src/vllm/model_executor/models/gemma4.cpp
@@ -572,11 +572,25 @@ DBuf ForwardBody(Dev d, const std::vector<int32_t>& token_ids,
     Tensor w_in = ResidentWeight(d, w.input_layernorm, {H});
     vt::RmsNorm(d.q, dhn.t(), hidden.t(), w_in, plain);
 
-    static const bool layer_prof = [] {
-      const char* e = std::getenv("VT_GEMMA4_PROFILE");
-      return e && e[0] == '1';
+    static const int layer_trace = [] {
+      // 0=off, 1=aggregate VT_GEMMA4_PROFILE, 2=per-layer begin/end (hang bisect)
+      const char* e = std::getenv("VT_GEMMA4_LAYER_TRACE");
+      if (e && e[0] == '2') return 2;
+      if (e && e[0] == '1') return 1;
+      const char* p = std::getenv("VT_GEMMA4_PROFILE");
+      return (p && p[0] == '1') ? 1 : 0;
     }();
     using clock = std::chrono::steady_clock;
+    const bool layer_prof = layer_trace >= 1;
+    const bool layer_hb = layer_trace >= 2;
+    if (layer_hb) {
+      std::fprintf(stderr,
+                   "INFO gemma4-layer begin l=%lld/%lld T=%lld full=%d moe=%d kv=%lld\n",
+                   static_cast<long long>(l), static_cast<long long>(L),
+                   static_cast<long long>(T), full ? 1 : 0, w.moe.enabled ? 1 : 0,
+                   static_cast<long long>(kv_idx));
+      std::fflush(stderr);
+    }
     const auto t0 = layer_prof ? clock::now() : clock::time_point{};
 
     DBuf attn = Gemma4AttnBlock(d, w, g, dhn.t(), si, attn_meta, kv, T, Dh, full,
@@ -589,6 +603,13 @@ DBuf ForwardBody(Dev d, const std::vector<int32_t>& token_ids,
 
     if (layer_prof) d.b.Synchronize(d.q);
     const auto t1 = layer_prof ? clock::now() : clock::time_point{};
+    if (layer_hb) {
+      const double ms =
+          std::chrono::duration<double, std::milli>(t1 - t0).count();
+      std::fprintf(stderr, "INFO gemma4-layer attn-done l=%lld ms=%.2f\n",
+                   static_cast<long long>(l), ms);
+      std::fflush(stderr);
+    }
 
     Tensor w_pf = ResidentWeight(d, w.pre_feedforward_layernorm, {H});
     vt::RmsNorm(d.q, dh2.t(), h1.t(), w_pf, plain);
@@ -616,6 +637,16 @@ DBuf ForwardBody(Dev d, const std::vector<int32_t>& token_ids,
     if (layer_prof) {
       d.b.Synchronize(d.q);
       const auto t3 = clock::now();
+      if (layer_hb) {
+        const double mlp_ms =
+            std::chrono::duration<double, std::milli>(t2 - t1).count();
+        const double moe_ms =
+            std::chrono::duration<double, std::milli>(t3 - t2).count();
+        std::fprintf(stderr,
+                     "INFO gemma4-layer end l=%lld mlp_ms=%.2f moe_ms=%.2f\n",
+                     static_cast<long long>(l), mlp_ms, moe_ms);
+        std::fflush(stderr);
+      }
       static std::atomic<uint64_t> n{0}, us_attn{0}, us_mlp{0}, us_moe{0};
       auto us = [](auto a, auto b) {
         return std::chrono::duration_cast<std::chrono::microseconds>(b - a).count();

--- a/src/vllm/model_executor/models/gemma4_moe.cpp
+++ b/src/vllm/model_executor/models/gemma4_moe.cpp
@@ -36,6 +36,9 @@ struct ExpertScratch {
   DBuf act;   // [T, I]
   DBuf gu_w;  // host-path [2I, H] weight upload
   DBuf down_w;
+  // Sticky H2D key (expert identity). Do NOT key on buffer pointers — ephemeral
+  // dequant reuses the same gu_tmp/dn_tmp addresses for every expert.
+  const void* sticky_key = nullptr;
   ExpertScratch(Dev d, int64_t T, int64_t I, int64_t H)
       : gu(d, DType::kBF16, {T, 2 * I}),
         act(d, DType::kBF16, {T, I}),
@@ -44,28 +47,47 @@ struct ExpertScratch {
 };
 
 void ExpertGeGLUHost(Dev d, DBuf& out, const Tensor& x, const uint16_t* gate_up_e,
-                     const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s) {
+                     const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s,
+                     const void* sticky_key = nullptr) {
+  const int64_t T = x.shape[0];
+  VT_CHECK(out.t().shape[0] >= T && out.t().shape[1] == H, "ExpertGeGLUHost out shape");
+  VT_CHECK(s.gu.t().shape[0] >= T && s.act.t().shape[0] >= T, "ExpertGeGLUHost scratch T");
   const size_t gu_b = static_cast<size_t>(2 * I * H) * sizeof(uint16_t);
   const size_t dn_b = static_cast<size_t>(H * I) * sizeof(uint16_t);
-  d.b.Copy(d.q, s.gu_w.ptr(), gate_up_e, gu_b);
-  d.b.Copy(d.q, s.down_w.ptr(), down_e, dn_b);
-  // One GEMM: x @ W_gu^T -> [T, 2I], then GeluAndMul (interleaved gate|up).
-  vt::MatmulBT(d.q, s.gu.t(), x, s.gu_w.t());
-  vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  vt::MatmulBT(d.q, out.t(), s.act.t(), s.down_w.t());
+  const void* key = sticky_key != nullptr ? sticky_key : static_cast<const void*>(gate_up_e);
+  if (s.sticky_key != key) {
+    d.b.Copy(d.q, s.gu_w.ptr(), gate_up_e, gu_b);
+    d.b.Copy(d.q, s.down_w.ptr(), down_e, dn_b);
+    s.sticky_key = key;
+  }
+  const vt::Device dev = d.q.device;
+  Tensor gu_act =
+      Tensor::Contiguous(s.gu.ptr(), DType::kBF16, dev, {T, 2 * I});
+  Tensor act = Tensor::Contiguous(s.act.ptr(), DType::kBF16, dev, {T, I});
+  Tensor out_view = Tensor::Contiguous(out.ptr(), DType::kBF16, dev, {T, H});
+  vt::MatmulBT(d.q, gu_act, x, s.gu_w.t());
+  vt::GeluAndMul(d.q, act, gu_act);
+  vt::MatmulBT(d.q, out_view, act, s.down_w.t());
+  // Per-expert drain: once-per-token-only still lost the server after pollution
+  // (connection refused). Keep barrier until a safer fused device path exists.
+  d.b.Synchronize(d.q);
 }
 
 void ExpertGeGLUDeviceAccum(Dev d, DBuf& out, const Tensor& x, const uint16_t* gate_up_e,
                             const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s,
                             float alpha, float beta) {
   const int64_t T = x.shape[0];
+  VT_CHECK(s.gu.t().shape[0] >= T && s.act.t().shape[0] >= T, "ExpertGeGLUDeviceAccum scratch T");
   const vt::Device dev = d.q.device;
   // gate_up_e is contiguous [2I, H] — one BT GEMM instead of two.
   Tensor gu_w =
       Tensor::Contiguous(const_cast<uint16_t*>(gate_up_e), DType::kBF16, dev, {2 * I, H});
-  vt::MatmulBT(d.q, s.gu.t(), x, gu_w);
-  vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  vt::MatmulBTAlphaBeta(d.q, out.ptr(), s.act.ptr(), down_e, static_cast<int>(T),
+  Tensor gu_act =
+      Tensor::Contiguous(s.gu.ptr(), DType::kBF16, dev, {T, 2 * I});
+  Tensor act = Tensor::Contiguous(s.act.ptr(), DType::kBF16, dev, {T, I});
+  vt::MatmulBT(d.q, gu_act, x, gu_w);
+  vt::GeluAndMul(d.q, act, gu_act);
+  vt::MatmulBTAlphaBeta(d.q, out.ptr(), act.data, down_e, static_cast<int>(T),
                                   static_cast<int>(H), static_cast<int>(I), alpha, beta,
                                   DType::kBF16);
 }
@@ -159,13 +181,110 @@ bool ExpertGeGLUDeviceBatched(Dev /*d*/, DBuf& /*ysum*/, const Tensor& /*x*/,
 
 }  // namespace
 
-// Ensure FP8 expert has BF16 cache filled (idempotent).
+namespace {
+// Bound permanent host BF16 expert packs. Unbounded cache + hipHostRegister OOM'd
+// the 30G box (~27G RSS) during pollution. Default 2 GiB; override VT_GEMMA4_HOST_EXPERT_MB.
+struct HostExpertLru {
+  struct Slot {
+    const Gemma4Fp8ExpertMats* ex = nullptr;
+    size_t bytes = 0;
+    uint64_t tick = 0;
+  };
+  std::vector<Slot> slots;
+  size_t used = 0;
+  uint64_t tick = 1;
+
+  size_t BudgetBytes() const {
+    static const size_t b = []() -> size_t {
+      size_t mb = 2048;
+      if (const char* e = std::getenv("VT_GEMMA4_HOST_EXPERT_MB")) {
+        const long v = std::strtol(e, nullptr, 10);
+        if (v == 0) return size_t{0};
+        if (v > 0) mb = static_cast<size_t>(v);
+      }
+      return mb * static_cast<size_t>(1024ull * 1024ull);
+    }();
+    return b;
+  }
+
+  void EvictOne() {
+    if (slots.empty()) return;
+    size_t victim = 0;
+    for (size_t i = 1; i < slots.size(); ++i) {
+      if (slots[i].tick < slots[victim].tick) victim = i;
+    }
+    auto& s = slots[victim];
+    if (s.ex) {
+      UnpinGemma4Fp8ExpertHostCache(*s.ex);
+      s.ex->cached_gu.clear();
+      s.ex->cached_gu.shrink_to_fit();
+      s.ex->cached_dn.clear();
+      s.ex->cached_dn.shrink_to_fit();
+    }
+    used = used >= s.bytes ? used - s.bytes : 0;
+    slots.erase(slots.begin() + static_cast<std::ptrdiff_t>(victim));
+  }
+
+  void MakeRoom(size_t need) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) {
+      // No permanent host cache — caller should use ephemeral path.
+      return;
+    }
+    while (used + need > bud && !slots.empty()) EvictOne();
+  }
+
+  void Note(const Gemma4Fp8ExpertMats* ex, size_t bytes) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) return;
+    // Already tracked?
+    for (auto& s : slots) {
+      if (s.ex == ex) {
+        s.tick = tick++;
+        return;
+      }
+    }
+    MakeRoom(bytes);
+    if (used + bytes > bud) {
+      // Still no room for a single expert — keep this one untracked; drop immediately
+      // after use is caller's problem. Prefer: allow one oversize by evicting all.
+      while (!slots.empty()) EvictOne();
+    }
+    if (used + bytes > bud) return;
+    slots.push_back(Slot{ex, bytes, tick++});
+    used += bytes;
+  }
+
+  void Touch(const Gemma4Fp8ExpertMats* ex) {
+    for (auto& s : slots) {
+      if (s.ex == ex) {
+        s.tick = tick++;
+        return;
+      }
+    }
+  }
+};
+
+HostExpertLru& HostCacheLru() {
+  static HostExpertLru lru;
+  return lru;
+}
+}  // namespace
+
+// Ensure FP8 expert has BF16 cache filled (idempotent), under host LRU budget.
 void EnsureGemma4Fp8ExpertCached(const Gemma4Fp8ExpertMats& ex, int64_t I, int64_t H) {
   if (!ex.cached_gu.empty() && !ex.cached_dn.empty() &&
       static_cast<int64_t>(ex.cached_gu.size()) == 2 * I * H &&
       static_cast<int64_t>(ex.cached_dn.size()) == H * I) {
+    HostCacheLru().Touch(&ex);
     return;
   }
+  const size_t bytes =
+      (static_cast<size_t>(2 * I * H) + static_cast<size_t>(H * I)) * sizeof(uint16_t);
+  // Budget 0 → do not retain permanent packs (ephemeral-only mode).
+  if (HostCacheLru().BudgetBytes() == 0) return;
+
+  HostCacheLru().MakeRoom(bytes);
   ex.cached_gu.resize(static_cast<size_t>(2 * I * H));
   ex.cached_dn.resize(static_cast<size_t>(H * I));
   DequantFp8ChannelToBf16(ex.gate_w.bytes.data(),
@@ -178,6 +297,7 @@ void EnsureGemma4Fp8ExpertCached(const Gemma4Fp8ExpertMats& ex, int64_t I, int64
                           reinterpret_cast<const uint16_t*>(ex.down_s.bytes.data()), H, I,
                           ex.cached_dn.data());
   PinGemma4Fp8ExpertHostCache(ex);
+  HostCacheLru().Note(&ex, bytes);
 }
 
 // Dequant into caller buffers without retaining a permanent host BF16 cache.
@@ -204,10 +324,10 @@ void DequantGemma4Fp8ExpertToBf16Ephemeral(const Gemma4Fp8ExpertMats& ex, int64_
                           down_out);
 }
 
-// Host BF16 cache + device upload once (subsequent tokens use device GEMM path).
-// H2D is async on d.q — later GEMMs on the same stream see the data without a
-// device-wide Synchronize (was serializing every expert upload).
-// A positive VT_GEMMA4_EXPERT_VRAM_MB caps the expert LRU in MiB; unset/0 is unlimited.
+// Host BF16 cache + optional device upload. H2D is async on d.q.
+// VT_GEMMA4_EXPERT_VRAM_MB: unset/0 = device expert LRU off; N>0 = N MiB fill-only
+// budget (evict only with VT_GEMMA4_EXPERT_EVICT=1). Free VRAM probed via
+// Backend::DeviceMemoryInfo when admitting new experts.
 namespace {
 struct DevExpertLru {
   struct Slot {
@@ -224,22 +344,49 @@ struct DevExpertLru {
   std::vector<Slot> slots;
   size_t used = 0;
   size_t budget = 0;
+  bool budget_set = false;
   uint64_t tick = 1;
   int dev = -1;
 
   size_t BudgetBytes() {
-    if (budget) return budget;
-    size_t mb = 0;
+    if (budget_set) return budget;
+    // unset → 2048 MiB fill-only cache (no eviction by default). "0" → off.
+    // N>0 → N MiB. Eviction opt-in: VT_GEMMA4_EXPERT_EVICT=1.
     if (const char* e = std::getenv("VT_GEMMA4_EXPERT_VRAM_MB")) {
       const long v = std::strtol(e, nullptr, 10);
-      if (v >= 0) mb = static_cast<size_t>(v);
+      if (v == 0) {
+        budget = 0;
+        budget_set = true;
+        return 0;
+      }
+      if (v > 0) {
+        budget = static_cast<size_t>(v) * 1024ull * 1024ull;
+        budget_set = true;
+        return budget;
+      }
     }
-    budget = mb == 0 ? static_cast<size_t>(-1) : mb * 1024ull * 1024ull;
+    budget = 2048ull * 1024ull * 1024ull;  // fill-only default
+    budget_set = true;
     return budget;
+  }
+
+  bool Enabled() { return BudgetBytes() > 0; }
+
+  // Free VRAM via Backend::DeviceMemoryInfo (ROCm/CUDA). No HIP in this TU.
+  static bool FreeBytes(Dev d, size_t* free_out) {
+    *free_out = 0;
+    size_t free_b = 0, tot_b = 0;
+    if (!d.b.DeviceMemoryInfo(&free_b, &tot_b)) return false;
+    *free_out = free_b;
+    return true;
   }
 
   void EvictOne(Dev d) {
     if (slots.empty()) return;
+    // CRITICAL: async H2D/GEMM may still reference the victim. hipFree without
+    // a stream barrier races the compute stream and has been observed as a
+    // permanent kfd_wait hang (GPU idle, prefill done, no decode tokens).
+    d.b.Synchronize(d.q);
     size_t victim = 0;
     for (size_t i = 1; i < slots.size(); ++i)
       if (slots[i].tick < slots[victim].tick) victim = i;
@@ -262,17 +409,49 @@ struct DevExpertLru {
     slots.erase(slots.begin() + static_cast<std::ptrdiff_t>(victim));
   }
 
+  // Evict until bookkeeping budget AND free VRAM (if knowable) can take `need`.
+  // DEFAULT: no hipFree eviction — ROCm hangs in kfd_wait when we free under
+  // load (hoist/pollution). Fill until full, then caller falls back to host H2D.
+  // Opt-in eviction: VT_GEMMA4_EXPERT_EVICT=1.
+  bool MakeRoom(Dev d, size_t need) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) return false;
+    static const bool allow_evict = [] {
+      const char* e = std::getenv("VT_GEMMA4_EXPERT_EVICT");
+      return e && e[0] == '1';
+    }();
+    constexpr size_t kHeadroom = 1536ull << 20;  // 1.5 GiB after expert — hipMalloc hung at 512MiB
+    constexpr size_t kMaxSlots = 24;             // hard cap; further experts stay host
+    if (slots.size() >= kMaxSlots) return false;
+    if (allow_evict) {
+      while (used + need > bud && !slots.empty()) EvictOne(d);
+    }
+    if (used + need > bud) return false;
+    size_t free_b = 0;
+    // Refuse device upload if free VRAM unknown — Alloc-without-headroom has
+    // hung hipMalloc (hoist start without hoist-done under pollution).
+    if (!FreeBytes(d, &free_b)) return false;
+    if (allow_evict) {
+      int guard = 0;
+      while (free_b < need + kHeadroom && !slots.empty() && guard++ < 256) {
+        EvictOne(d);
+        if (!FreeBytes(d, &free_b)) return false;
+      }
+    }
+    return free_b >= need + kHeadroom;
+  }
+
   void Note(const Gemma4Fp8ExpertMats* ex, void* gu, void* dn, size_t bytes, Dev d,
             void* fp8_gu = nullptr, void* fp8_dn = nullptr, void* s_gu = nullptr,
             void* s_dn = nullptr) {
     if (dev != d.q.device.index) {
+      // Device change: drop bookkeeping only (buffers owned by prior device).
       slots.clear();
       used = 0;
       dev = d.q.device.index;
     }
     const size_t bud = BudgetBytes();
-    while (used + bytes > bud && !slots.empty()) EvictOne(d);
-    if (used + bytes > bud) return;
+    if (used + bytes > bud) return;  // no eviction — drop tracking if over
     slots.push_back(Slot{ex, gu, dn, fp8_gu, fp8_dn, s_gu, s_dn, bytes, tick++});
     used += bytes;
   }
@@ -295,11 +474,14 @@ DevExpertLru& ExpertLru() {
 
 bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t I,
                                    int64_t H) {
-  EnsureGemma4Fp8ExpertCached(ex, I, H);
+  // When device LRU disabled, do NOT host-cache-dequant here — that path was
+  // unbounded (every expert forever) and OOM'd the 30G host (~27G RSS) under pollution.
+  if (!ExpertLru().Enabled()) return false;
   if (ex.dev_gu != nullptr && ex.dev_dn != nullptr) {
     ExpertLru().Touch(&ex);
     return true;
   }
+  EnsureGemma4Fp8ExpertCached(ex, I, H);
   const size_t gu_b = static_cast<size_t>(2 * I * H) * sizeof(uint16_t);
   const size_t dn_b = static_cast<size_t>(H * I) * sizeof(uint16_t);
   const size_t total = gu_b + dn_b;
@@ -307,11 +489,13 @@ bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
   void* dn = nullptr;
   try {
     auto& lru = ExpertLru();
-    while (lru.used + total > lru.BudgetBytes() && !lru.slots.empty()) lru.EvictOne(d);
+    if (!lru.MakeRoom(d, total)) return false;
     gu = d.b.Alloc(gu_b);
     dn = d.b.Alloc(dn_b);
     d.b.Copy(d.q, gu, ex.cached_gu.data(), gu_b);
     d.b.Copy(d.q, dn, ex.cached_dn.data(), dn_b);
+    // Ensure H2D lands before any later free/evict on another admission path.
+    d.b.Synchronize(d.q);
     ex.dev_gu = gu;
     ex.dev_dn = dn;
     lru.Note(&ex, gu, dn, total, d);
@@ -330,6 +514,7 @@ bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
 
 // Upload FP8 weights + channel scales (no BF16 dequant). Half weight VRAM vs BF16 path.
 bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t I, int64_t H) {
+  if (!ExpertLru().Enabled()) return false;
   if (ex.dev_fp8_gu && ex.dev_fp8_dn && ex.dev_s_gu && ex.dev_s_dn) {
     ExpertLru().Touch(&ex);
     return true;
@@ -346,7 +531,7 @@ bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
   void *fgu = nullptr, *fdn = nullptr, *sgu = nullptr, *sdn = nullptr;
   try {
     auto& lru = ExpertLru();
-    while (lru.used + total > lru.BudgetBytes() && !lru.slots.empty()) lru.EvictOne(d);
+    if (!lru.MakeRoom(d, total)) return false;
     fgu = d.b.Alloc(gu_b);
     fdn = d.b.Alloc(dn_b);
     sgu = d.b.Alloc(sgu_b);
@@ -360,6 +545,7 @@ bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
     d.b.Copy(d.q, static_cast<char*>(sgu) + static_cast<size_t>(I) * 2, ex.up_s.bytes.data(),
              static_cast<size_t>(I) * 2);
     d.b.Copy(d.q, sdn, ex.down_s.bytes.data(), sdn_b);
+    d.b.Synchronize(d.q);
     ex.dev_fp8_gu = fgu;
     ex.dev_fp8_dn = fdn;
     ex.dev_s_gu = sgu;
@@ -548,7 +734,175 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   std::vector<uint16_t> hsum;
   if (host_axpy) hsum.assign(static_cast<size_t>(H), vt::F32ToBF16(0.f));
 
+  // Device expert cache: DECODE-ONLY (T==1), fill-only. NO bulk hoist — pre-upload
+  // of top_k experts hung hipMalloc (hoist without hoist-done). Lazy Ensure in the
+  // expert loop only. Prefill stays host. Opt out: EXPERT_VRAM_MB=0.
+  static const bool moe_trace = [] {
+    const char* e = std::getenv("VT_GEMMA4_LAYER_TRACE");
+    return e && e[0] == '2';
+  }();
+  const bool use_dev_expert_lru =
+      (T == 1) && ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr && ExpertLru().Enabled();
+  // Lazy Ensure only (below). Bulk hoist removed — was the pollution hang site.
+  (void)moe_trace;
+
+  // Prefill batch MoE: DEFAULT OFF. Chunked host-scatter still kfd_wait-hangs on
+  // long prefill (~T=400 l=9) under ROCm. Serial token MoE + EXPERT_VRAM_MB=0 is
+  // the pollution-stable path. Enable: VT_GEMMA4_PREFILL_BATCH_MOE=1.
+  static const bool prefill_batch_moe = [] {
+    const char* e = std::getenv("VT_GEMMA4_PREFILL_BATCH_MOE");
+    return e != nullptr && e[0] == '1' && e[1] == '\0';
+  }();
+  if (T > 1 && prefill_batch_moe && !host_axpy) {
+    const vt::Device dev = d.q.device;
+    std::vector<std::vector<int32_t>> etok(static_cast<size_t>(E));
+    std::vector<std::vector<float>> ewt(static_cast<size_t>(E));
+    for (int64_t t = 0; t < T; ++t) {
+      for (int k = 0; k < top_k; ++k) {
+        const size_t o = static_cast<size_t>(t * top_k + k);
+        const int e = static_cast<int>(hi[o]);
+        if (e < 0 || e >= static_cast<int>(E)) continue;
+        etok[static_cast<size_t>(e)].push_back(static_cast<int32_t>(t));
+        ewt[static_cast<size_t>(e)].push_back(hw[o]);
+      }
+    }
+    int64_t max_n = 0;
+    for (int64_t e = 0; e < E; ++e) {
+      max_n = std::max<int64_t>(max_n, static_cast<int64_t>(etok[static_cast<size_t>(e)].size()));
+    }
+    if (max_n > 0) {
+      // Cap GeGLU M — ROCm hipBLAS hung with n~400 (kfd_wait after attn-done,
+      // before host-scatter finished). Chunk tokens per expert.
+      constexpr int64_t kMaxGemmM = 64;
+      const int64_t scratch_n = std::min(max_n, kMaxGemmM);
+      ExpertScratch besc(d, scratch_n, I, H);
+      DBuf bx(d, DType::kBF16, {scratch_n, H});
+      DBuf by(d, DType::kBF16, {scratch_n, H});
+      std::vector<float> hacc(static_cast<size_t>(T * H), 0.f);
+      std::vector<uint16_t> hy(static_cast<size_t>(scratch_n * H));
+      int experts_run = 0;
+      for (int64_t e = 0; e < E; ++e) {
+        const auto& toks = etok[static_cast<size_t>(e)];
+        if (toks.empty()) continue;
+        const auto& wts_e = ewt[static_cast<size_t>(e)];
+        const int64_t n_all = static_cast<int64_t>(toks.size());
+
+        const uint16_t* gu_p = nullptr;
+        const uint16_t* dn_p = nullptr;
+        const uint16_t* gu_host_e = nullptr;
+        const uint16_t* dn_host_e = nullptr;
+        bool use_device_w = false;
+        if (same_dev) {
+          gu_p = static_cast<const uint16_t*>(ex.gate_up_dev) + e * gu_stride;
+          dn_p = static_cast<const uint16_t*>(ex.down_dev) + e * dn_stride;
+          use_device_w = true;
+        } else if (ex.is_fp8) {
+          auto& fex = ex.fp8[static_cast<size_t>(e)];
+          if (use_dev_expert_lru && !fp8_native &&
+              EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
+            gu_p = static_cast<const uint16_t*>(fex.dev_gu);
+            dn_p = static_cast<const uint16_t*>(fex.dev_dn);
+            use_device_w = true;
+          } else {
+            // Prefill-batch host path: ephemeral dequant (no unbounded host cache).
+            static thread_local std::vector<uint16_t> bgu, bdn;
+            const size_t gu_n = static_cast<size_t>(2 * I * H);
+            const size_t dn_n = static_cast<size_t>(H * I);
+            if (bgu.size() != gu_n) bgu.resize(gu_n);
+            if (bdn.size() != dn_n) bdn.resize(dn_n);
+            DequantGemma4Fp8ExpertToBf16Ephemeral(fex, I, H, bgu.data(), bdn.data());
+            gu_host_e = bgu.data();
+            dn_host_e = bdn.data();
+          }
+        } else if (gu_host && dn_host) {
+          gu_host_e = gu_host + e * gu_stride;
+          dn_host_e = dn_host + e * dn_stride;
+        } else {
+          continue;
+        }
+
+        for (int64_t base = 0; base < n_all; base += kMaxGemmM) {
+          const int64_t n = std::min(kMaxGemmM, n_all - base);
+          for (int64_t i = 0; i < n; ++i) {
+            const int64_t t = toks[static_cast<size_t>(base + i)];
+            d.b.Copy(d.q,
+                     static_cast<char*>(bx.ptr()) +
+                         static_cast<size_t>(i) * static_cast<size_t>(H) * 2,
+                     static_cast<const char*>(expert_in.data) +
+                         static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
+                     static_cast<size_t>(H) * 2);
+          }
+          Tensor x = Tensor::Contiguous(bx.ptr(), DType::kBF16, dev, {n, H});
+          if (use_device_w) {
+            ExpertGeGLUDeviceAccum(d, by, x, gu_p, dn_p, I, H, besc, 1.f, 0.f);
+          } else {
+            ExpertGeGLUHost(d, by, x, gu_host_e, dn_host_e, I, H, besc, &ex.fp8[static_cast<size_t>(e)]);
+          }
+          d.b.Synchronize(d.q);
+          d.b.Copy(d.q, hy.data(), by.ptr(),
+                   static_cast<size_t>(n) * static_cast<size_t>(H) * 2);
+          d.b.Synchronize(d.q);
+          for (int64_t i = 0; i < n; ++i) {
+            const int64_t t = toks[static_cast<size_t>(base + i)];
+            const float w = wts_e[static_cast<size_t>(base + i)];
+            const size_t yoff = static_cast<size_t>(i) * static_cast<size_t>(H);
+            const size_t aoff = static_cast<size_t>(t) * static_cast<size_t>(H);
+            for (int64_t j = 0; j < H; ++j) {
+              hacc[aoff + static_cast<size_t>(j)] +=
+                  w * vt::BF16ToF32(hy[yoff + static_cast<size_t>(j)]);
+            }
+          }
+        }
+        ++experts_run;
+      }
+      std::vector<uint16_t> hbf(static_cast<size_t>(T * H));
+      for (size_t i = 0; i < hbf.size(); ++i) hbf[i] = vt::F32ToBF16(hacc[i]);
+      d.b.Copy(d.q, acc.ptr(), hbf.data(), hbf.size() * sizeof(uint16_t));
+      d.b.Synchronize(d.q);
+      if (moe_trace) {
+        std::fprintf(stderr,
+                     "INFO gemma4-moe prefill-batch T=%lld experts_run=%d max_n=%lld "
+                     "chunk=%lld (host-scatter)\n",
+                     static_cast<long long>(T), experts_run, static_cast<long long>(max_n),
+                     static_cast<long long>(kMaxGemmM));
+        std::fflush(stderr);
+      }
+      Gemma4MoeScratch r;
+      r.tensor = acc.t();
+      const size_t alloc = acc.alloc_bytes();
+      void* p = acc.Release();
+      r.storage = std::shared_ptr<void>(p, [alloc](void* q) { Pool().Put(alloc, q); });
+      if (profile) {
+        const auto t_all1 = clock::now();
+        static std::atomic<uint64_t> ncalls{0};
+        static std::atomic<uint64_t> us_router{0};
+        static std::atomic<uint64_t> us_total{0};
+        const auto ur =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_router1 - t_all0).count();
+        const auto ut =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_all1 - t_all0).count();
+        us_router.fetch_add(static_cast<uint64_t>(ur), std::memory_order_relaxed);
+        us_total.fetch_add(static_cast<uint64_t>(ut), std::memory_order_relaxed);
+        const uint64_t c = ncalls.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (c == 1 || c % 64 == 0) {
+          const uint64_t tr = us_router.load(std::memory_order_relaxed);
+          const uint64_t tt = us_total.load(std::memory_order_relaxed);
+          std::fprintf(stderr,
+                       "gemma4 moe profile: calls=%llu router_us/call=%.1f expert+rest_us/call=%.1f "
+                       "total_us/call=%.1f (router%%=%.0f) [prefill-batch-chunked]\n",
+                       static_cast<unsigned long long>(c), static_cast<double>(tr) / c,
+                       static_cast<double>(tt - tr) / c, static_cast<double>(tt) / c,
+                       tt ? 100.0 * static_cast<double>(tr) / static_cast<double>(tt) : 0.0);
+        }
+      }
+      return r;
+    }
+  }
+
   for (int64_t t = 0; t < T; ++t) {
+    // Drain previous token's device work before starting the next (prefill only).
+    if (T > 1 && t > 0) d.b.Synchronize(d.q);
+
     std::vector<int> idx(static_cast<size_t>(top_k));
     std::vector<float> wts(static_cast<size_t>(top_k));
     for (int i = 0; i < top_k; ++i) {
@@ -567,35 +921,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     }
     // device path: first expert MulScalar writes ysum (no Zero needed)
 
-    // Prefetch BF16 caches for this token's top-k experts in parallel (cold only).
-    if (ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr) {
-      bool any_cold = false;
-      for (int i = 0; i < top_k; ++i) {
-        const auto& fex = ex.fp8[static_cast<size_t>(idx[static_cast<size_t>(i)])];
-        if (fex.cached_gu.empty() || fex.cached_dn.empty()) {
-          any_cold = true;
-          break;
-        }
-      }
-      if (any_cold) {
-        Fp8DequantBeginOuterParallel();
-        std::vector<std::thread> pref;
-        pref.reserve(static_cast<size_t>(top_k));
-        for (int i = 0; i < top_k; ++i) {
-          const int e = idx[static_cast<size_t>(i)];
-          pref.emplace_back([&, e] {
-            EnsureGemma4Fp8ExpertCached(ex.fp8[static_cast<size_t>(e)], I, H);
-          });
-        }
-        for (auto& th : pref) th.join();
-        Fp8DequantEndOuterParallel();
-      }
-    }
-
-    // Prefetch: queue device expert H2D for all top-k before any GEMM (same stream).
-    // Skip when fused resident packs exist (same_dev or peer) — those are the source of truth
-    // and VRAM is already tight after full resident upload.
-    if (ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr) {
+    // Decode-only device Ensure (Touch/fallback). Prefill skips device LRU.
+    if (use_dev_expert_lru) {
       for (int i = 0; i < top_k; ++i) {
         const int e = idx[static_cast<size_t>(i)];
         if (e >= 0 && e < static_cast<int>(E)) {
@@ -634,8 +961,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       }
     }
 
-    // Batched path: VT_GEMMA4_BATCH_EXPERTS=1 (default off).
-    if (batch_experts && ex.is_fp8 && !host_axpy) {
+    // Batched path: VT_GEMMA4_BATCH_EXPERTS=1 (default off). Decode-only device.
+    if (batch_experts && ex.is_fp8 && !host_axpy && T == 1) {
       std::vector<const uint16_t*> gu_ptrs;
       std::vector<const uint16_t*> dn_ptrs;
       gu_ptrs.reserve(static_cast<size_t>(top_k));
@@ -710,6 +1037,7 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
               d.q,
               static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
               ysum.ptr(), static_cast<size_t>(H) * 2);
+          d.b.Synchronize(d.q);
           continue;
         }
       }
@@ -745,32 +1073,42 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
         } else if (ex.is_fp8) {
           const auto& fex = ex.fp8[static_cast<size_t>(e)];
           DequantGemma4Fp8ExpertToBf16Ephemeral(fex, I, H, gu_tmp.data(), dn_tmp.data());
-          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc);
+          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc, &fex);
         } else {
           VT_CHECK(gu_host && dn_host, "gemma4 moe: peer fail no host");
           ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
-                          dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc);
+                          dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc,
+                          gu_host + static_cast<int64_t>(e) * gu_stride);
         }
       } else if (ex.is_fp8) {
-        const auto& fex = ex.fp8[static_cast<size_t>(e)];
-        if (EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
-          ExpertGeGLUDeviceAccum(d, ysum, xin.t(), static_cast<const uint16_t*>(fex.dev_gu),
-                                 static_cast<const uint16_t*>(fex.dev_dn), I, H, esc, ww,
-                                 beta);
-          fused_mix = true;
-        } else {
-          EnsureGemma4Fp8ExpertCached(fex, I, H);
-          ExpertGeGLUHost(d, y, xin.t(), fex.cached_gu.data(), fex.cached_dn.data(), I, H,
-                          esc);
-        }
-      } else if (gu_host && dn_host) {
-        ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
-                        dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc);
+      const auto& fex = ex.fp8[static_cast<size_t>(e)];
+      if (EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
+        ExpertGeGLUDeviceAccum(d, ysum, xin.t(), static_cast<const uint16_t*>(fex.dev_gu),
+                               static_cast<const uint16_t*>(fex.dev_dn), I, H, esc, ww,
+                               beta);
+        fused_mix = true;
       } else {
-        VT_CHECK(false, "gemma4 moe: no expert weights");
+        // Prefer bounded host BF16 LRU; fall back to stack ephemeral dequant.
+        EnsureGemma4Fp8ExpertCached(fex, I, H);
+        if (!fex.cached_gu.empty() && !fex.cached_dn.empty()) {
+          ExpertGeGLUHost(d, y, xin.t(), fex.cached_gu.data(), fex.cached_dn.data(), I, H, esc,
+                          &fex);
+        } else {
+          DequantGemma4Fp8ExpertToBf16Ephemeral(fex, I, H, gu_tmp.data(), dn_tmp.data());
+          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc, &fex);
+        }
+      }
+      } else if (gu_host && dn_host) {
+      ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
+                      dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc,
+                      gu_host + static_cast<int64_t>(e) * gu_stride);
+      } else {
+      VT_CHECK(false, "gemma4 moe: no expert weights");
       }
 
-      if (fused_mix) continue;  // already accumulated into ysum
+      if (fused_mix) {
+        continue;  // already accumulated into ysum (same stream)
+      }
 
       if (host_axpy) {
         d.b.Synchronize(d.q);
@@ -794,6 +1132,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     d.b.Copy(d.q,
              static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
              ysum.ptr(), static_cast<size_t>(H) * 2);
+    // One drain per token after all top_k experts (prefill + decode).
+    d.b.Synchronize(d.q);
   }
 
   Gemma4MoeScratch r;
@@ -861,6 +1201,7 @@ bool PeerCopyGemma4ExpertSlice(int, const void*, const void*, int, int64_t, int6
   return false;
 }
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats&) {}
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats&) {}
 #endif  // VLLM_CPP_HIP
 
 }  // namespace vllm

--- a/src/vllm/model_executor/models/gemma4_moe.cpp
+++ b/src/vllm/model_executor/models/gemma4_moe.cpp
@@ -784,9 +784,10 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   }();
   static const bool fp8_native = [] {
     const char* e = std::getenv("VT_GEMMA4_FP8_NATIVE");
-    // Default OFF: software FP8 GEMV is slower/riskier than BF16 hipBLAS resident.
-    // Enable with =1 (or use VT_GEMMA4_RESIDENT_NATIVE=1 at load for packs).
-    return e && e[0] == '1';
+    // Default ON: use fused FP8 expert kernels when packs/LRU available.
+    // =0 forces BF16 device/host paths only.
+    if (e == nullptr) return true;
+    return e[0] == '1';
   }();
   static const bool custom_expert = [] {
     const char* e = std::getenv("VT_GEMMA4_CUSTOM_EXPERT");
@@ -1059,10 +1060,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       fdn.reserve(static_cast<size_t>(top_k));
       sdn.reserve(static_cast<size_t>(top_k));
       bool ok = true;
-      // Peer path: copy each expert into scratch one at a time into a packed TLS
-      // would need G packs — fall back to serial ExpertGeGLUFp8Native with peer.
       if (fp8_res_peer) {
-        ok = false;
+        ok = false;  // serial peer path below
       } else {
         for (int i = 0; i < top_k && ok; ++i) {
           const int e = idx[static_cast<size_t>(i)];
@@ -1082,14 +1081,22 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
           }
         }
       }
-      if (ok && static_cast<int>(fgu.size()) == top_k &&
-          ExpertGeGLUFp8TopKFusedGelu(d, ysum, xin.t(), fgu.data(), sgu.data(), fdn.data(),
-                                      sdn.data(), wts.data(), top_k, I, H)) {
+      bool ran = false;
+      if (ok && static_cast<int>(fgu.size()) == top_k) {
+        // Prefer fused HIP expert kernel (vectorized FP8) over 3× channel GEMV.
+        ran = vt::ExpertGeGLUFp8TopKM1(d.q, ysum.ptr(), xin.ptr(), fgu.data(), sgu.data(),
+                                       fdn.data(), sdn.data(), wts.data(), top_k,
+                                       static_cast<int>(I), static_cast<int>(H));
+        if (!ran) {
+          ran = ExpertGeGLUFp8TopKFusedGelu(d, ysum, xin.t(), fgu.data(), sgu.data(), fdn.data(),
+                                            sdn.data(), wts.data(), top_k, I, H);
+        }
+      }
+      if (ran) {
         d.b.Copy(
             d.q,
             static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
             ysum.ptr(), static_cast<size_t>(H) * 2);
-        // One drain per token on full device path (not per expert).
         d.b.Synchronize(d.q);
         continue;
       }

--- a/src/vllm/model_executor/models/gemma4_moe.cpp
+++ b/src/vllm/model_executor/models/gemma4_moe.cpp
@@ -99,18 +99,58 @@ void ExpertGeGLUFp8Native(Dev d, DBuf& out, const Tensor& x, const void* fp8_gu,
   vt::MatmulBTFp8Channel(d.q, s.gu.ptr(), x.data, fp8_gu, s_gu, /*M=*/1,
                                    static_cast<int>(2 * I), static_cast<int>(H), 1.f, 0.f);
   vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  if (beta == 0.f) {
-    vt::MatmulBTFp8Channel(d.q, out.ptr(), s.act.ptr(), fp8_dn, s_dn, /*M=*/1,
-                                     static_cast<int>(H), static_cast<int>(I), alpha, 0.f);
-  } else {
-    DBuf ytmp(d, DType::kBF16, {1, H});
-    vt::MatmulBTFp8Channel(d.q, ytmp.ptr(), s.act.ptr(), fp8_dn, s_dn, /*M=*/1,
-                                     static_cast<int>(H), static_cast<int>(I), 1.f, 0.f);
-    vt::MulScalar(d.q, out.t(), out.t(), static_cast<double>(beta));
-    DBuf ysc(d, DType::kBF16, {1, H});
-    vt::MulScalar(d.q, ysc.t(), ytmp.t(), static_cast<double>(alpha));
-    vt::Add(d.q, out.t(), out.t(), ysc.t());
+  // Channel GEMV supports alpha/beta accumulate into out.
+  vt::MatmulBTFp8Channel(d.q, out.ptr(), s.act.ptr(), fp8_dn, s_dn, /*M=*/1,
+                                   static_cast<int>(H), static_cast<int>(I), alpha, beta);
+}
+
+// Top-k FP8 native: gate_up×G → one GeluAndMul → down×G (alpha/beta mix). Decode M=1.
+bool ExpertGeGLUFp8TopKFusedGelu(Dev d, DBuf& ysum, const Tensor& x, const void* const* fp8_gu,
+                                 const void* const* s_gu, const void* const* fp8_dn,
+                                 const void* const* s_dn, const float* wts, int G, int64_t I,
+                                 int64_t H) {
+  if (G <= 0 || x.shape[0] != 1) return false;
+  struct Tls {
+    int dev = -1;
+    int Gcap = 0;
+    int64_t I = 0, H = 0;
+    std::optional<DBuf> gu;   // [G, 2I]
+    std::optional<DBuf> act;  // [G, I]
+  };
+  static thread_local Tls tls;
+  if (tls.dev != d.q.device.index || tls.Gcap < G || tls.I != I || tls.H != H) {
+    tls.gu.emplace(d, DType::kBF16, std::vector<int64_t>{G, 2 * I});
+    tls.act.emplace(d, DType::kBF16, std::vector<int64_t>{G, I});
+    tls.dev = d.q.device.index;
+    tls.Gcap = G;
+    tls.I = I;
+    tls.H = H;
   }
+  const vt::Device dev = d.q.device;
+  const size_t gu_row = static_cast<size_t>(2 * I) * 2;
+  const size_t act_row = static_cast<size_t>(I) * 2;
+  const int Ngu = static_cast<int>(2 * I);
+  const int Nh = static_cast<int>(H);
+  const int Ki = static_cast<int>(I);
+  const int Kh = static_cast<int>(H);
+
+  for (int g = 0; g < G; ++g) {
+    void* gu_out = static_cast<char*>(tls.gu->ptr()) + static_cast<size_t>(g) * gu_row;
+    vt::MatmulBTFp8Channel(d.q, gu_out, x.data, fp8_gu[g], s_gu[g], /*M=*/1, Ngu, Kh, 1.f, 0.f);
+  }
+  Tensor gu_all = Tensor::Contiguous(static_cast<uint16_t*>(tls.gu->ptr()), DType::kBF16, dev,
+                                     {G, 2 * I});
+  Tensor act_all = Tensor::Contiguous(static_cast<uint16_t*>(tls.act->ptr()), DType::kBF16, dev,
+                                      {G, I});
+  vt::GeluAndMul(d.q, act_all, gu_all);
+  for (int g = 0; g < G; ++g) {
+    const float alpha = wts[g];
+    const float beta = (g == 0) ? 0.f : 1.f;
+    void* act_g = static_cast<char*>(tls.act->ptr()) + static_cast<size_t>(g) * act_row;
+    vt::MatmulBTFp8Channel(d.q, ysum.ptr(), act_g, fp8_dn[g], s_dn[g], /*M=*/1, Nh, Ki, alpha,
+                           beta);
+  }
+  return true;
 }
 
 // Top-k experts: all gate_up GEMMs → one GeluAndMul → all down GEMMs (alpha/beta mix).
@@ -659,6 +699,13 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   const int64_t dn_stride = H * I;
   const bool same_dev =
       ex.gate_up_dev != nullptr && ex.down_dev != nullptr && ex.dev_id == compute_dev;
+  const bool fp8_res =
+      ex.fp8_native_resident && !ex.fp8.empty() && ex.fp8[0].dev_fp8_gu != nullptr &&
+      ex.dev_id >= 0;
+  const bool fp8_res_same = fp8_res && ex.dev_id == compute_dev;
+  const bool fp8_res_peer = fp8_res && ex.dev_id != compute_dev;
+  const bool need_peer_sc = (!same_dev && ex.gate_up_dev && ex.down_dev && ex.dev_id >= 0) ||
+                            fp8_res_peer;
 
   const auto* gu_host = ex.gate_up.Empty()
                             ? nullptr
@@ -676,7 +723,9 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     std::unique_ptr<ExpertScratch> esc;
     std::optional<DBuf> xin, ysum, y, ysc;
     std::optional<DBuf> gu_sc, dn_sc;
+    std::optional<DBuf> fp8_gu_sc, fp8_dn_sc, fp8_sgu_sc, fp8_sdn_sc;
     bool have_peer = false;
+    bool have_fp8_peer = false;
     std::vector<uint16_t> gu_tmp, dn_tmp;
   };
   static thread_local MoeTlsScratch tls;
@@ -688,7 +737,12 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     tls.ysc.emplace(d, DType::kBF16, std::vector<int64_t>{1, H});
     tls.gu_sc.reset();
     tls.dn_sc.reset();
+    tls.fp8_gu_sc.reset();
+    tls.fp8_dn_sc.reset();
+    tls.fp8_sgu_sc.reset();
+    tls.fp8_sdn_sc.reset();
     tls.have_peer = false;
+    tls.have_fp8_peer = false;
     tls.gu_tmp.clear();
     tls.dn_tmp.clear();
     tls.dev = compute_dev;
@@ -700,12 +754,17 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   DBuf& ysum = *tls.ysum;
   DBuf& y = *tls.y;
   DBuf& ysc = *tls.ysc;
-  const bool need_peer_sc =
-      ex.gate_up_dev != nullptr && ex.down_dev != nullptr && !same_dev;
-  if (need_peer_sc && !tls.have_peer) {
+  if (need_peer_sc && !fp8_res_peer && !tls.have_peer) {
     tls.gu_sc.emplace(d, DType::kBF16, std::vector<int64_t>{2 * I, H});
     tls.dn_sc.emplace(d, DType::kBF16, std::vector<int64_t>{H, I});
     tls.have_peer = true;
+  }
+  if (fp8_res_peer && !tls.have_fp8_peer) {
+    tls.fp8_gu_sc.emplace(d, DType::kI8, std::vector<int64_t>{2 * I * H});
+    tls.fp8_dn_sc.emplace(d, DType::kI8, std::vector<int64_t>{H * I});
+    tls.fp8_sgu_sc.emplace(d, DType::kBF16, std::vector<int64_t>{2 * I});
+    tls.fp8_sdn_sc.emplace(d, DType::kBF16, std::vector<int64_t>{H});
+    tls.have_fp8_peer = true;
   }
   std::optional<DBuf>& gu_sc = tls.gu_sc;
   std::optional<DBuf>& dn_sc = tls.dn_sc;
@@ -725,6 +784,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   }();
   static const bool fp8_native = [] {
     const char* e = std::getenv("VT_GEMMA4_FP8_NATIVE");
+    // Default OFF: software FP8 GEMV is slower/riskier than BF16 hipBLAS resident.
+    // Enable with =1 (or use VT_GEMMA4_RESIDENT_NATIVE=1 at load for packs).
     return e && e[0] == '1';
   }();
   static const bool custom_expert = [] {
@@ -746,14 +807,17 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   // Lazy Ensure only (below). Bulk hoist removed — was the pollution hang site.
   (void)moe_trace;
 
-  // Prefill batch MoE: DEFAULT OFF. Chunked host-scatter still kfd_wait-hangs on
-  // long prefill (~T=400 l=9) under ROCm. Serial token MoE + EXPERT_VRAM_MB=0 is
-  // the pollution-stable path. Enable: VT_GEMMA4_PREFILL_BATCH_MOE=1.
-  static const bool prefill_batch_moe = [] {
+  // Prefill batch MoE: ON when BF16 device-resident same GPU (group-by-expert).
+  // Native FP8 is M=1 GEMV — stay serial. Explicit 0/1 overrides.
+  static const int prefill_batch_env = [] {
     const char* e = std::getenv("VT_GEMMA4_PREFILL_BATCH_MOE");
-    return e != nullptr && e[0] == '1' && e[1] == '\0';
+    if (e == nullptr) return -1;  // auto
+    return (e[0] == '1') ? 1 : 0;
   }();
-  if (T > 1 && prefill_batch_moe && !host_axpy) {
+  const bool prefill_batch_moe =
+      (T > 1) && !host_axpy &&
+      ((prefill_batch_env == 1) || (prefill_batch_env < 0 && same_dev));
+  if (prefill_batch_moe) {
     const vt::Device dev = d.q.device;
     std::vector<std::vector<int32_t>> etok(static_cast<size_t>(E));
     std::vector<std::vector<float>> ewt(static_cast<size_t>(E));
@@ -987,9 +1051,54 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       }
     }
 
-    // Fused-Gelu top-k: gate_up×G → one GeluAndMul → down×G (default BF16 device path).
+    // Fused-Gelu top-k FP8 native (resident or LRU). xin is always 1×H in this loop.
+    if (!host_axpy && (fp8_native || fp8_res) && ex.is_fp8) {
+      std::vector<const void*> fgu, sgu, fdn, sdn;
+      fgu.reserve(static_cast<size_t>(top_k));
+      sgu.reserve(static_cast<size_t>(top_k));
+      fdn.reserve(static_cast<size_t>(top_k));
+      sdn.reserve(static_cast<size_t>(top_k));
+      bool ok = true;
+      // Peer path: copy each expert into scratch one at a time into a packed TLS
+      // would need G packs — fall back to serial ExpertGeGLUFp8Native with peer.
+      if (fp8_res_peer) {
+        ok = false;
+      } else {
+        for (int i = 0; i < top_k && ok; ++i) {
+          const int e = idx[static_cast<size_t>(i)];
+          const auto& fex = ex.fp8[static_cast<size_t>(e)];
+          if (fex.dev_fp8_gu && fex.dev_fp8_dn && fex.dev_s_gu && fex.dev_s_dn) {
+            fgu.push_back(fex.dev_fp8_gu);
+            sgu.push_back(fex.dev_s_gu);
+            fdn.push_back(fex.dev_fp8_dn);
+            sdn.push_back(fex.dev_s_dn);
+          } else if (EnsureGemma4Fp8NativeOnDevice(d, fex, I, H)) {
+            fgu.push_back(fex.dev_fp8_gu);
+            sgu.push_back(fex.dev_s_gu);
+            fdn.push_back(fex.dev_fp8_dn);
+            sdn.push_back(fex.dev_s_dn);
+          } else {
+            ok = false;
+          }
+        }
+      }
+      if (ok && static_cast<int>(fgu.size()) == top_k &&
+          ExpertGeGLUFp8TopKFusedGelu(d, ysum, xin.t(), fgu.data(), sgu.data(), fdn.data(),
+                                      sdn.data(), wts.data(), top_k, I, H)) {
+        d.b.Copy(
+            d.q,
+            static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
+            ysum.ptr(), static_cast<size_t>(H) * 2);
+        // One drain per token on full device path (not per expert).
+        d.b.Synchronize(d.q);
+        continue;
+      }
+    }
+
+    // Fused-Gelu top-k BF16 device path (resident gate_up_dev or LRU BF16).
     // Optional custom RDNA4 expert kernels: VT_GEMMA4_CUSTOM_EXPERT=1
-    if (!host_axpy && T == 1 && !fp8_native) {
+    // Always try when BF16 stacks are on this GPU; peer BF16 uses serial+PeerCopy.
+    if (!host_axpy && !fp8_res) {
       std::vector<const uint16_t*> gu_p, dn_p;
       gu_p.reserve(static_cast<size_t>(top_k));
       dn_p.reserve(static_cast<size_t>(top_k));
@@ -1056,7 +1165,23 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
             static_cast<const uint16_t*>(ex.down_dev) + static_cast<int64_t>(e) * dn_stride;
         ExpertGeGLUDeviceAccum(d, ysum, xin.t(), gu, dn, I, H, esc, ww, beta);
         fused_mix = true;
-      } else if (fp8_native && ex.is_fp8 && T == 1) {
+      } else if (fp8_res_same && ex.is_fp8) {
+        const auto& fex = ex.fp8[static_cast<size_t>(e)];
+        ExpertGeGLUFp8Native(d, ysum, xin.t(), fex.dev_fp8_gu, fex.dev_s_gu, fex.dev_fp8_dn,
+                             fex.dev_s_dn, I, H, esc, ww, beta);
+        fused_mix = true;
+      } else if (fp8_res_peer && ex.is_fp8 && tls.fp8_gu_sc && tls.fp8_dn_sc && tls.fp8_sgu_sc &&
+                 tls.fp8_sdn_sc) {
+        const auto& fex = ex.fp8[static_cast<size_t>(e)];
+        if (PeerCopyGemma4Fp8ExpertSlice(ex.dev_id, fex.dev_fp8_gu, fex.dev_fp8_dn, fex.dev_s_gu,
+                                         fex.dev_s_dn, I, H, compute_dev, tls.fp8_gu_sc->ptr(),
+                                         tls.fp8_dn_sc->ptr(), tls.fp8_sgu_sc->ptr(),
+                                         tls.fp8_sdn_sc->ptr())) {
+          ExpertGeGLUFp8Native(d, ysum, xin.t(), tls.fp8_gu_sc->ptr(), tls.fp8_sgu_sc->ptr(),
+                               tls.fp8_dn_sc->ptr(), tls.fp8_sdn_sc->ptr(), I, H, esc, ww, beta);
+          fused_mix = true;
+        }
+      } else if (fp8_native && ex.is_fp8) {
         const auto& fex = ex.fp8[static_cast<size_t>(e)];
         if (EnsureGemma4Fp8NativeOnDevice(d, fex, I, H)) {
           ExpertGeGLUFp8Native(d, ysum, xin.t(), fex.dev_fp8_gu, fex.dev_s_gu, fex.dev_fp8_dn,
@@ -1198,6 +1323,10 @@ bool RunGemma4FusedTopkExpertGeGLU(vt::Queue&, void*, const void*, const uint16_
 }
 bool PeerCopyGemma4ExpertSlice(int, const void*, const void*, int, int64_t, int64_t, int, void*,
                                void*) {
+  return false;
+}
+bool PeerCopyGemma4Fp8ExpertSlice(int, const void*, const void*, const void*, const void*, int64_t,
+                                  int64_t, int, void*, void*, void*, void*) {
   return false;
 }
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats&) {}

--- a/src/vllm/transformers_utils/hf_config.cpp
+++ b/src/vllm/transformers_utils/hf_config.cpp
@@ -7,9 +7,13 @@
 #include "vllm/transformers_utils/hf_config.h"
 
 #include <cmath>
+#include <cstdint>
 #include <fstream>
 #include <limits>
+#include <set>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace vllm {
 
@@ -312,6 +316,58 @@ RopeParameters ParseRopeParameters(const nlohmann::json& text,
   return params;
 }
 
+// Collect eos_token_id from a JSON object as a unique ordered vector.
+void CollectEosIds(const nlohmann::json& doc, std::set<int32_t>* out) {
+  auto it = doc.find("eos_token_id");
+  if (it == doc.end() || it->is_null()) return;
+  if (it->is_number_integer()) {
+    out->insert(it->get<int32_t>());
+    return;
+  }
+  if (it->is_array()) {
+    for (const auto& e : *it) {
+      if (e.is_number_integer()) out->insert(e.get<int32_t>());
+    }
+  }
+}
+
+// Sibling of config.json: generation_config.json (HF transformers layout).
+// path may be ".../config.json" or a directory containing it.
+std::string SiblingGenerationConfigPath(const std::string& path) {
+  std::string dir = path;
+  // Strip trailing slashes.
+  while (!dir.empty() && (dir.back() == '/' || dir.back() == '\\')) dir.pop_back();
+  // If path ends with config.json, take parent directory.
+  const std::string leaf = "config.json";
+  if (dir.size() >= leaf.size() &&
+      dir.compare(dir.size() - leaf.size(), leaf.size(), leaf) == 0) {
+    const auto slash = dir.find_last_of("/\\");
+    dir = (slash == std::string::npos) ? std::string(".") : dir.substr(0, slash);
+  }
+  return dir + "/generation_config.json";
+}
+
+// Merge generation_config.json eos_token_id into cfg.raw["eos_token_id"].
+// Silent no-op if generation_config is missing or has no eos field.
+void MergeGenerationConfigEos(const std::string& config_path, nlohmann::json* raw) {
+  if (raw == nullptr || !raw->is_object()) return;
+  std::set<int32_t> ids;
+  CollectEosIds(*raw, &ids);
+
+  const std::string gen_path = SiblingGenerationConfigPath(config_path);
+  std::ifstream gin(gen_path, std::ios::binary);
+  if (!gin) return;
+  nlohmann::json gdoc = nlohmann::json::parse(gin, /*cb=*/nullptr,
+                                              /*allow_exceptions=*/false);
+  if (gdoc.is_discarded() || !gdoc.is_object()) return;
+  CollectEosIds(gdoc, &ids);
+  if (ids.empty()) return;
+
+  nlohmann::json arr = nlohmann::json::array();
+  for (int32_t id : ids) arr.push_back(id);
+  (*raw)["eos_token_id"] = std::move(arr);
+}
+
 }  // namespace
 
 std::vector<std::string> PeekHfArchitectures(const std::string& path) {
@@ -484,6 +540,15 @@ HfConfig LoadHfConfig(const std::string& path) {
   }
 
   cfg.raw = std::move(doc);
+
+  // Union generation_config.json eos_token_id into cfg.raw["eos_token_id"].
+  // Upstream SamplingParams.update_from_generation_config loads BOTH
+  // config.json and generation_config.json. Gemma-4-26B ships:
+  //   config.json eos:            [1, 106]
+  //   generation_config.json eos: [1, 106, 50]   // 50 = <turn|> stop
+  // Missing the generation_config extras leaves chat gens without full EOG.
+  MergeGenerationConfigEos(path, &cfg.raw);
+
   return cfg;
 }
 

--- a/src/vllm/v1/core/sched/scheduler.cpp
+++ b/src/vllm/v1/core/sched/scheduler.cpp
@@ -53,7 +53,9 @@ void MaybeLogPrefillProgress(const Request& request) {
   using clock = std::chrono::steady_clock;
   struct State {
     clock::time_point last{};
+    clock::time_point first{};
     int last_computed = -1;
+    int first_computed = -1;
     bool logged_done = false;
   };
   static std::mutex mu;
@@ -61,12 +63,22 @@ void MaybeLogPrefillProgress(const Request& request) {
   std::lock_guard<std::mutex> lock(mu);
   State& st = states[request.request_id];
   const auto now = clock::now();
+  if (st.first.time_since_epoch().count() == 0) {
+    st.first = now;
+    st.first_computed = computed;
+  }
   const bool done = !request.is_prefill_chunk && computed >= prompt;
   if (done) {
     if (!st.logged_done) {
+      const double elapsed_s =
+          std::chrono::duration<double>(now - st.first).count();
+      const int done_tok = std::min(computed, prompt);
+      const double tok_s =
+          elapsed_s > 0.0 ? static_cast<double>(done_tok) / elapsed_s : 0.0;
       std::cerr << "INFO prefill id=" << request.request_id
-                << " computed=" << std::min(computed, prompt) << "/" << prompt
-                << " (100%) status=done\n";
+                << " computed=" << done_tok << "/" << prompt
+                << " (100%) status=done elapsed_s=" << elapsed_s
+                << " prefill_tok_s=" << tok_s << "\n";
       std::cerr.flush();
       st.logged_done = true;
     }
@@ -83,15 +95,24 @@ void MaybeLogPrefillProgress(const Request& request) {
 
   const auto ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(now - st.last).count();
-  if (st.last_computed >= 0 && ms < 500 && (computed - st.last_computed) < 2048) {
+  // Long contexts: log at least every 500ms OR every 512 new tokens so
+  // "prefill gets slower as seq grows" is visible in the log.
+  if (st.last_computed >= 0 && ms < 500 && (computed - st.last_computed) < 512) {
     return;
   }
+  const double window_s = st.last.time_since_epoch().count() == 0
+                              ? 0.0
+                              : std::chrono::duration<double>(now - st.last).count();
+  const int delta =
+      st.last_computed < 0 ? 0 : std::max(0, computed - st.last_computed);
+  const double inst_tok_s = window_s > 0.0 ? static_cast<double>(delta) / window_s : 0.0;
   st.last = now;
   st.last_computed = computed;
   const int shown = std::min(computed, prompt);
   const double pct = 100.0 * static_cast<double>(shown) / static_cast<double>(prompt);
   std::cerr << "INFO prefill id=" << request.request_id << " computed=" << shown
-            << "/" << prompt << " (" << pct << "%) status=running\n";
+            << "/" << prompt << " (" << pct << "%) status=running"
+            << " inst_tok_s=" << inst_tok_s << "\n";
   std::cerr.flush();
 }
 

--- a/src/vllm/v1/engine/core_proc.cpp
+++ b/src/vllm/v1/engine/core_proc.cpp
@@ -182,7 +182,31 @@ void EngineCoreProc::process_input_queue() {
 bool EngineCoreProc::process_engine_step() {
   // core.py:1300-1318. "Called only when there are unfinished local requests."
   // core.py:1303: step the engine core.
+  static const bool kStepHb = [] {
+    const char* e = std::getenv("VT_ENGINE_STEP_LOG");
+    if (e != nullptr && e[0] == '1') return true;
+    const char* v = std::getenv("VT_SERVER_VERBOSE");
+    return v != nullptr && v[0] == '1';
+  }();
+  const double t0 = MonotonicSeconds();
+  if (kStepHb) {
+    std::fprintf(stderr,
+                 "INFO core-step begin unfinished=%d finished_pending=%d\n",
+                 scheduler_.get_num_unfinished_requests(),
+                 scheduler_.has_finished_requests() ? 1 : 0);
+    std::fflush(stderr);
+  }
   auto [outputs, model_executed] = (this->*step_fn_)();
+  if (kStepHb) {
+    int n_out = 0;
+    for (const auto& kv : outputs) {
+      n_out += static_cast<int>(kv.second.outputs.size());
+    }
+    std::fprintf(stderr,
+                 "INFO core-step end model_executed=%d n_out=%d elapsed_s=%.3f\n",
+                 model_executed ? 1 : 0, n_out, MonotonicSeconds() - t0);
+    std::fflush(stderr);
+  }
   // core.py:1305-1306: put EngineCoreOutputs into the output queue.
   for (auto& [client_index, engine_core_outputs] : outputs) {
     EngineCoreOutputItem out;

--- a/src/vllm/v1/engine/llm_engine.cpp
+++ b/src/vllm/v1/engine/llm_engine.cpp
@@ -3,8 +3,12 @@
 // generate driver loop). See llm_engine.h for scope, wiring and deviations.
 #include "vllm/v1/engine/llm_engine.h"
 
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 #include "vllm/v1/engine/parallel_sampling.h"
@@ -14,6 +18,32 @@
 #include "vllm/v1/request.h"
 
 namespace vllm::v1 {
+namespace {
+
+// VT_ENGINE_STEP_LOG=1 or VT_SERVER_VERBOSE=1: log first few generate steps so
+// a post-prefill hang shows "begin" without "end" (stuck inside step()).
+bool EngineStepLogEnabled() {
+  static const bool on = [] {
+    const char* e = std::getenv("VT_ENGINE_STEP_LOG");
+    if (e != nullptr && e[0] == '1' && e[1] == '\0') return true;
+    const char* v = std::getenv("VT_SERVER_VERBOSE");
+    return v != nullptr && v[0] == '1' && v[1] == '\0';
+  }();
+  return on;
+}
+
+void LogEngineStep(const char* phase, const std::string& request_id, int step,
+                   int outs, double elapsed_s) {
+  if (!EngineStepLogEnabled()) return;
+  // Only spam the first few steps (prefill + first decode tokens).
+  if (step > 6) return;
+  std::fprintf(stderr,
+               "INFO eng-step id=%s phase=%s step=%d outs=%d elapsed_s=%.3f\n",
+               request_id.c_str(), phase, step, outs, elapsed_s);
+  std::fflush(stderr);
+}
+
+}  // namespace
 
 LLMEngine::LLMEngine(InputProcessor& input_processor, EngineCore& engine_core,
                      OutputProcessor& output_processor, BlockHasher block_hasher)
@@ -236,7 +266,14 @@ RequestOutput LLMEngine::generate(const std::string& prompt,
   int steps = 0;
   constexpr int kMaxIdleSteps = 100000;  // safety; max_tokens should stop sooner
   while (true) {
+    const auto t0 = std::chrono::steady_clock::now();
+    LogEngineStep("begin", request_id, steps, -1, 0.0);
     std::vector<RequestOutput> step_outputs = step();
+    const double dt =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+            .count();
+    LogEngineStep("end", request_id, steps, static_cast<int>(step_outputs.size()),
+                  dt);
     ++steps;
     bool saw_self = false;
     bool self_finished = false;
@@ -276,9 +313,18 @@ RequestOutput LLMEngine::generate(std::vector<int32_t> prompt_token_ids,
               priority);
   RequestOutput result;
   int idle_steps = 0;
+  int steps = 0;
   constexpr int kMaxIdleSteps = 100000;
   while (true) {
+    const auto t0 = std::chrono::steady_clock::now();
+    LogEngineStep("begin", request_id, steps, -1, 0.0);
     std::vector<RequestOutput> step_outputs = step();
+    const double dt =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+            .count();
+    LogEngineStep("end", request_id, steps, static_cast<int>(step_outputs.size()),
+                  dt);
+    ++steps;
     bool saw_self = false;
     bool self_finished = false;
     for (RequestOutput& out : step_outputs) {

--- a/src/vt/fused_ops.cpp
+++ b/src/vt/fused_ops.cpp
@@ -131,4 +131,26 @@ bool ExpertGeGLUBf16TopKM1(Queue& q, void* ysum, const void* x, const void* cons
   return false;
 }
 
+bool ExpertGeGLUFp8TopKM1(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                          const void* const* s_gu, const void* const* fp8_dn,
+                          const void* const* s_dn, const float* wts, int G, int I, int H) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    return rocm::ExpertGeGLUFp8TopKM1Rocm(q, ysum, x, fp8_gu, s_gu, fp8_dn, s_dn, wts, G, I, H);
+  }
+#endif
+  (void)q;
+  (void)ysum;
+  (void)x;
+  (void)fp8_gu;
+  (void)s_gu;
+  (void)fp8_dn;
+  (void)s_dn;
+  (void)wts;
+  (void)G;
+  (void)I;
+  (void)H;
+  return false;
+}
+
 }  // namespace vt

--- a/src/vt/rocm/rocm_backend.hip
+++ b/src/vt/rocm/rocm_backend.hip
@@ -240,6 +240,15 @@ class RocmBackend final : public Backend {
   // Probed, never inferred from the gfx name.
   bool UnifiedMemory() const override { return unified_memory_; }
 
+  bool DeviceMemoryInfo(size_t* free_bytes, size_t* total_bytes) const override {
+    size_t free_b = 0, tot_b = 0;
+    if (hipSetDevice(device_) != hipSuccess) return false;
+    if (hipMemGetInfo(&free_b, &tot_b) != hipSuccess) return false;
+    if (free_bytes) *free_bytes = free_b;
+    if (total_bytes) *total_bytes = tot_b;
+    return true;
+  }
+
  private:
   int device_ = 0;
   bool unified_memory_ = false;

--- a/src/vt/rocm/rocm_fp8_channel_gemv.hip
+++ b/src/vt/rocm/rocm_fp8_channel_gemv.hip
@@ -1,8 +1,18 @@
-// FP8 E4M3 weight + BF16 per-row channel scale × BF16 activation GEMV (M=1).
-// y[n] = alpha * scale[n] * sum_k x[k]*f8(W[n,k]) + beta * y[n]
-// Opt-in via VT_GEMMA4_FP8_NATIVE path in gemma4 MoE.
+// Fast FP8-E4M3FN weight × BF16 activation decode kernels for Gemma-4 MoE.
+// Channel scales are BF16 per output row: y[n] = alpha * scale[n] * dot(x, dequant(W[n])) + beta*y
+//
+// Why this exists: the first MatmulBTFp8Channel was a scalar software GEMV and was
+// MUCH slower than hipBLAS BF16. FP8 should win on bandwidth when the kernel is good.
+//
+// Strategy (T=1 decode):
+//  - Fused Expert GeGLU: one x load, gate+up dots together, gelu*up, then down.
+//  - Vectorized uint4 weight loads (16 FP8 / iter), float FMAs.
+//  - Top-k sequential mix with alpha/beta into ysum.
 #include <hip/hip_bf16.h>
 #include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
 
 #include "vt/device.h"
 #include "vt/dtype.h"
@@ -10,43 +20,82 @@
 namespace vt::rocm {
 namespace {
 
-// IEEE fp8-e4m3fn (matches vllm::F8E4M3ToF32)
+constexpr int kBlock = 256;
+
+// IEEE fp8-e4m3fn (matches vllm::F8E4M3ToF32 / HF compressed-tensors).
 __device__ inline float F8E4M3ToF32(uint8_t byte) {
   const uint32_t sign = static_cast<uint32_t>(byte >> 7) & 0x1U;
   const uint32_t exp = static_cast<uint32_t>(byte >> 3) & 0xFU;
   const uint32_t mant = static_cast<uint32_t>(byte) & 0x7U;
   const float sm = sign ? -1.0f : 1.0f;
-  if (exp == 0xFU && mant == 0x7U) return 0.f;  // NaN → 0 in matmul
+  if (exp == 0xFU && mant == 0x7U) return 0.f;
   if (exp == 0U) return sm * (static_cast<float>(mant) * (1.0f / 512.0f));
   const float mantissa = 1.0f + static_cast<float>(mant) * (1.0f / 8.0f);
   return sm * ldexpf(mantissa, static_cast<int>(exp) - 7);
 }
 
-// x in LDS; each thread owns output rows
-__global__ void Fp8ChannelGemvKernel(__hip_bfloat16* __restrict__ y,
-                                     const __hip_bfloat16* __restrict__ x,
-                                     const uint8_t* __restrict__ W,  // [N,K]
-                                     const __hip_bfloat16* __restrict__ scale,  // [N]
-                                     int N, int K, float alpha, float beta) {
+__device__ inline float BlockSum256(float v) {
+  __shared__ float sm[256];
+  const int tid = static_cast<int>(threadIdx.x);
+  sm[tid] = v;
+  __syncthreads();
+#pragma unroll
+  for (int s = 128; s > 0; s >>= 1) {
+    if (tid < s) sm[tid] += sm[tid + s];
+    __syncthreads();
+  }
+  return sm[0];
+}
+
+__device__ inline float gelu_tanh(float g) {
+  const float inner = 0.7978845608028654f * (g + 0.044715f * g * g * g);
+  return 0.5f * g * (1.f + tanhf(inner));
+}
+
+// Dot x[K] (float LDS) with FP8 row W[n,0:K], then * scale.
+__device__ inline float DotFp8Row(const float* __restrict__ x_cache, const uint8_t* __restrict__ wrow,
+                                  int K) {
+  float acc = 0.f;
+  const int tid = static_cast<int>(threadIdx.x);
+  // 16-byte chunks when aligned
+  const int K16 = K & ~15;
+  for (int k = tid * 16; k < K16; k += kBlock * 16) {
+    // manual unroll of 16 loads keeps ILP without requiring alignment of wrow+k
+    float a0 = 0.f, a1 = 0.f, a2 = 0.f, a3 = 0.f;
+#pragma unroll
+    for (int t = 0; t < 4; ++t) {
+      const int base = k + t * 4;
+      a0 += x_cache[base + 0] * F8E4M3ToF32(wrow[base + 0]);
+      a1 += x_cache[base + 1] * F8E4M3ToF32(wrow[base + 1]);
+      a2 += x_cache[base + 2] * F8E4M3ToF32(wrow[base + 2]);
+      a3 += x_cache[base + 3] * F8E4M3ToF32(wrow[base + 3]);
+    }
+    acc += (a0 + a1) + (a2 + a3);
+  }
+  for (int k = K16 + tid; k < K; k += kBlock) {
+    acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
+  }
+  return BlockSum256(acc);
+}
+
+// Single-row channel GEMV (fallback / general MatmulBTFp8Channel M=1).
+// grid: ceil(N / rows_per_block) with rows_per_block=1 → one block per output row.
+__global__ void Fp8ChannelGemvFastKernel(__hip_bfloat16* __restrict__ y,
+                                         const __hip_bfloat16* __restrict__ x,
+                                         const uint8_t* __restrict__ W,  // [N,K]
+                                         const __hip_bfloat16* __restrict__ scale, int N, int K,
+                                         float alpha, float beta) {
   extern __shared__ float smem[];
   float* x_cache = smem;
-  for (int k = static_cast<int>(threadIdx.x); k < K; k += static_cast<int>(blockDim.x)) {
-    x_cache[k] = __bfloat162float(x[k]);
-  }
+  const int tid = static_cast<int>(threadIdx.x);
+  for (int k = tid; k < K; k += kBlock) x_cache[k] = __bfloat162float(x[k]);
   __syncthreads();
 
-  for (int n = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x); n < N;
-       n += static_cast<int>(gridDim.x * blockDim.x)) {
-    const uint8_t* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
-    float acc = 0.f;
-    int k = 0;
-    for (; k + 3 < K; k += 4) {
-      acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
-      acc += x_cache[k + 1] * F8E4M3ToF32(wrow[k + 1]);
-      acc += x_cache[k + 2] * F8E4M3ToF32(wrow[k + 2]);
-      acc += x_cache[k + 3] * F8E4M3ToF32(wrow[k + 3]);
-    }
-    for (; k < K; ++k) acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
+  const int n = static_cast<int>(blockIdx.x);
+  if (n >= N) return;
+  const uint8_t* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
+  float acc = DotFp8Row(x_cache, wrow, K);
+  if (tid == 0) {
     const float s = __bfloat162float(scale[n]);
     float v = alpha * s * acc;
     if (beta != 0.f) v += beta * __bfloat162float(y[n]);
@@ -54,22 +103,138 @@ __global__ void Fp8ChannelGemvKernel(__hip_bfloat16* __restrict__ y,
   }
 }
 
+// Fused gate|up act: grid = I. w_gu is packed FP8 [2I, H], s_gu BF16 [2I].
+__global__ void ExpertFp8ActKernel(float* __restrict__ act, const __hip_bfloat16* __restrict__ x,
+                                   const uint8_t* __restrict__ w_gu,
+                                   const __hip_bfloat16* __restrict__ s_gu, int I, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  if (i >= I) return;
+  extern __shared__ float smem[];
+  float* x_cache = smem;
+  const int tid = static_cast<int>(threadIdx.x);
+  for (int h = tid; h < H; h += kBlock) x_cache[h] = __bfloat162float(x[h]);
+  __syncthreads();
+
+  const uint8_t* grow = w_gu + static_cast<int64_t>(i) * H;
+  const uint8_t* urow = w_gu + static_cast<int64_t>(I + i) * H;
+  // Partial dots in registers then block-reduce once each would need two passes —
+  // compute both in one K loop:
+  float gate = 0.f, up = 0.f;
+  const int H16 = H & ~15;
+  for (int h = tid * 16; h < H16; h += kBlock * 16) {
+#pragma unroll
+    for (int t = 0; t < 16; ++t) {
+      const int hh = h + t;
+      const float xv = x_cache[hh];
+      gate += xv * F8E4M3ToF32(grow[hh]);
+      up += xv * F8E4M3ToF32(urow[hh]);
+    }
+  }
+  for (int h = H16 + tid; h < H; h += kBlock) {
+    const float xv = x_cache[h];
+    gate += xv * F8E4M3ToF32(grow[h]);
+    up += xv * F8E4M3ToF32(urow[h]);
+  }
+  gate = BlockSum256(gate);
+  up = BlockSum256(up);
+  if (tid == 0) {
+    const float sg = __bfloat162float(s_gu[i]);
+    const float su = __bfloat162float(s_gu[I + i]);
+    act[i] = gelu_tanh(sg * gate) * (su * up);
+  }
+}
+
+// Down: grid = ceil(H/kBlock). w_dn FP8 [H,I], s_dn BF16 [H].
+__global__ void ExpertFp8DownKernel(__hip_bfloat16* __restrict__ y, const float* __restrict__ act,
+                                    const uint8_t* __restrict__ w_dn,
+                                    const __hip_bfloat16* __restrict__ s_dn, int I, int H,
+                                    float alpha, float beta) {
+  const int h = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (h >= H) return;
+  const uint8_t* drow = w_dn + static_cast<int64_t>(h) * I;
+  float acc = 0.f;
+  int i = 0;
+  for (; i + 3 < I; i += 4) {
+    acc += act[i] * F8E4M3ToF32(drow[i]);
+    acc += act[i + 1] * F8E4M3ToF32(drow[i + 1]);
+    acc += act[i + 2] * F8E4M3ToF32(drow[i + 2]);
+    acc += act[i + 3] * F8E4M3ToF32(drow[i + 3]);
+  }
+  for (; i < I; ++i) acc += act[i] * F8E4M3ToF32(drow[i]);
+  const float sd = __bfloat162float(s_dn[h]);
+  float v = alpha * sd * acc;
+  if (beta != 0.f) v += beta * __bfloat162float(y[h]);
+  y[h] = __float2bfloat16(v);
+}
+
+struct ActBuf {
+  float* p = nullptr;
+  int cap = 0;
+};
+ActBuf& TlsAct() {
+  static thread_local ActBuf b;
+  return b;
+}
+bool EnsureAct(int I) {
+  auto& b = TlsAct();
+  if (b.cap >= I && b.p) return true;
+  if (b.p) (void)hipFree(b.p);
+  b.p = nullptr;
+  b.cap = 0;
+  if (hipMalloc(&b.p, static_cast<size_t>(I) * sizeof(float)) != hipSuccess) return false;
+  b.cap = I;
+  return true;
+}
+
 }  // namespace
 
-// out[1,N] bf16, a[1,K] bf16, b_fp8[N,K], scale_bf16[N]
+// General M=1 channel GEMV (used if fused expert path not taken).
 void MatmulBTFp8ChannelRocm(Queue& q, void* out, const void* a, const void* b_fp8,
                             const void* scale_bf16, int M, int N, int K, float alpha,
                             float beta) {
   if (M != 1 || N <= 0 || K <= 0) return;
   hipStream_t s = static_cast<hipStream_t>(q.handle);
-  constexpr int kBlock = 256;
-  const int grid = (N + kBlock - 1) / kBlock;
   const size_t shmem = static_cast<size_t>(K) * sizeof(float);
-  if (shmem > 48 * 1024) return;  // caller must fall back
-  Fp8ChannelGemvKernel<<<grid, kBlock, shmem, s>>>(
+  if (shmem > 48 * 1024) return;
+  // One block per output row — full-block reduction over K (much better than
+  // the old "one thread per row" scalar kernel).
+  Fp8ChannelGemvFastKernel<<<N, kBlock, shmem, s>>>(
       static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
       static_cast<const uint8_t*>(b_fp8), static_cast<const __hip_bfloat16*>(scale_bf16), N, K,
       alpha, beta);
+}
+
+// Fused Expert GeGLU FP8 decode T=1. Returns false on setup failure.
+bool ExpertGeGLUFp8M1Rocm(Queue& q, void* y, const void* x, const void* fp8_gu, const void* s_gu,
+                          const void* fp8_dn, const void* s_dn, int I, int H, float alpha,
+                          float beta) {
+  if (!y || !x || !fp8_gu || !s_gu || !fp8_dn || !s_dn || I <= 0 || H <= 0) return false;
+  const size_t shmem = static_cast<size_t>(H) * sizeof(float);
+  if (shmem > 48 * 1024) return false;
+  if (!EnsureAct(I)) return false;
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  float* act = TlsAct().p;
+  ExpertFp8ActKernel<<<I, kBlock, shmem, st>>>(
+      act, static_cast<const __hip_bfloat16*>(x), static_cast<const uint8_t*>(fp8_gu),
+      static_cast<const __hip_bfloat16*>(s_gu), I, H);
+  const int grid_dn = (H + kBlock - 1) / kBlock;
+  ExpertFp8DownKernel<<<grid_dn, kBlock, 0, st>>>(
+      static_cast<__hip_bfloat16*>(y), act, static_cast<const uint8_t*>(fp8_dn),
+      static_cast<const __hip_bfloat16*>(s_dn), I, H, alpha, beta);
+  return hipGetLastError() == hipSuccess;
+}
+
+bool ExpertGeGLUFp8TopKM1Rocm(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                              const void* const* s_gu, const void* const* fp8_dn,
+                              const void* const* s_dn, const float* wts, int G, int I, int H) {
+  if (G <= 0 || !ysum || !x || !fp8_gu || !s_gu || !fp8_dn || !s_dn || !wts) return false;
+  for (int g = 0; g < G; ++g) {
+    const float beta = (g == 0) ? 0.f : 1.f;
+    if (!ExpertGeGLUFp8M1Rocm(q, ysum, x, fp8_gu[g], s_gu[g], fp8_dn[g], s_dn[g], I, H, wts[g],
+                              beta))
+      return false;
+  }
+  return true;
 }
 
 }  // namespace vt::rocm

--- a/src/vt/rocm/rocm_gemma4_experts.hip
+++ b/src/vt/rocm/rocm_gemma4_experts.hip
@@ -241,4 +241,15 @@ void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex) {
   }
 }
 
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex) {
+  if (!ex.host_pinned) return;
+  if (!ex.cached_gu.empty()) {
+    (void)hipHostUnregister(const_cast<uint16_t*>(ex.cached_gu.data()));
+  }
+  if (!ex.cached_dn.empty()) {
+    (void)hipHostUnregister(const_cast<uint16_t*>(ex.cached_dn.data()));
+  }
+  ex.host_pinned = false;
+}
+
 }  // namespace vllm

--- a/src/vt/rocm/rocm_gemma4_experts.hip
+++ b/src/vt/rocm/rocm_gemma4_experts.hip
@@ -241,16 +241,17 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
   int fill_dev = 0;
 
   // FP8 resident mode:
-  // - Default dual-GPU: BF16 expand (hipBLAS; ~2× VRAM, much faster decode).
-  // - VT_GEMMA4_RESIDENT_NATIVE=1 → native FP8 packs (~½ VRAM, GEMV kernel).
-  // - Single GPU auto-prefers native to fit; override with RESIDENT_BF16=1.
+  // Default: native FP8 packs (½ VRAM + fast fused ExpertGeGLU FP8 kernels).
+  // VT_GEMMA4_RESIDENT_BF16=1 forces BF16 expand (hipBLAS reference / A/B).
   static const bool force_bf16 = [] {
     const char* e = std::getenv("VT_GEMMA4_RESIDENT_BF16");
     return e && e[0] == '1';
   }();
   static const bool force_native = [] {
     const char* e = std::getenv("VT_GEMMA4_RESIDENT_NATIVE");
-    return e && e[0] == '1';
+    // Default ON when unset. =0 disables native (use BF16 expand).
+    if (e == nullptr) return true;
+    return e[0] == '1';
   }();
 
   for (size_t li = 0; li < layers.size(); ++li) {
@@ -261,8 +262,7 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
     const int64_t E = ex.num_experts;
     const int64_t I = ex.intermediate;
     const int64_t H = ex.hidden;
-    const bool want_native =
-        ex.is_fp8 && !force_bf16 && (force_native || (num_gpus <= 1 && !force_bf16));
+    const bool want_native = ex.is_fp8 && !force_bf16 && force_native;
     const size_t layer_bytes =
         want_native
             ? (static_cast<size_t>(E) * (static_cast<size_t>(2 * I * H) + static_cast<size_t>(H * I) +

--- a/src/vt/rocm/rocm_gemma4_experts.hip
+++ b/src/vt/rocm/rocm_gemma4_experts.hip
@@ -1,4 +1,5 @@
 // ROCm upload of Gemma-4 MoE expert stacks (BF16 fused or FP8→BF16 dequant).
+#include <cstring>
 // Packs GPU0 first (compute device), then GPU1. FP8 streams per-expert to
 // avoid ~30G host OOM from permanent BF16 caches / full-layer host buffers.
 #include <hip/hip_runtime.h>
@@ -45,6 +46,110 @@ bool AllocLayerDev(int dev, size_t gu_bytes, size_t dn_bytes, void** gu, void** 
   return true;
 }
 
+bool AllocFour(int dev, size_t a, size_t b, size_t c, size_t d, void** pa, void** pb, void** pc,
+               void** pd) {
+  if (!DeviceHasRoom(dev, a + b + c + d)) return false;
+  Check(hipSetDevice(dev), "hipSetDevice");
+  *pa = *pb = *pc = *pd = nullptr;
+  if (hipMalloc(pa, a) != hipSuccess) return false;
+  if (hipMalloc(pb, b) != hipSuccess) {
+    (void)hipFree(*pa);
+    *pa = nullptr;
+    return false;
+  }
+  if (hipMalloc(pc, c) != hipSuccess) {
+    (void)hipFree(*pa);
+    (void)hipFree(*pb);
+    *pa = *pb = nullptr;
+    return false;
+  }
+  if (hipMalloc(pd, d) != hipSuccess) {
+    (void)hipFree(*pa);
+    (void)hipFree(*pb);
+    (void)hipFree(*pc);
+    *pa = *pb = *pc = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// Native FP8 resident: keep u8 weights + BF16 channel scales on device (no BF16 expand).
+// ~½ VRAM vs UploadFp8LayerStreaming BF16 path. Per-expert pointers alias layer packs.
+bool UploadFp8NativeLayer(Gemma4FusedExperts& ex, int dev) {
+  const int64_t E = ex.num_experts;
+  const int64_t I = ex.intermediate;
+  const int64_t H = ex.hidden;
+  if (E <= 0 || I <= 0 || H <= 0 || ex.fp8.size() != static_cast<size_t>(E)) return false;
+
+  const size_t gu_one = static_cast<size_t>(2 * I * H);       // u8
+  const size_t dn_one = static_cast<size_t>(H * I);           // u8
+  const size_t sgu_one = static_cast<size_t>(2 * I) * 2;      // bf16
+  const size_t sdn_one = static_cast<size_t>(H) * 2;          // bf16
+  const size_t gu_bytes = gu_one * static_cast<size_t>(E);
+  const size_t dn_bytes = dn_one * static_cast<size_t>(E);
+  const size_t sgu_bytes = sgu_one * static_cast<size_t>(E);
+  const size_t sdn_bytes = sdn_one * static_cast<size_t>(E);
+
+  void *gu = nullptr, *dn = nullptr, *sgu = nullptr, *sdn = nullptr;
+  if (!AllocFour(dev, gu_bytes, dn_bytes, sgu_bytes, sdn_bytes, &gu, &dn, &sgu, &sdn))
+    return false;
+
+  std::vector<uint8_t> gu_pack(gu_one);
+  for (int64_t e = 0; e < E; ++e) {
+    auto& fex = ex.fp8[static_cast<size_t>(e)];
+    VT_CHECK(fex.gate_w.HasHostBytes() && fex.up_w.HasHostBytes() && fex.down_w.HasHostBytes(),
+             "fp8 native resident: missing weights");
+    VT_CHECK(fex.gate_s.HasHostBytes() && fex.up_s.HasHostBytes() && fex.down_s.HasHostBytes(),
+             "fp8 native resident: missing scales");
+    // Pack gate|up FP8 contiguous [2I, H]
+    const size_t half = static_cast<size_t>(I * H);
+    std::memcpy(gu_pack.data(), fex.gate_w.bytes.data(), half);
+    std::memcpy(gu_pack.data() + half, fex.up_w.bytes.data(), half);
+    Check(hipMemcpy(static_cast<char*>(gu) + static_cast<size_t>(e) * gu_one, gu_pack.data(),
+                    gu_one, hipMemcpyHostToDevice),
+          "H2D fp8 gu");
+    Check(hipMemcpy(static_cast<char*>(dn) + static_cast<size_t>(e) * dn_one,
+                    fex.down_w.bytes.data(), dn_one, hipMemcpyHostToDevice),
+          "H2D fp8 dn");
+    // scales: gate then up → [2I]
+    Check(hipMemcpy(static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one,
+                    fex.gate_s.bytes.data(), static_cast<size_t>(I) * 2, hipMemcpyHostToDevice),
+          "H2D sgu g");
+    Check(hipMemcpy(static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one +
+                        static_cast<size_t>(I) * 2,
+                    fex.up_s.bytes.data(), static_cast<size_t>(I) * 2, hipMemcpyHostToDevice),
+          "H2D sgu u");
+    Check(hipMemcpy(static_cast<char*>(sdn) + static_cast<size_t>(e) * sdn_one,
+                    fex.down_s.bytes.data(), sdn_one, hipMemcpyHostToDevice),
+          "H2D sdn");
+
+    // Drop host BF16 caches if any
+    fex.cached_gu.clear();
+    fex.cached_gu.shrink_to_fit();
+    fex.cached_dn.clear();
+    fex.cached_dn.shrink_to_fit();
+
+    fex.dev_fp8_gu = static_cast<char*>(gu) + static_cast<size_t>(e) * gu_one;
+    fex.dev_fp8_dn = static_cast<char*>(dn) + static_cast<size_t>(e) * dn_one;
+    fex.dev_s_gu = static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one;
+    fex.dev_s_dn = static_cast<char*>(sdn) + static_cast<size_t>(e) * sdn_one;
+    // Clear BF16 device expert slots (owned by LRU if any)
+    fex.dev_gu = nullptr;
+    fex.dev_dn = nullptr;
+  }
+
+  ex.fp8_gu_base = gu;
+  ex.fp8_dn_base = dn;
+  ex.fp8_sgu_base = sgu;
+  ex.fp8_sdn_base = sdn;
+  ex.fp8_native_resident = true;
+  ex.gate_up_dev = nullptr;
+  ex.down_dev = nullptr;
+  ex.dev_id = dev;
+  return true;
+}
+
+// Legacy: FP8 → BF16 expand on device (2× VRAM). Opt-in VT_GEMMA4_RESIDENT_BF16=1.
 bool UploadFp8LayerStreaming(Gemma4FusedExperts& ex, int dev) {
   const int64_t E = ex.num_experts;
   const int64_t I = ex.intermediate;
@@ -135,6 +240,19 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
 
   int fill_dev = 0;
 
+  // FP8 resident mode:
+  // - Default dual-GPU: BF16 expand (hipBLAS; ~2× VRAM, much faster decode).
+  // - VT_GEMMA4_RESIDENT_NATIVE=1 → native FP8 packs (~½ VRAM, GEMV kernel).
+  // - Single GPU auto-prefers native to fit; override with RESIDENT_BF16=1.
+  static const bool force_bf16 = [] {
+    const char* e = std::getenv("VT_GEMMA4_RESIDENT_BF16");
+    return e && e[0] == '1';
+  }();
+  static const bool force_native = [] {
+    const char* e = std::getenv("VT_GEMMA4_RESIDENT_NATIVE");
+    return e && e[0] == '1';
+  }();
+
   for (size_t li = 0; li < layers.size(); ++li) {
     if (ok_layers >= max_layers) break;
     auto& moe = layers[li];
@@ -143,23 +261,36 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
     const int64_t E = ex.num_experts;
     const int64_t I = ex.intermediate;
     const int64_t H = ex.hidden;
+    const bool want_native =
+        ex.is_fp8 && !force_bf16 && (force_native || (num_gpus <= 1 && !force_bf16));
     const size_t layer_bytes =
-        static_cast<size_t>(E * 2 * I * H) * 2 + static_cast<size_t>(E * H * I) * 2;
+        want_native
+            ? (static_cast<size_t>(E) * (static_cast<size_t>(2 * I * H) + static_cast<size_t>(H * I) +
+                                         static_cast<size_t>(2 * I) * 2 + static_cast<size_t>(H) * 2))
+            : (static_cast<size_t>(E * 2 * I * H) * 2 + static_cast<size_t>(E * H * I) * 2);
 
     bool ok = false;
-    if (ex.is_fp8)
-      ok = UploadFp8LayerStreaming(ex, fill_dev);
-    else
+    if (ex.is_fp8) {
+      if (want_native)
+        ok = UploadFp8NativeLayer(ex, fill_dev);
+      else
+        ok = UploadFp8LayerStreaming(ex, fill_dev);
+    } else {
       ok = UploadBf16Layer(ex, fill_dev);
+    }
 
     if (!ok && fill_dev + 1 < num_gpus) {
       ++fill_dev;
       std::fprintf(stderr, "gemma4 moe: GPU%d full after %d layers; continuing on GPU%d\n",
                    fill_dev - 1, ok_layers, fill_dev);
-      if (ex.is_fp8)
-        ok = UploadFp8LayerStreaming(ex, fill_dev);
-      else
+      if (ex.is_fp8) {
+        if (want_native)
+          ok = UploadFp8NativeLayer(ex, fill_dev);
+        else
+          ok = UploadFp8LayerStreaming(ex, fill_dev);
+      } else {
         ok = UploadBf16Layer(ex, fill_dev);
+      }
     }
     if (!ok) {
       std::fprintf(stderr, "gemma4 moe: resident upload stopped at layer %zu (OOM)\n", li);
@@ -167,8 +298,10 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
     }
     total += layer_bytes;
     ++ok_layers;
-    std::fprintf(stderr, "gemma4 moe: resident layer %zu -> gpu %d (%.2f GiB cumulative)\n", li,
-                 ex.dev_id, total / (1024.0 * 1024.0 * 1024.0));
+    std::fprintf(stderr,
+                 "gemma4 moe: resident layer %zu -> gpu %d %s (%.2f GiB cumulative)\n", li,
+                 ex.dev_id, ex.fp8_native_resident ? "fp8-native" : "bf16",
+                 total / (1024.0 * 1024.0 * 1024.0));
     std::fflush(stderr);
   }
   Check(hipSetDevice(0), "hipSetDevice0");
@@ -223,6 +356,39 @@ bool PeerCopyGemma4ExpertSlice(int src_dev, const void* gate_up_base, const void
     Check(hipMemcpy(down_dst, dn_tmp.data(), dn_one, hipMemcpyHostToDevice), "H2D dn");
   }
   Check(hipSetDevice(compute_dev), "peer restore compute");
+  return true;
+}
+
+bool PeerCopyGemma4Fp8ExpertSlice(int src_dev, const void* fp8_gu, const void* fp8_dn,
+                                  const void* s_gu, const void* s_dn, int64_t I, int64_t H,
+                                  int compute_dev, void* fp8_gu_dst, void* fp8_dn_dst,
+                                  void* s_gu_dst, void* s_dn_dst) {
+  if (!fp8_gu || !fp8_dn || !s_gu || !s_dn || !fp8_gu_dst || !fp8_dn_dst || !s_gu_dst ||
+      !s_dn_dst)
+    return false;
+  if (src_dev < 0 || compute_dev < 0) return false;
+  const size_t gu_b = static_cast<size_t>(2 * I * H);
+  const size_t dn_b = static_cast<size_t>(H * I);
+  const size_t sgu_b = static_cast<size_t>(2 * I) * 2;
+  const size_t sdn_b = static_cast<size_t>(H) * 2;
+  auto copy1 = [&](void* dst, const void* src, size_t n) -> bool {
+    if (src_dev == compute_dev) {
+      Check(hipSetDevice(compute_dev), "fp8 peer same");
+      return hipMemcpy(dst, src, n, hipMemcpyDeviceToDevice) == hipSuccess;
+    }
+    if (hipMemcpyPeer(dst, compute_dev, const_cast<void*>(src), src_dev, n) == hipSuccess)
+      return true;
+    std::vector<char> tmp(n);
+    Check(hipSetDevice(src_dev), "fp8 peer fb src");
+    if (hipMemcpy(tmp.data(), src, n, hipMemcpyDeviceToHost) != hipSuccess) return false;
+    Check(hipSetDevice(compute_dev), "fp8 peer fb dst");
+    return hipMemcpy(dst, tmp.data(), n, hipMemcpyHostToDevice) == hipSuccess;
+  };
+  if (!copy1(fp8_gu_dst, fp8_gu, gu_b)) return false;
+  if (!copy1(fp8_dn_dst, fp8_dn, dn_b)) return false;
+  if (!copy1(s_gu_dst, s_gu, sgu_b)) return false;
+  if (!copy1(s_dn_dst, s_dn, sdn_b)) return false;
+  Check(hipSetDevice(compute_dev), "fp8 peer restore");
   return true;
 }
 

--- a/tests/vllm/test_hf_config.cpp
+++ b/tests/vllm/test_hf_config.cpp
@@ -4,6 +4,7 @@
 // 33-112,243-283 @ e24d1b24fe96.
 #include <doctest/doctest.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -33,6 +34,34 @@ class TempJson {
 
  private:
   std::string path_;
+};
+
+// Temp directory with config.json + optional generation_config.json (HF layout).
+class TempModelDir {
+ public:
+  TempModelDir(const std::string& config_json, const std::string& gen_json) {
+    static int counter = 0;
+    dir_ = (std::filesystem::temp_directory_path() /
+            ("vllm_hf_cfgdir_" + std::to_string(counter++)))
+               .string();
+    std::filesystem::create_directories(dir_);
+    {
+      std::ofstream out(dir_ + "/config.json", std::ios::binary);
+      out << config_json;
+    }
+    if (!gen_json.empty()) {
+      std::ofstream out(dir_ + "/generation_config.json", std::ios::binary);
+      out << gen_json;
+    }
+  }
+  ~TempModelDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+  std::string config_path() const { return dir_ + "/config.json"; }
+
+ private:
+  std::string dir_;
 };
 
 // Qwen3-Next-like hybrid MoE config (key names per upstream
@@ -302,6 +331,45 @@ TEST_CASE("LoadHfConfig parses a minimal llama-like config with defaults") {
   CHECK(cfg.linear_conv_kernel_dim == 0);
 
   CHECK(cfg.torch_dtype == "float16");
+}
+
+TEST_CASE("LoadHfConfig unions generation_config.json eos_token_id (Gemma4)") {
+  // config.json has [1, 106]; generation_config adds 50 (<turn|>) — same shape
+  // as google/gemma-4-26B-A4B-it.
+  const char* cfg_json = R"({
+    "model_type": "gemma4",
+    "architectures": ["Gemma4ForConditionalGeneration"],
+    "hidden_size": 2816,
+    "num_hidden_layers": 30,
+    "num_attention_heads": 16,
+    "eos_token_id": [1, 106]
+  })";
+  const char* gen_json = R"({
+    "bos_token_id": 2,
+    "eos_token_id": [1, 106, 50],
+    "pad_token_id": 0
+  })";
+  TempModelDir d(cfg_json, gen_json);
+  vllm::HfConfig cfg = vllm::LoadHfConfig(d.config_path());
+  REQUIRE(cfg.raw.contains("eos_token_id"));
+  REQUIRE(cfg.raw["eos_token_id"].is_array());
+  std::vector<int32_t> eos = cfg.raw["eos_token_id"].get<std::vector<int32_t>>();
+  // Unique sorted union.
+  CHECK(eos == std::vector<int32_t>({1, 50, 106}));
+}
+
+TEST_CASE("LoadHfConfig generation_config missing is a no-op") {
+  TempJson f(R"({
+    "model_type": "llama",
+    "hidden_size": 16,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 2,
+    "eos_token_id": 2
+  })");
+  vllm::HfConfig cfg = vllm::LoadHfConfig(f.path());
+  // No sibling generation_config.json → raw eos stays a single int.
+  CHECK(cfg.raw.at("eos_token_id").is_number_integer());
+  CHECK(cfg.raw.at("eos_token_id").get<int>() == 2);
 }
 
 TEST_CASE("LoadHfConfig applies upstream rotary and head_dim defaults") {


### PR DESCRIPTION
## Summary

Long-prompt / pollution bring-up for **Gemma-4-26B MoE** on discrete ROCm (gfx1201 dual R9700 lab):

1. **Multi-EOS** — union `generation_config.json` `eos_token_id` with `config.json` at `LoadHfConfig` (Gemma-4 needs `[1,50,106]` including `<turn|>`).
2. **Host expert BF16 LRU** — `VT_GEMMA4_HOST_EXPERT_MB` caps permanent dequant packs + unpin on eviction (unbounded cache OOM'd ~30G hosts under pollution).
3. **Device expert LRU harden** — fill-only default; free-VRAM via `Backend::DeviceMemoryInfo`; no `hipFree` unless `VT_GEMMA4_EXPERT_EVICT=1`.
4. **Hang instrumentation** — EngineCore step begin/end + optional layer-trace; prefill `inst_tok_s`.
5. Sticky expert H2D keyed by expert identity (not ephemeral buffer pointers).

Docs: `docs/ENVIRONMENT.md`, `docs/FEATURES.md` row. Unit tests: `tests/vllm/test_hf_config.cpp`.

## Lab evidence (not CI)

- Dual-GPU `VT_GEMMA4_RESIDENT_EXPERTS=1`: 30 layers / **42.5 GiB** resident; pollution **ALL_OK 12**; short chat ~**1.5s** (was ~12.5s host-stream).
- Host-stream path also pollution-stable with host LRU + multi-EOS.

## Test plan

- [x] `check-device-leakage`, `check-env-doc`, `check-doc-checkpoint`, `check-public-doc-tables`, `check-pr-size`, commit trailers
- [x] `test_hf_config` multi-EOS cases (local)
- [x] Live `:8012` pollution + long-prompt chat/completions on gfx1201

FOLLOWING_AGENTS_PROTOCOL