### PR TITLE
feat(rocm): V1 sampling ops for Hermes EngineCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1312,6 +1312,7 @@ if(VLLM_CPP_HIP)
     src/vt/rocm/rocm_gemma4_expert_geglu.hip
     src/vt/rocm/rocm_fp8_channel_gemv.hip
     src/vt/rocm/rocm_moe_router.hip
+    src/vt/rocm/rocm_sample.hip
     src/vt/rocm/rocm_ops.hip)
   if(VLLM_CPP_HIP_ARCHITECTURES)
     set_source_files_properties(
@@ -1326,6 +1327,7 @@ if(VLLM_CPP_HIP)
       src/vt/rocm/rocm_gemma4_expert_geglu.hip
       src/vt/rocm/rocm_fp8_channel_gemv.hip
       src/vt/rocm/rocm_moe_router.hip
+      src/vt/rocm/rocm_sample.hip
       src/vt/rocm/rocm_ops.hip
       PROPERTIES HIP_ARCHITECTURES "${VLLM_CPP_HIP_ARCHITECTURES}")
   endif()

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -302,6 +302,7 @@ CPU elementwise GEMM (f32/f16/bf16) runs AVX2 and AVX-512 tiers on x86 where the
 | Custom logits processors on CUDA | Open, not root-caused | Segfaults in a CUDA build, 232/232 green on CPU |
 | Memory budgeting (`ROAD-V1-MEM`, #83) | M1+M2 landed (absolute bytes) | `--kv-cache-memory` sizes the KV pool from an absolute byte budget (ABI v16, group-aware divisor); `--num-blocks` overrides; `--gpu-memory-utilization` needs the M3 profile run (dgx-gated). See `specs/kv-sizing.md` |
 | Gemma4 MoE ROCm fused helpers (`vt::fused_ops`) | Partial | Portable ROCm seam. Public: `VT_GEMMA4_EXPERT_VRAM_MB` (positive-MiB LRU cap; unset/0 unlimited) + `VT_SERVER_MAX_{PROMPT_CHARS,NEW_TOKENS}` (200000/4096; 0 disables). Nine tuning vars internal; defaults unchanged |
+| ROCm V1 sampler ops | Landed (this PR) | temperature/top-k/top-p/min-p/penalties/masks/logprobs/random; parallel gumbel-max sample |
 
 ## How to read this page
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,6 +24,12 @@ directory (issue #85).
 
 ### One ROCm-specific behaviour
 
+ROCm builds register the full V1 sampler surface (temperature, top-k/top-p, min-p,
+penalties, allowed-token masks, logprobs, random sample) so EngineCore does not
+fatal with `no kernel for op` after prefill on AMD. Random sample uses a parallel
+gumbel-max reduce (not a 1-thread full-vocab scan) so temp>0 decode stays in the
+same class as greedy on large vocabs (e.g. Gemma-4).
+
 Worth knowing before you read a hang as a bug in the tests: a build that sets no
 `CMAKE_BUILD_TYPE` floors **HIP device code** at `-O1` and prints a configure
 line saying so. At `-O0` the ROCm runtime starts a hostcall listener the kernels

--- a/src/vt/rocm/rocm_dense_basic.hip
+++ b/src/vt/rocm/rocm_dense_basic.hip
@@ -767,4 +767,43 @@ void GeluErfKernelRocm(Queue& q, Tensor& out, const Tensor& x) {
   Check(hipGetLastError(), "gelu_erf");
 }
 
+// --- sampling logit masks (Hermes allowed_token_ids / bad_words) ------------
+// mask TRUE => exclude (set -inf). Mirrors CPU/CUDA ApplyAllowedTokenIds.
+__global__ void ApplyAllowedTokenIdsK(float* logits, const int8_t* mask, int64_t total) {
+  const int64_t step = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < total;
+       idx += step)
+    if (mask[idx]) logits[idx] = -INFINITY;
+}
+
+void ApplyAllowedTokenIdsKernelRocm(Queue& q, Tensor& logits, const Tensor& mask) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  VT_CHECK(logits.dtype == DType::kF32, "rocm apply_allowed_token_ids: logits f32");
+  VT_CHECK(mask.dtype == DType::kI8, "rocm apply_allowed_token_ids: mask i8");
+  const int64_t total = n * v;
+  ApplyAllowedTokenIdsK<<<GridFor(total), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), mask.Ptr<int8_t>(), total);
+  Check(hipGetLastError(), "apply_allowed_token_ids");
+}
+
+// Sparse -inf scatter at (rows[k], cols[k]) — bad_words path.
+__global__ void ApplyTokenMaskK(float* logits, const int32_t* rows, const int32_t* cols,
+                                int64_t v, int64_t m) {
+  const int64_t step = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t k = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; k < m;
+       k += step)
+    logits[static_cast<int64_t>(rows[k]) * v + cols[k]] = -INFINITY;
+}
+
+void ApplyTokenMaskKernelRocm(Queue& q, Tensor& logits, const Tensor& rows,
+                              const Tensor& cols) {
+  const int64_t v = logits.shape[1], m = rows.shape[0];
+  if (m == 0) return;
+  VT_CHECK(logits.dtype == DType::kF32, "rocm apply_token_mask: logits f32");
+  ApplyTokenMaskK<<<GridFor(m), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), rows.Ptr<int32_t>(), cols.Ptr<int32_t>(), v, m);
+  Check(hipGetLastError(), "apply_token_mask");
+}
+
 }  // namespace vt::rocm

--- a/src/vt/rocm/rocm_ops.hip
+++ b/src/vt/rocm/rocm_ops.hip
@@ -38,6 +38,20 @@ void GeluTanhKernelRocm(Queue& q, Tensor& out, const Tensor& x);
 void GeluErfKernelRocm(Queue& q, Tensor& out, const Tensor& x);
 void MoeRouterTopKKernelRocm(Queue& q, Tensor& weights, Tensor& indices, const Tensor& logits,
                              const MoeRouterTopKArgs& args, const Tensor* bias);
+void ApplyAllowedTokenIdsKernelRocm(Queue& q, Tensor& logits, const Tensor& mask);
+void ApplyTokenMaskKernelRocm(Queue& q, Tensor& logits, const Tensor& rows, const Tensor& cols);
+void ApplyTemperatureKernelRocm(Queue& q, Tensor& logits, const Tensor& temp, bool all_random);
+void ApplyTopKTopPKernelRocm(Queue& q, Tensor& logits, const Tensor* k, const Tensor* p);
+void ComputeProbsKernelRocm(Queue& q, Tensor& probs, const Tensor& logits);
+void ComputeLogprobsKernelRocm(Queue& q, Tensor& logprobs, const Tensor& logits);
+void RandomSampleKernelRocm(Queue& q, Tensor& token_ids, const Tensor& probs, const Tensor& seeds);
+void ApplyPenaltiesKernelRocm(Queue& q, Tensor& logits, const Tensor& prompt_mask,
+                              const Tensor& output_bin_counts, const Tensor& output_mask,
+                              const Tensor& frequency_penalties, const Tensor& presence_penalties,
+                              const Tensor& repetition_penalties);
+void ApplyMinPKernelRocm(Queue& q, Tensor& logits, const Tensor& min_p);
+void ApplyLogitBiasKernelRocm(Queue& q, Tensor& logits, const Tensor& rows, const Tensor& cols,
+                              const Tensor& biases);
 
 namespace {
 
@@ -95,6 +109,34 @@ struct Registrar {
     RegisterOp(OpId::kMoeRouterTopK, DeviceType::kROCM,
                reinterpret_cast<void*>(
                    static_cast<MoeRouterTopKFn>(&MoeRouterTopKKernelRocm)));
+    // Full V1 sampler surface for Hermes (temp/top-p/allowed ids/penalties/...).
+    RegisterOp(OpId::kApplyTemperature, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyTemperatureFn>(&ApplyTemperatureKernelRocm)));
+    RegisterOp(OpId::kApplyTopKTopP, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyTopKTopPFn>(&ApplyTopKTopPKernelRocm)));
+    RegisterOp(OpId::kComputeProbs, DeviceType::kROCM,
+               reinterpret_cast<void*>(static_cast<ComputeProbsFn>(&ComputeProbsKernelRocm)));
+    RegisterOp(OpId::kComputeLogprobs, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ComputeLogprobsFn>(&ComputeLogprobsKernelRocm)));
+    RegisterOp(OpId::kRandomSample, DeviceType::kROCM,
+               reinterpret_cast<void*>(static_cast<RandomSampleFn>(&RandomSampleKernelRocm)));
+    RegisterOp(OpId::kApplyPenalties, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyPenaltiesFn>(&ApplyPenaltiesKernelRocm)));
+    RegisterOp(OpId::kApplyMinP, DeviceType::kROCM,
+               reinterpret_cast<void*>(static_cast<ApplyMinPFn>(&ApplyMinPKernelRocm)));
+    RegisterOp(OpId::kApplyLogitBias, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyLogitBiasFn>(&ApplyLogitBiasKernelRocm)));
+    RegisterOp(OpId::kApplyAllowedTokenIds, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyAllowedTokenIdsFn>(&ApplyAllowedTokenIdsKernelRocm)));
+    RegisterOp(OpId::kApplyTokenMask, DeviceType::kROCM,
+               reinterpret_cast<void*>(
+                   static_cast<ApplyTokenMaskFn>(&ApplyTokenMaskKernelRocm)));
   }
 } registrar;
 

--- a/src/vt/rocm/rocm_sample.hip
+++ b/src/vt/rocm/rocm_sample.hip
@@ -1,0 +1,438 @@
+// ROCm V1 sampling ops — port of cuda_sample.cu for Hermes / OpenAI paths.
+// Correctness-grade: temperature, top-k/top-p, softmax, gumbel-max sample,
+// penalties, min-p, logit bias. (Allowed/token mask also live in dense_basic.)
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+#include "vt/ops.h"
+
+namespace vt::rocm {
+namespace {
+
+constexpr int kBlock = 256;
+constexpr float kNegInf = -INFINITY;
+constexpr int kThreshMaxIter = 64;
+
+void Check(hipError_t err, const char* what) {
+  if (err != hipSuccess) {
+    throw std::runtime_error(std::string("vt rocm: ") + what + ": " + hipGetErrorString(err));
+  }
+}
+hipStream_t AsStream(const Queue& q) { return static_cast<hipStream_t>(q.handle); }
+unsigned GridFor(int64_t n) {
+  const int64_t blocks = (n + kBlock - 1) / kBlock;
+  return static_cast<unsigned>(blocks < 4096 ? blocks : 4096);
+}
+
+__device__ inline uint64_t SplitMix64(uint64_t x) {
+  x += 0x9E3779B97F4A7C15ULL;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+  return x ^ (x >> 31);
+}
+__device__ inline double ExpNoise(uint64_t seed, int64_t row, int64_t col) {
+  const uint64_t row_key = SplitMix64(seed + 0x9E3779B97F4A7C15ULL * static_cast<uint64_t>(row));
+  const uint64_t r = SplitMix64(row_key + static_cast<uint64_t>(col));
+  const double u = static_cast<double>((r >> 11) + 1ULL) * (1.0 / 9007199254740993.0);
+  return -log(u);
+}
+
+// --- temperature ------------------------------------------------------------
+__global__ void ApplyTemperatureK(float* logits, const float* temp, int64_t n, int64_t v,
+                                  bool all_random) {
+  const int64_t total = n * v;
+  const int64_t step = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < total;
+       idx += step) {
+    const int64_t row = idx / v;
+    float t = temp[row];
+    if (!all_random && t < kSamplingEps) t = 1.0f;
+    logits[idx] /= t;
+  }
+}
+
+// --- softmax / log_softmax --------------------------------------------------
+__global__ void SoftmaxK(float* out, const float* logits, int64_t v, bool log_softmax) {
+  const int64_t row = blockIdx.x;
+  const float* r = logits + row * v;
+  float* o = out + row * v;
+  __shared__ float red[kBlock];
+
+  float m = kNegInf;
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x) m = fmaxf(m, r[j]);
+  red[threadIdx.x] = m;
+  __syncthreads();
+  for (int s = kBlock / 2; s > 0; s /= 2) {
+    if (static_cast<int>(threadIdx.x) < s)
+      red[threadIdx.x] = fmaxf(red[threadIdx.x], red[threadIdx.x + s]);
+    __syncthreads();
+  }
+  const float mx = red[0];
+  __syncthreads();
+
+  float acc = 0.0f;
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x) acc += expf(r[j] - mx);
+  red[threadIdx.x] = acc;
+  __syncthreads();
+  for (int s = kBlock / 2; s > 0; s /= 2) {
+    if (static_cast<int>(threadIdx.x) < s) red[threadIdx.x] += red[threadIdx.x + s];
+    __syncthreads();
+  }
+  const float sum = red[0];
+  const float lse = mx + logf(sum);
+  __syncthreads();
+
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x)
+    o[j] = log_softmax ? (r[j] - lse) : expf(r[j] - mx) / sum;
+}
+
+// --- random sample (gumbel-max / exp noise) ---------------------------------
+// Parallel argmax over vocab. The 1-thread serial scan (cuda_sample.cu style)
+// is fine on fat CUDA SMs for ~128k vocab but on gfx1201 + Gemma-4 V=262144 it
+// costs ~0.5s/token and collapses Hermes (temp>0) decode to ~1.8 t/s while
+// greedy stays ~45 t/s. One block/row, kBlock threads, tree-reduce best score.
+__global__ void RandomSampleK(int64_t* out, const float* probs, const int64_t* seeds, int64_t v) {
+  const int64_t row = blockIdx.x;
+  const float* r = probs + row * v;
+  const uint64_t seed = static_cast<uint64_t>(seeds[row]);
+  const int t = static_cast<int>(threadIdx.x);
+
+  float best_v = kNegInf;
+  int64_t best = 0;
+  for (int64_t j = t; j < v; j += kBlock) {
+    const float qn = static_cast<float>(ExpNoise(seed, row, j));
+    // Guard div-by-zero / denorm noise (should not happen with ExpNoise).
+    const float score = (qn > 0.0f) ? (r[j] / qn) : kNegInf;
+    if (score > best_v) {
+      best_v = score;
+      best = j;
+    }
+  }
+
+  __shared__ float s_val[kBlock];
+  __shared__ int64_t s_idx[kBlock];
+  s_val[t] = best_v;
+  s_idx[t] = best;
+  __syncthreads();
+  for (int o = kBlock / 2; o > 0; o >>= 1) {
+    if (t < o) {
+      const float ov = s_val[t + o];
+      if (ov > s_val[t]) {
+        s_val[t] = ov;
+        s_idx[t] = s_idx[t + o];
+      }
+    }
+    __syncthreads();
+  }
+  if (t == 0) out[row] = s_idx[0];
+}
+
+// --- top-k / top-p (sort-free threshold, from cuda_sample) ------------------
+__device__ inline float BlockRedMaxF(float v, float* s) {
+  const int t = threadIdx.x;
+  s[t] = v;
+  __syncthreads();
+  for (int o = kBlock / 2; o > 0; o >>= 1) {
+    if (t < o) s[t] = fmaxf(s[t], s[t + o]);
+    __syncthreads();
+  }
+  const float r = s[0];
+  __syncthreads();
+  return r;
+}
+__device__ inline float BlockRedMinF(float v, float* s) {
+  const int t = threadIdx.x;
+  s[t] = v;
+  __syncthreads();
+  for (int o = kBlock / 2; o > 0; o >>= 1) {
+    if (t < o) s[t] = fminf(s[t], s[t + o]);
+    __syncthreads();
+  }
+  const float r = s[0];
+  __syncthreads();
+  return r;
+}
+__device__ inline float BlockRedSumF(float v, float* s) {
+  const int t = threadIdx.x;
+  s[t] = v;
+  __syncthreads();
+  for (int o = kBlock / 2; o > 0; o >>= 1) {
+    if (t < o) s[t] += s[t + o];
+    __syncthreads();
+  }
+  const float r = s[0];
+  __syncthreads();
+  return r;
+}
+__device__ inline int BlockRedSumI(int v, int* s) {
+  const int t = threadIdx.x;
+  s[t] = v;
+  __syncthreads();
+  for (int o = kBlock / 2; o > 0; o >>= 1) {
+    if (t < o) s[t] += s[t + o];
+    __syncthreads();
+  }
+  const int r = s[0];
+  __syncthreads();
+  return r;
+}
+
+__global__ void ApplyTopKTopPRowK(float* logits, const int32_t* k_arr, const float* p_arr,
+                                  int64_t v) {
+  const int64_t row = blockIdx.x;
+  float* r = logits + row * v;
+  const int t = threadIdx.x;
+
+  __shared__ float red[kBlock];
+  __shared__ int redi[kBlock];
+  __shared__ float sh_thr_k;
+  __shared__ float sh_low;
+
+  const bool has_k = (k_arr != nullptr);
+  const bool has_p = (p_arr != nullptr);
+  const int32_t k = has_k ? k_arr[row] : 0;
+  const float p = has_p ? p_arr[row] : 1.0f;
+
+  float lmax = kNegInf, lmin = INFINITY;
+  for (int64_t j = t; j < v; j += kBlock) {
+    const float x = r[j];
+    lmax = fmaxf(lmax, x);
+    if (x != kNegInf) lmin = fminf(lmin, x);
+  }
+  const float mx = BlockRedMaxF(lmax, red);
+  const float mn = BlockRedMinF(lmin, red);
+
+  const bool topk_active = has_k && (k >= 1) && (static_cast<int64_t>(k) < v);
+  float thr_k = kNegInf;
+  if (topk_active) {
+    int lc = 0;
+    for (int64_t j = t; j < v; j += kBlock)
+      if (r[j] > mn) ++lc;
+    const int cnt_gt_min = BlockRedSumI(lc, redi);
+    if (cnt_gt_min < k) {
+      thr_k = mn;
+    } else {
+      float low = mn, high = mx, min_gt_low = mx, max_le_high = mn;
+      for (int iter = 0; iter < kThreshMaxIter; ++iter) {
+        const float p0 = (2.0f * low + high) / 3.0f;
+        const float p1 = (low + 2.0f * high) / 3.0f;
+        int l0 = 0, l1 = 0;
+        float lmglow = high, lmleh = low;
+        for (int64_t j = t; j < v; j += kBlock) {
+          const float x = r[j];
+          if (x > p0) ++l0;
+          if (x > p1) ++l1;
+          if (x > low) lmglow = fminf(lmglow, x);
+          if (x <= high) lmleh = fmaxf(lmleh, x);
+        }
+        const int c0 = BlockRedSumI(l0, redi);
+        const int c1 = BlockRedSumI(l1, redi);
+        min_gt_low = BlockRedMinF(lmglow, red);
+        max_le_high = BlockRedMaxF(lmleh, red);
+        if (c1 >= k) {
+          low = p1;
+        } else if (c0 >= k) {
+          low = p0;
+          high = fminf(p1, max_le_high);
+        } else {
+          high = fminf(p0, max_le_high);
+        }
+        if (min_gt_low == max_le_high) break;
+      }
+      thr_k = min_gt_low;
+    }
+  }
+  if (t == 0) sh_thr_k = thr_k;
+  __syncthreads();
+  thr_k = sh_thr_k;
+
+  float low = -1.0f;
+  const bool topp_active = has_p && (p < 1.0f);
+  if (topp_active) {
+    float lden = 0.0f;
+    for (int64_t j = t; j < v; j += kBlock)
+      if (r[j] >= thr_k) lden += expf(r[j] - mx);
+    const float denom = BlockRedSumF(lden, red);
+    const float target = p * denom;
+    float lo = 0.0f, hi = 1.0f, min_gt_low = 1.0f, max_le_high = 0.0f;
+    for (int iter = 0; denom > 0.0f && iter < kThreshMaxIter; ++iter) {
+      const float p0 = (2.0f * lo + hi) / 3.0f;
+      const float p1 = (lo + 2.0f * hi) / 3.0f;
+      float la0 = 0.0f, la1 = 0.0f, lmglow = hi, lmleh = lo;
+      for (int64_t j = t; j < v; j += kBlock) {
+        if (r[j] < thr_k) continue;
+        const float e = expf(r[j] - mx);
+        if (e > p0) la0 += e;
+        if (e > p1) la1 += e;
+        if (e > lo) lmglow = fminf(lmglow, e);
+        if (e <= hi) lmleh = fmaxf(lmleh, e);
+      }
+      const float a0 = BlockRedSumF(la0, red);
+      const float a1 = BlockRedSumF(la1, red);
+      min_gt_low = BlockRedMinF(lmglow, red);
+      max_le_high = BlockRedMaxF(lmleh, red);
+      if (a1 >= target) {
+        lo = p1;
+      } else if (a0 >= target) {
+        lo = p0;
+        hi = fminf(p1, max_le_high);
+      } else {
+        hi = fminf(p0, max_le_high);
+      }
+      if (min_gt_low == max_le_high) break;
+    }
+    low = lo;
+  }
+  if (t == 0) sh_low = low;
+  __syncthreads();
+  low = sh_low;
+
+  for (int64_t j = t; j < v; j += kBlock) {
+    const float x = r[j];
+    const bool keep = (x >= thr_k) && (low < 0.0f || expf(x - mx) > low);
+    if (!keep) r[j] = kNegInf;
+  }
+}
+
+// --- penalties / min_p / logit bias -----------------------------------------
+__global__ void ApplyPenaltiesK(float* logits, const int8_t* prompt_mask,
+                                const int32_t* output_bin_counts, const int8_t* output_mask,
+                                const float* freq, const float* pres, const float* rep, int64_t n,
+                                int64_t v) {
+  const int64_t total = n * v;
+  const int64_t step = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < total;
+       idx += step) {
+    const int64_t row = idx / v;
+    float x = logits[idx];
+    if (prompt_mask[idx] || output_mask[idx]) {
+      const float r = rep[row];
+      x = x > 0.0f ? x / r : x * r;
+    }
+    x -= freq[row] * static_cast<float>(output_bin_counts[idx]);
+    x -= pres[row] * static_cast<float>(output_mask[idx]);
+    logits[idx] = x;
+  }
+}
+
+__global__ void ApplyMinPK(float* logits, const float* min_p, int64_t v) {
+  const int64_t row = blockIdx.x;
+  const float m = min_p[row];
+  if (m <= 0.0f) return;
+  float* r = logits + row * v;
+  __shared__ float red[kBlock];
+
+  float mx = kNegInf;
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x) mx = fmaxf(mx, r[j]);
+  red[threadIdx.x] = mx;
+  __syncthreads();
+  for (int s = kBlock / 2; s > 0; s /= 2) {
+    if (static_cast<int>(threadIdx.x) < s)
+      red[threadIdx.x] = fmaxf(red[threadIdx.x], red[threadIdx.x + s]);
+    __syncthreads();
+  }
+  const float rowmax = red[0];
+  __syncthreads();
+
+  float acc = 0.0f;
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x) acc += expf(r[j] - rowmax);
+  red[threadIdx.x] = acc;
+  __syncthreads();
+  for (int s = kBlock / 2; s > 0; s /= 2) {
+    if (static_cast<int>(threadIdx.x) < s) red[threadIdx.x] += red[threadIdx.x + s];
+    __syncthreads();
+  }
+  const float sum = red[0];
+  __syncthreads();
+  const float thr = m / sum;
+  for (int64_t j = threadIdx.x; j < v; j += blockDim.x)
+    if (expf(r[j] - rowmax) / sum < thr) r[j] = kNegInf;
+}
+
+__global__ void ApplyLogitBiasK(float* logits, const int32_t* rows, const int32_t* cols,
+                                const float* biases, int64_t v, int64_t m) {
+  const int64_t step = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t k = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; k < m; k += step)
+    logits[static_cast<int64_t>(rows[k]) * v + cols[k]] += biases[k];
+}
+
+}  // namespace
+
+void ApplyTemperatureKernelRocm(Queue& q, Tensor& logits, const Tensor& temp, bool all_random) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  ApplyTemperatureK<<<GridFor(n * v), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), temp.Ptr<float>(), n, v, all_random);
+  Check(hipGetLastError(), "apply_temperature");
+}
+
+void ApplyTopKTopPKernelRocm(Queue& q, Tensor& logits, const Tensor* k, const Tensor* p) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  ApplyTopKTopPRowK<<<static_cast<unsigned>(n), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), k != nullptr ? k->Ptr<int32_t>() : nullptr,
+      p != nullptr ? p->Ptr<float>() : nullptr, v);
+  Check(hipGetLastError(), "top_k_top_p");
+}
+
+void ComputeProbsKernelRocm(Queue& q, Tensor& probs, const Tensor& logits) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  SoftmaxK<<<static_cast<unsigned>(n), kBlock, 0, AsStream(q)>>>(probs.Ptr<float>(),
+                                                                   logits.Ptr<float>(), v, false);
+  Check(hipGetLastError(), "compute_probs");
+}
+
+void ComputeLogprobsKernelRocm(Queue& q, Tensor& logprobs, const Tensor& logits) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  SoftmaxK<<<static_cast<unsigned>(n), kBlock, 0, AsStream(q)>>>(
+      logprobs.Ptr<float>(), logits.Ptr<float>(), v, true);
+  Check(hipGetLastError(), "compute_logprobs");
+}
+
+void RandomSampleKernelRocm(Queue& q, Tensor& token_ids, const Tensor& probs,
+                            const Tensor& seeds) {
+  const int64_t n = probs.shape[0], v = probs.shape[1];
+  if (n == 0 || v == 0) return;
+  RandomSampleK<<<static_cast<unsigned>(n), kBlock, 0, AsStream(q)>>>(
+      token_ids.Ptr<int64_t>(), probs.Ptr<float>(), seeds.Ptr<int64_t>(), v);
+  Check(hipGetLastError(), "random_sample");
+}
+
+void ApplyPenaltiesKernelRocm(Queue& q, Tensor& logits, const Tensor& prompt_mask,
+                              const Tensor& output_bin_counts, const Tensor& output_mask,
+                              const Tensor& frequency_penalties, const Tensor& presence_penalties,
+                              const Tensor& repetition_penalties) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  ApplyPenaltiesK<<<GridFor(n * v), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), prompt_mask.Ptr<int8_t>(), output_bin_counts.Ptr<int32_t>(),
+      output_mask.Ptr<int8_t>(), frequency_penalties.Ptr<float>(), presence_penalties.Ptr<float>(),
+      repetition_penalties.Ptr<float>(), n, v);
+  Check(hipGetLastError(), "apply_penalties");
+}
+
+void ApplyMinPKernelRocm(Queue& q, Tensor& logits, const Tensor& min_p) {
+  const int64_t n = logits.shape[0], v = logits.shape[1];
+  if (n == 0 || v == 0) return;
+  ApplyMinPK<<<static_cast<unsigned>(n), kBlock, 0, AsStream(q)>>>(logits.Ptr<float>(),
+                                                                     min_p.Ptr<float>(), v);
+  Check(hipGetLastError(), "apply_min_p");
+}
+
+void ApplyLogitBiasKernelRocm(Queue& q, Tensor& logits, const Tensor& rows, const Tensor& cols,
+                              const Tensor& biases) {
+  const int64_t v = logits.shape[1], m = rows.shape[0];
+  if (m == 0) return;
+  ApplyLogitBiasK<<<GridFor(m), kBlock, 0, AsStream(q)>>>(
+      logits.Ptr<float>(), rows.Ptr<int32_t>(), cols.Ptr<int32_t>(), biases.Ptr<float>(), v, m);
+  Check(hipGetLastError(), "apply_logit_bias");
+}
+
+}  // namespace vt::rocm

--- a/tests/vt/test_ops_sample.cpp
+++ b/tests/vt/test_ops_sample.cpp
@@ -765,3 +765,175 @@ TEST_CASE("CUDA random_sample agrees with CPU on the vast majority of rows") {
   // Allow a small number of ULP-driven argmax flips; require strong agreement.
   CHECK(agree >= static_cast<size_t>(0.98 * static_cast<double>(N)));
 }
+
+// ===========================================================================
+// CPU-vs-ROCm parity (same contracts as the CUDA block above). Skips when no
+// ROCm backend is linked/registered (CPU CI). Lab proof: dual R9700 gfx1201.
+namespace {
+
+bool HasRocm() {
+  try {
+    vt::GetBackend(DeviceType::kROCM);
+    return true;
+  } catch (const std::runtime_error&) {
+    return false;
+  }
+}
+
+Device RocmDev() { return Device{DeviceType::kROCM, 0}; }
+
+class RocmDeviceTensor {
+ public:
+  RocmDeviceTensor(Backend& b, Queue& q, DType dt, const std::vector<int64_t>& shape,
+                   const void* host = nullptr)
+      : b_(b) {
+    int64_t numel = 1;
+    for (auto s : shape) numel *= s;
+    bytes_ = static_cast<size_t>(numel) * vt::SizeOf(dt);
+    p_ = b_.Alloc(bytes_ == 0 ? 1 : bytes_);
+    if (host != nullptr) b_.Copy(q, p_, host, bytes_);
+    t_ = MakeT(p_, dt, RocmDev(), shape);
+  }
+  ~RocmDeviceTensor() { b_.Free(p_); }
+  RocmDeviceTensor(const RocmDeviceTensor&) = delete;
+  RocmDeviceTensor& operator=(const RocmDeviceTensor&) = delete;
+  Tensor& tensor() { return t_; }
+  void Download(Queue& q, void* dst) {
+    b_.Copy(q, dst, p_, bytes_);
+    b_.Synchronize(q);
+  }
+
+ private:
+  Backend& b_;
+  void* p_ = nullptr;
+  size_t bytes_ = 0;
+  Tensor t_;
+};
+
+}  // namespace
+
+TEST_CASE("ROCm greedy_argmax / temperature / top-k-p / allowed_ids / logprobs match CPU") {
+  if (!HasRocm()) {
+    MESSAGE("no ROCm backend registered; skipping");
+    return;
+  }
+  const int64_t N = 4, V = 256;
+  const auto logits = RandomLogits(static_cast<size_t>(N * V), 7777);
+  Backend& gpu = vt::GetBackend(DeviceType::kROCM);
+  QueueGuard gq(gpu);
+  Queue cq = Q();
+
+  // greedy_argmax bit-exact
+  {
+    std::vector<float> lc = logits;
+    std::vector<int64_t> id_cpu(static_cast<size_t>(N), -1);
+    Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {N, V});
+    Tensor ti = MakeT(id_cpu.data(), DType::kI64, Cpu(), {N});
+    vt::GreedyArgmax(cq, ti, tl);
+    RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {N, V}, logits.data());
+    RocmDeviceTensor did(gpu, gq.q, DType::kI64, {N});
+    vt::GreedyArgmax(gq.q, did.tensor(), dl.tensor());
+    std::vector<int64_t> id_gpu(static_cast<size_t>(N));
+    did.Download(gq.q, id_gpu.data());
+    for (size_t i = 0; i < id_cpu.size(); ++i) CHECK(id_gpu[i] == id_cpu[i]);
+  }
+
+  // apply_temperature
+  {
+    std::vector<float> lc = logits, lg = logits;
+    std::vector<float> temp(static_cast<size_t>(N), 0.7f);
+    Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {N, V});
+    Tensor tt = MakeT(temp.data(), DType::kF32, Cpu(), {N});
+    vt::ApplyTemperature(cq, tl, tt, /*all_random=*/true);
+    RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {N, V}, lg.data());
+    RocmDeviceTensor dt(gpu, gq.q, DType::kF32, {N}, temp.data());
+    vt::ApplyTemperature(gq.q, dl.tensor(), dt.tensor(), /*all_random=*/true);
+    std::vector<float> out(lg.size());
+    dl.Download(gq.q, out.data());
+    for (size_t i = 0; i < lc.size(); ++i)
+      CHECK(out[i] == doctest::Approx(lc[i]).epsilon(1e-5));
+  }
+
+  // top-k only
+  {
+    std::vector<float> lc = logits, lg = logits;
+    std::vector<int32_t> k(static_cast<size_t>(N), 16);
+    Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {N, V});
+    Tensor tk = MakeT(k.data(), DType::kI32, Cpu(), {N});
+    vt::ApplyTopKTopP(cq, tl, &tk, /*p=*/nullptr);
+    RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {N, V}, lg.data());
+    RocmDeviceTensor dk(gpu, gq.q, DType::kI32, {N}, k.data());
+    vt::ApplyTopKTopP(gq.q, dl.tensor(), &dk.tensor(), /*p=*/nullptr);
+    std::vector<float> out(lc.size());
+    dl.Download(gq.q, out.data());
+    for (size_t i = 0; i < lc.size(); ++i) {
+      if (std::isinf(lc[i])) CHECK(std::isinf(out[i]));
+      else CHECK(out[i] == doctest::Approx(lc[i]).epsilon(1e-5));
+    }
+  }
+
+  // allowed_token_ids mask (Hermes title-gen path).
+  // Contract: mask[i]!=0 → logit becomes -inf (blocked). 0 keeps the value.
+  {
+    std::vector<float> lc = logits, lg = logits;
+    std::vector<int8_t> mask(static_cast<size_t>(N * V), 0);
+    // Block all but first 8 ids per row
+    for (int64_t n = 0; n < N; ++n)
+      for (int64_t v = 8; v < V; ++v) mask[static_cast<size_t>(n * V + v)] = 1;
+    Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {N, V});
+    Tensor tm = MakeT(mask.data(), DType::kI8, Cpu(), {N, V});
+    vt::ApplyAllowedTokenIds(cq, tl, tm);
+    RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {N, V}, lg.data());
+    RocmDeviceTensor dm(gpu, gq.q, DType::kI8, {N, V}, mask.data());
+    vt::ApplyAllowedTokenIds(gq.q, dl.tensor(), dm.tensor());
+    std::vector<float> out(lc.size());
+    dl.Download(gq.q, out.data());
+    for (size_t i = 0; i < lc.size(); ++i) {
+      if (std::isinf(lc[i])) CHECK(std::isinf(out[i]));
+      else CHECK(out[i] == doctest::Approx(lc[i]).epsilon(1e-5));
+    }
+  }
+
+  // compute_logprobs
+  {
+    std::vector<float> lp_cpu(static_cast<size_t>(N * V));
+    std::vector<float> lc = logits;
+    Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {N, V});
+    Tensor to = MakeT(lp_cpu.data(), DType::kF32, Cpu(), {N, V});
+    vt::ComputeLogprobs(cq, to, tl);
+    RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {N, V}, logits.data());
+    RocmDeviceTensor dout(gpu, gq.q, DType::kF32, {N, V});
+    vt::ComputeLogprobs(gq.q, dout.tensor(), dl.tensor());
+    std::vector<float> lp_gpu(lp_cpu.size());
+    dout.Download(gq.q, lp_gpu.data());
+    for (size_t i = 0; i < lp_cpu.size(); ++i)
+      CHECK(lp_gpu[i] == doctest::Approx(lp_cpu[i]).epsilon(1e-4));
+  }
+}
+
+TEST_CASE("ROCm apply_min_p / penalties surface matches CPU mask pattern") {
+  if (!HasRocm()) {
+    MESSAGE("no ROCm backend registered; skipping");
+    return;
+  }
+  // min_p: keep values that are high enough vs row max
+  std::vector<float> logits = {0.0f, 1.0f, 2.0f, 3.0f,
+                               5.0f, 4.0f, 0.0f, -1.0f};
+  std::vector<float> min_p = {0.5f, 0.1f};
+  std::vector<float> lc = logits, lg = logits;
+  Backend& gpu = vt::GetBackend(DeviceType::kROCM);
+  QueueGuard gq(gpu);
+  Queue cq = Q();
+  Tensor tl = MakeT(lc.data(), DType::kF32, Cpu(), {2, 4});
+  Tensor tp = MakeT(min_p.data(), DType::kF32, Cpu(), {2});
+  vt::ApplyMinP(cq, tl, tp);
+  RocmDeviceTensor dl(gpu, gq.q, DType::kF32, {2, 4}, lg.data());
+  RocmDeviceTensor dp(gpu, gq.q, DType::kF32, {2}, min_p.data());
+  vt::ApplyMinP(gq.q, dl.tensor(), dp.tensor());
+  std::vector<float> out(8);
+  dl.Download(gq.q, out.data());
+  for (size_t i = 0; i < 8; ++i) {
+    if (std::isinf(lc[i])) CHECK(std::isinf(out[i]));
+    else CHECK(out[i] == doctest::Approx(lc[i]).epsilon(1e-5));
+  }
+}


### PR DESCRIPTION
## Summary

Makes **Hermes Agent ↔ local Gemma-4-26B MoE FP8 on AMD ROCm (RDNA4)** finish chat turns *and* decode at usable speed when `temperature > 0`.

Public shout-out context: [@anothervariable](https://x.com/anothervariable/status/2086614087178293373) — Gemma 4 26B MoE on AMD ROCm via vllm.cpp.

### Root causes (lab)

**1) Missing ROCm V1 sampler ops (engine death)**  
After a large Hermes SOUL prefill (~38k tokens), sampling called V1 ops registered on CUDA/CPU only:

| Op | Symptom |
|----|---------|
| `kApplyAllowedTokenIds` (40) | title-gen allowlist → `no kernel for op 40 on device type 5` |
| `kApplyTemperature` (30) | temp/top_p path → `no kernel for op 30` |
| cascade | `request submitted to a stopped AsyncLLM` |

ROCm device type = 5. Missing registration = hard engine death, not a soft 4xx.

**2) `RandomSampleK` serial full-vocab scan (decode cliff)**  
HIP port initially matched CUDA's `<<<n, 1>>>` gumbel-max. On gfx1201 with Gemma-4 **V=262144**, every temp>0 token paid ~0.5s in sampling → Hermes decode **~1.75 t/s** vs greedy **~40–50 t/s**.

Fix: parallel block reduce, launch **`<<<n, kBlock>>>`** with `kBlock=256`.

### Changes

1. **`src/vt/rocm/rocm_sample.hip`** — HIP V1 sampler surface:
   - temperature, top-k/top-p, softmax / log-softmax
   - **parallel** gumbel-max random sample, penalties, min-p, logit bias
2. **`rocm_ops.hip` / `rocm_dense_basic.hip`** — register those + `ApplyAllowedTokenIds` / `ApplyTokenMask`
3. **Chat `max_tokens=-1`** (Hermes “unlimited”) → map to `VT_SERVER_MAX_NEW_TOKENS` default (**4096**) before `SamplingParams::PostInit` rejects `<1`
4. Docs: `ENVIRONMENT.md`, `FEATURES.md`, `USAGE.md` (sampler note)

No `vt::rocm` calls from `models/` (device-leakage clean). CUDA still has 1-thread `RandomSample` (hidden on fat SMs / smaller V); ROCm deliberately diverges for gfx1201.

### Lab verification (2× Radeon AI PRO R9700, gfx1201, ROCm 7.2)

| case | temp | decode t/s |
|------|------|----------:|
| short | 0.0 | ~51 |
| short | 0.7 | **~45** (was ~1.78) |
| hermesish+55 tools @~37k | 0.0 | ~42 |
| hermesish+55 tools @~37k | 0.7 | **~41** (was ~1.74) |

Also: title-gen allowlist + temp/top_p + `max_tokens=-1` → 200; Paris smoke OK.

Binary: CMake `OUTPUT_NAME` is `vllm-server` under `build-*/examples/`.

### Land order

1. **This PR (#234)** — ROCm V1 sampler + RandomSample perf
2. **#227** — KV fail-fast unschedulable waits
3. **#316** — SSE keepalives
4. **#317** — Gemma4/ROCm FP8 + SharedK-WMMA (split from closed #228)

### Follow-ups (not this PR)

- Optional CUDA RandomSample parity (same serial pattern exists in `cuda_sample.cu`)
- Prefill/decode stack beyond sampling (#317)

## Test plan

- [x] `python3 scripts/check-device-leakage.py`
- [x] `python3 scripts/check-env-doc.py`
- [x] `python3 scripts/check-doc-checkpoint.py --base origin/main --head HEAD`
- [x] `python3 scripts/check-pr-size.py` (under budget)
- [x] Live `:8010` Gemma-4-26B-A4B-it-fp8 dual-GPU: temp 0 vs 0.7 A/B
- [ ] CI green on tip-of-main
