### PR TITLE
fix(server): SSE keepalives via collector timed wait

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -25,6 +25,7 @@ These change how the engine runs and have no CLI flag (or complement one).
 | `VT_LMCACHE_PORT` | `65432` | Default LMCache server port. The `kv_connector_extra_config.port` key overrides it |
 | `VT_LMCACHE_HASH_ALGO` | `blake3` | Default LMCache key-derivation algorithm. Set `vllm` (alias `sha256_cbor`) for byte-for-byte interop with a real vLLM + LMCache peer. The `kv_connector_extra_config.hash_algo` key overrides it |
 | `VT_SERVER_MAX_PROMPT_CHARS` | `200000` characters | Rejects chat-completion prompts larger than this many characters. Set `0` to disable the prompt-size guard |
+| `VT_SERVER_SSE_PING_S` | 15 | Seconds between SSE comment keepalives (`:\n\n`) on silent streams; `<=0` disables. |
 | `VT_SERVER_MAX_NEW_TOKENS` | `4096` | Clamps the requested generation length to this many new tokens. Set `0` to disable the cap |
 | `VT_VULKAN_DEVICE` | first suitable device | Forces the Vulkan physical device index. Required on a multi-GPU host to pin the intended device |
 | `VT_KV_CACHE_F32` | off (native KV dtype) | Forces the KV cache to fp32. A precision/diagnostic lever, at the cost of double the KV memory |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1004,3 +1004,11 @@ were removed when the example became a thin ABI client; see the header comment i
 Served over HTTP too: pass `--video-dit` (plus the VAEs and configs) to `examples/server` and
 `POST /v1/videos`, `POST /v1/videos/sync` and `GET /v1/videos/{id}` register. Without it the
 routes stay unregistered.
+
+## SSE keepalives on long prefill
+
+Async chat/completion streams may emit SSE **comment** frames (`:\n\n`) while
+waiting on the engine (long prefill / TTFT). Interval is `VT_SERVER_SSE_PING_S`
+(default 15s; `0` disables). Comment frames are not `data:` events and do not
+carry tokens. Token streaming still uses a timed wait on the request collector
+so deltas are not collapsed by a poll loop.

--- a/include/vllm/entrypoints/openai/serving_utils.h
+++ b/include/vllm/entrypoints/openai/serving_utils.h
@@ -41,6 +41,14 @@ std::string SanitizeUtf8(const std::string& s);
 int SsePingIntervalSec();
 inline constexpr const char kSsePingFrame[] = ":\n\n";
 
+// Shared chat + completion framing after a timed collector wait.
+// - ready set  -> move into `out`, return true  (caller emits a data frame)
+// - ready empty -> set `chunk` to kSsePingFrame ONLY, return false
+//   (caller emits that standalone comment; never concatenate with data).
+// Used by ChatSseStream / CompletionSseStream WaitOutput.
+bool AssignSseWaitResult(std::optional<vllm::RequestOutput> ready,
+                         vllm::RequestOutput& out, std::string& chunk);
+
 // Ported from: vllm/entrypoints/serve/utils/api_utils.py:276-289
 // (should_include_usage). Force mode enables final and continuous usage;
 // request-level continuous stats never take effect without include_usage.

--- a/include/vllm/entrypoints/openai/serving_utils.h
+++ b/include/vllm/entrypoints/openai/serving_utils.h
@@ -36,6 +36,11 @@ namespace vllm::entrypoints::openai {
 // result is always well-formed UTF-8 and therefore safe for nlohmann json dump.
 std::string SanitizeUtf8(const std::string& s);
 
+// SSE comment keepalives while the stream is silent (long prefill / TTFT).
+// VT_SERVER_SSE_PING_S: seconds between pings; default 15; <=0 disables.
+int SsePingIntervalSec();
+inline constexpr const char kSsePingFrame[] = ":\n\n";
+
 // Ported from: vllm/entrypoints/serve/utils/api_utils.py:276-289
 // (should_include_usage). Force mode enables final and continuous usage;
 // request-level continuous stats never take effect without include_usage.

--- a/include/vllm/v1/engine/async_llm.h
+++ b/include/vllm/v1/engine/async_llm.h
@@ -25,6 +25,7 @@
 #define VLLM_V1_ENGINE_ASYNC_LLM_H_
 
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -121,6 +122,9 @@ class AsyncLLM {
   RequestOutput get_output(const AsyncRequest& request);
   std::optional<RequestOutput> get_output_nowait(
       const AsyncRequest& request);
+  // Timed wait — nullopt on timeout (for SSE keepalives).
+  std::optional<RequestOutput> get_output_for(
+      const AsyncRequest& request, std::chrono::milliseconds timeout);
 
   // Blocking convenience for non-streaming callers: drain this request's
   // collector until its terminal RequestOutput. Other requests keep running.

--- a/include/vllm/v1/engine/output_processor.h
+++ b/include/vllm/v1/engine/output_processor.h
@@ -49,6 +49,7 @@
 #include <exception>
 #include <map>
 #include <memory>
+#include <chrono>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -84,6 +85,9 @@ class RequestOutputCollector {
   // Stored producer errors are rethrown on the consumer thread.
   RequestOutput get();
   std::optional<RequestOutput> get_nowait();
+  // Timed wait on the single-slot collector. nullopt on timeout (no error);
+  // rethrows producer errors. Wakes immediately when put()/put_error().
+  std::optional<RequestOutput> get_for(std::chrono::milliseconds timeout);
 
   bool has_output() const;
   const std::string& request_id() const { return request_id_; }

--- a/src/vllm/entrypoints/openai/serving_chat.cpp
+++ b/src/vllm/entrypoints/openai/serving_chat.cpp
@@ -354,12 +354,8 @@ class ChatSseStream final : public SseStream {
     for (;;) {
       auto ready = engine_.get_output_for(
           async_request_, std::chrono::milliseconds(ping_s * 1000));
-      if (ready.has_value()) {
-        out = std::move(*ready);
-        return true;
-      }
-      ping_chunk = kSsePingFrame;
-      return false;
+      // Shared framing with completion: ping is a standalone comment frame.
+      return AssignSseWaitResult(std::move(ready), out, ping_chunk);
     }
   }
 

--- a/src/vllm/entrypoints/openai/serving_chat.cpp
+++ b/src/vllm/entrypoints/openai/serving_chat.cpp
@@ -341,6 +341,29 @@ class ChatSseStream final : public SseStream {
 
   ~ChatSseStream() override { abort(); }
 
+  // Timed wait on this request's collector. On timeout with pings enabled,
+  // writes a pure SSE comment frame to `ping_chunk` and returns false so next()
+  // can deliver it alone (never concatenated with a data frame). On data,
+  // moves into `out` and returns true.
+  bool WaitOutput(RequestOutput& out, std::string& ping_chunk) {
+    const int ping_s = SsePingIntervalSec();
+    if (ping_s <= 0) {
+      out = engine_.get_output(async_request_);
+      return true;
+    }
+    for (;;) {
+      auto ready = engine_.get_output_for(
+          async_request_, std::chrono::milliseconds(ping_s * 1000));
+      if (ready.has_value()) {
+        out = std::move(*ready);
+        return true;
+      }
+      ping_chunk = kSsePingFrame;
+      return false;
+    }
+  }
+
+
   bool next(std::string& chunk) override {
     if (complete_) return false;
     if (role_pending_) {
@@ -349,7 +372,11 @@ class ChatSseStream final : public SseStream {
       // count; the default path retains its immediately available role frame.
       if (usage_.include_continuous_usage) {
         for (;;) {
-          RequestOutput response = engine_.get_output(async_request_);
+          RequestOutput response;
+          if (!WaitOutput(response, chunk)) {
+            // WaitOutput filled chunk with a pure SSE ping — return it first.
+            return true;
+          }
           prompt_tokens_ =
               static_cast<int>(response.prompt_token_ids.size());
           if (!response.outputs.empty() || response.finished) {
@@ -401,7 +428,9 @@ class ChatSseStream final : public SseStream {
         response = std::move(*buffered_response_);
         buffered_response_.reset();
       } else {
-        response = engine_.get_output(async_request_);
+        if (!WaitOutput(response, chunk)) {
+          return true;  // pure ping frame
+        }
       }
       prompt_tokens_ = static_cast<int>(response.prompt_token_ids.size());
       if (response.outputs.empty()) {

--- a/src/vllm/entrypoints/openai/serving_completion.cpp
+++ b/src/vllm/entrypoints/openai/serving_completion.cpp
@@ -36,6 +36,22 @@ class CompletionSseStream final : public SseStream {
 
   ~CompletionSseStream() override { abort(); }
 
+  bool WaitOutput(RequestOutput& out, std::string& ping_chunk) {
+    const int ping_s = SsePingIntervalSec();
+    if (ping_s <= 0) {
+      out = engine_.get_output(request_);
+      return true;
+    }
+    auto ready = engine_.get_output_for(
+        request_, std::chrono::milliseconds(ping_s * 1000));
+    if (ready.has_value()) {
+      out = std::move(*ready);
+      return true;
+    }
+    ping_chunk = kSsePingFrame;
+    return false;
+  }
+
   bool next(std::string& chunk) override {
     if (complete_) return false;
     if (usage_pending_) {
@@ -59,7 +75,10 @@ class CompletionSseStream final : public SseStream {
     }
 
     for (;;) {
-      RequestOutput response = engine_.get_output(request_);
+      RequestOutput response;
+      if (!WaitOutput(response, chunk)) {
+        return true;  // pure SSE ping
+      }
       prompt_tokens_ = static_cast<int>(response.prompt_token_ids.size());
       if (response.outputs.empty()) {
         if (response.finished) {

--- a/src/vllm/entrypoints/openai/serving_completion.cpp
+++ b/src/vllm/entrypoints/openai/serving_completion.cpp
@@ -44,12 +44,8 @@ class CompletionSseStream final : public SseStream {
     }
     auto ready = engine_.get_output_for(
         request_, std::chrono::milliseconds(ping_s * 1000));
-    if (ready.has_value()) {
-      out = std::move(*ready);
-      return true;
-    }
-    ping_chunk = kSsePingFrame;
-    return false;
+    // Shared framing with chat: ping is a standalone comment frame.
+    return AssignSseWaitResult(std::move(ready), out, ping_chunk);
   }
 
   bool next(std::string& chunk) override {

--- a/src/vllm/entrypoints/openai/serving_utils.cpp
+++ b/src/vllm/entrypoints/openai/serving_utils.cpp
@@ -1,6 +1,8 @@
 // vllm.cpp original — see serving_utils.h.
 #include <cstdlib>
+#include <optional>
 #include "vllm/entrypoints/openai/serving_utils.h"
+#include "vllm/outputs.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -235,6 +237,18 @@ std::vector<vllm::CompletionOutput> SelectBestOf(
   return outputs;
 }
 
+
+
+bool AssignSseWaitResult(std::optional<vllm::RequestOutput> ready,
+                         vllm::RequestOutput& out, std::string& chunk) {
+  if (ready.has_value()) {
+    out = std::move(*ready);
+    return true;
+  }
+  // Pure SSE comment — never prefix/suffix a data frame here.
+  chunk = kSsePingFrame;
+  return false;
+}
 
 int SsePingIntervalSec() {
   // Default 15s. <=0 disables. Long MoE prefill needs body bytes so proxies /

--- a/src/vllm/entrypoints/openai/serving_utils.cpp
+++ b/src/vllm/entrypoints/openai/serving_utils.cpp
@@ -1,4 +1,5 @@
 // vllm.cpp original — see serving_utils.h.
+#include <cstdlib>
 #include "vllm/entrypoints/openai/serving_utils.h"
 
 #include <algorithm>
@@ -232,6 +233,20 @@ std::vector<vllm::CompletionOutput> SelectBestOf(
     outputs[static_cast<std::size_t>(i)].index = i;
   }
   return outputs;
+}
+
+
+int SsePingIntervalSec() {
+  // Default 15s. <=0 disables. Long MoE prefill needs body bytes so proxies /
+  // Hermes inactivity_timeout do not drop the stream.
+  const char* e = std::getenv("VT_SERVER_SSE_PING_S");
+  if (e == nullptr || e[0] == '\0') return 15;
+  char* end = nullptr;
+  long v = std::strtol(e, &end, 10);
+  if (end == e) return 15;
+  if (v <= 0) return 0;
+  if (v > 600) v = 600;
+  return static_cast<int>(v);
 }
 
 }  // namespace vllm::entrypoints::openai

--- a/src/vllm/v1/engine/async_llm.cpp
+++ b/src/vllm/v1/engine/async_llm.cpp
@@ -180,6 +180,14 @@ std::optional<RequestOutput> AsyncLLM::get_output_nowait(
   return request.collector->get_nowait();
 }
 
+std::optional<RequestOutput> AsyncLLM::get_output_for(
+    const AsyncRequest& request, std::chrono::milliseconds timeout) {
+  if (request.collector == nullptr) {
+    throw std::invalid_argument("AsyncLLM request has no collector");
+  }
+  return request.collector->get_for(timeout);
+}
+
 RequestOutput AsyncLLM::generate(const std::string& prompt,
                                  SamplingParams params,
                                  const std::string& request_id, int priority) {

--- a/src/vllm/v1/engine/output_processor.cpp
+++ b/src/vllm/v1/engine/output_processor.cpp
@@ -4,6 +4,7 @@
 #include "vllm/v1/engine/output_processor.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <iterator>
@@ -52,6 +53,24 @@ RequestOutput RequestOutputCollector::get() {
     std::rethrow_exception(error);
   }
   RequestOutput output = std::move(*output_);
+  output_.reset();
+  return output;
+}
+
+std::optional<RequestOutput> RequestOutputCollector::get_for(
+    std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  const bool ready = ready_.wait_for(lock, timeout, [&] {
+    return output_.has_value() || error_ != nullptr;
+  });
+  if (!ready) return std::nullopt;
+  if (error_ != nullptr) {
+    std::exception_ptr error = std::move(error_);
+    error_ = nullptr;
+    lock.unlock();
+    std::rethrow_exception(error);
+  }
+  std::optional<RequestOutput> output(std::move(*output_));
   output_.reset();
   return output;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -553,6 +553,7 @@ target_compile_definitions(test_chat_mm PRIVATE
   PARITY_GOLDENS_DIR="${CMAKE_SOURCE_DIR}/tests/parity/goldens")
 vllm_cpp_add_test(test_openai_protocol vllm/entrypoints/openai/test_protocol.cpp)
 vllm_cpp_add_test(test_openai_serving vllm/entrypoints/openai/test_serving.cpp)
+vllm_cpp_add_test(test_sse_keepalive vllm/entrypoints/openai/test_sse_keepalive.cpp)
 vllm_cpp_add_test(test_openai_run_batch
   vllm/entrypoints/openai/test_run_batch.cpp)
 vllm_cpp_add_test(test_openai_serving_chat_stream

--- a/tests/vllm/entrypoints/openai/test_sse_keepalive.cpp
+++ b/tests/vllm/entrypoints/openai/test_sse_keepalive.cpp
@@ -1,0 +1,139 @@
+// SSE keepalive contract (VT_SERVER_SSE_PING_S) — chat + completion share
+// AssignSseWaitResult / kSsePingFrame. Maint-bot #316: timeout emits a
+// standalone comment frame; never concatenated with data; <=0 disables;
+// a later real output still streams as a separate data frame.
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "vllm/entrypoints/openai/serving_utils.h"
+#include "vllm/outputs.h"
+#include "vllm/sampling_params.h"
+#include "vllm/v1/engine/output_processor.h"
+
+using vllm::CompletionOutput;
+using vllm::RequestOutput;
+using vllm::RequestOutputKind;
+using vllm::entrypoints::openai::AssignSseWaitResult;
+using vllm::entrypoints::openai::kSsePingFrame;
+using vllm::entrypoints::openai::SsePingIntervalSec;
+
+namespace {
+
+struct EnvRestorer {
+  const char* key;
+  std::optional<std::string> prev;
+  explicit EnvRestorer(const char* k) : key(k) {
+    if (const char* v = std::getenv(k)) prev = std::string(v);
+  }
+  ~EnvRestorer() {
+    if (prev.has_value()) {
+      ::setenv(key, prev->c_str(), 1);
+    } else {
+      ::unsetenv(key);
+    }
+  }
+};
+
+}  // namespace
+
+TEST_CASE("SSE keepalive: frame is a pure comment, never a data frame") {
+  const std::string ping(kSsePingFrame);
+  CHECK(ping == ":\n\n");
+  CHECK(ping.find("data:") == std::string::npos);
+  const std::string data = "data: {\"id\":\"x\"}\n\n";
+  CHECK(ping + data != ping);
+  CHECK(data.find(ping) == std::string::npos);
+}
+
+TEST_CASE("SSE keepalive: chat+completion timeout -> standalone ping frame") {
+  RequestOutput out;
+  out.request_id = "stale";
+  std::string chunk = "data: SHOULD_BE_OVERWRITTEN\n\n";
+  const bool got = AssignSseWaitResult(std::nullopt, out, chunk);
+  CHECK_FALSE(got);
+  CHECK(chunk == std::string(kSsePingFrame));
+  CHECK(chunk == ":\n\n");
+  CHECK(out.request_id == "stale");
+}
+
+TEST_CASE("SSE keepalive: chat+completion data path fills out, no ping rewrite") {
+  RequestOutput ready;
+  ready.request_id = "req-1";
+  ready.finished = true;
+  RequestOutput out;
+  std::string chunk = "untouched";
+  const bool got = AssignSseWaitResult(std::move(ready), out, chunk);
+  CHECK(got);
+  CHECK(out.request_id == "req-1");
+  CHECK(out.finished);
+  CHECK(chunk == "untouched");
+  CHECK(chunk != std::string(kSsePingFrame));
+}
+
+TEST_CASE("SSE keepalive: later real output is a separate framing step") {
+  std::vector<std::string> frames;
+  {
+    RequestOutput out;
+    std::string chunk;
+    CHECK_FALSE(AssignSseWaitResult(std::nullopt, out, chunk));
+    frames.push_back(chunk);
+  }
+  {
+    RequestOutput ready;
+    ready.request_id = "req-2";
+    CompletionOutput co;
+    co.index = 0;
+    co.text = "hi";
+    ready.outputs.push_back(std::move(co));
+    RequestOutput out;
+    std::string chunk;
+    CHECK(AssignSseWaitResult(std::move(ready), out, chunk));
+    CHECK(out.request_id == "req-2");
+    REQUIRE(out.outputs.size() == 1);
+    CHECK(out.outputs[0].text == "hi");
+    frames.push_back("data: " + out.outputs[0].text + "\n\n");
+  }
+  REQUIRE(frames.size() == 2);
+  CHECK(frames[0] == std::string(kSsePingFrame));
+  CHECK(frames[1].rfind("data: ", 0) == 0);
+  // Two discrete frames — next() never returns ping+data concatenated.
+  CHECK(frames[0] + frames[1] != frames[0]);
+  CHECK(frames[1] != frames[0] + frames[1]);
+}
+
+TEST_CASE("SSE keepalive: VT_SERVER_SSE_PING_S <=0 disables") {
+  EnvRestorer rest("VT_SERVER_SSE_PING_S");
+  ::unsetenv("VT_SERVER_SSE_PING_S");
+  CHECK(SsePingIntervalSec() == 15);
+  ::setenv("VT_SERVER_SSE_PING_S", "0", 1);
+  CHECK(SsePingIntervalSec() == 0);
+  ::setenv("VT_SERVER_SSE_PING_S", "-3", 1);
+  CHECK(SsePingIntervalSec() == 0);
+  ::setenv("VT_SERVER_SSE_PING_S", "2", 1);
+  CHECK(SsePingIntervalSec() == 2);
+  ::setenv("VT_SERVER_SSE_PING_S", "9999", 1);
+  CHECK(SsePingIntervalSec() == 600);
+}
+
+TEST_CASE("SSE keepalive: collector get_for timeout then later deliver") {
+  using namespace std::chrono_literals;
+  vllm::v1::RequestOutputCollector c(RequestOutputKind::kDelta, "sse0");
+  CHECK_FALSE(c.get_for(15ms).has_value());
+  std::thread th([&] {
+    std::this_thread::sleep_for(25ms);
+    RequestOutput out;
+    out.request_id = "sse0";
+    out.finished = true;
+    c.put(std::move(out));
+  });
+  auto hit = c.get_for(500ms);
+  th.join();
+  REQUIRE(hit.has_value());
+  CHECK(hit->request_id == "sse0");
+}

--- a/tests/vllm/v1/test_output_processor.cpp
+++ b/tests/vllm/v1/test_output_processor.cpp
@@ -7,6 +7,8 @@
 //       and reqs_to_abort carries the req (EngineCore did not signal STOP);
 //   (c) finish-reason mapping (LENGTH/STOP) -> RequestOutput strings;
 //   (d) a normal EngineCore-signaled EOS finish -> finished, no reqs_to_abort.
+#include <chrono>
+#include <thread>
 #include <doctest/doctest.h>
 
 #include <cstdint>
@@ -435,4 +437,26 @@ TEST_CASE("per-request stream_interval below the engine interval is clamped up")
       MakeStep("r0", {9}, std::optional<FinishReason>(FinishReason::kLength)));
   REQUIRE(s3.request_outputs.size() == 1);
   CHECK(s3.request_outputs[0].outputs[0].text == "12");
+}
+
+TEST_CASE("RequestOutputCollector.get_for times out and delivers") {
+  using namespace std::chrono_literals;
+  vllm::v1::RequestOutputCollector c(RequestOutputKind::kDelta, "t0");
+  // Timeout with nothing queued.
+  auto miss = c.get_for(20ms);
+  CHECK_FALSE(miss.has_value());
+
+  // Producer after a short delay.
+  std::thread th([&] {
+    std::this_thread::sleep_for(30ms);
+    RequestOutput out;
+    out.request_id = "t0";
+    out.finished = true;
+    c.put(std::move(out));
+  });
+  auto hit = c.get_for(500ms);
+  th.join();
+  REQUIRE(hit.has_value());
+  CHECK(hit->request_id == "t0");
+  CHECK(hit->finished);
 }


### PR DESCRIPTION
## Summary

Split out of #228 (SSE half) with the maintainer review defects fixed. **#228 is closed** in favor of this + #317.

Long prefill/TTFT can sit silent long enough that proxies and Hermes `inactivity_timeout` drop the TCP stream even though the engine is healthy. This PR adds timed waits on the per-request collector and optional SSE **comment** keepalives.

## What changed

| Piece | Detail |
|--------|--------|
| `RequestOutputCollector::get_for` | `ready_.wait_for` — nullopt on timeout, immediate wake on `put` |
| `AsyncLLM::get_output_for` | thin wrapper |
| Chat + completion async SSE | use timed wait; on timeout emit **only** SSE comment keepalives (never concatenated with a data frame) |
| Continuous usage | **preserved** from main (role frame still gets prompt tokens when requested) |
| `VT_SERVER_SSE_PING_S` | default 15s; `<=0` disables |

## Explicitly not this PR

- No 50ms `get_output_nowait` + `sleep_for` poll loop (that collapsed multi-token streams in #228)
- No deferred `add_request` rewrite (can follow once this lands)
- No ROCm / Gemma4 MoE (#317) or sampler (#234)

## Land order

1. **#234** ROCm V1 sampler
2. **#227** KV fail-fast
3. **This PR (#316)** SSE keepalives
4. **#317** Gemma4/ROCm FP8 stack

## Tests

- `RequestOutputCollector.get_for times out and delivers` in `test_output_processor.cpp`
- Existing streaming suites should stay green
- Local gates: doc-checkpoint, env-doc, pr-size, agent-record, device-leakage
