### PR TITLE
feat(gemma4/rocm): FP8 resident MoE + SharedK-WMMA (split from #228)

### DIFF
--- a/.agents/specs/gemma4-rocm-fp8-moe.md
+++ b/.agents/specs/gemma4-rocm-fp8-moe.md
@@ -1,0 +1,60 @@
+# SPIKE / SPEC — Gemma-4 MoE ROCm FP8 + SharedK-WMMA (#317)
+
+**Status:** ACTIVE lab path (dual R9700 gfx1201) · PR tip `feat/gemma4-rocm-fp8-split`  
+**Claim class:** ROCm serve correctness + decode/prefill knobs (not CUDA SACRED parity)  
+**Related PRs:** #234 sampler · #227 KV fail-fast · #316 SSE · #328 bare toolcall · **this**
+
+## Problem
+Gemma-4-26B MoE FP8 on consumer RDNA4 needs: resident dual-GPU experts, peer mix, SharedK-WMMA prefill, decode multi-CTA KV splits, and portable `vt::` seams so `models/` never names HIP (device-leakage).
+
+## In scope (this PR)
+| Area | Files (representative) | Gate |
+|------|------------------------|------|
+| Portable fused_ops / backend hooks | `include/vt/fused_ops.h`, `src/vt/fused_ops.cpp`, `backend.h` | CPU link + device-leakage |
+| FP8 ExpertGeGLU / channel GEMV | `rocm_fp8_channel_gemv.hip`, `rocm_gemma4_experts.hip` | Lab A/B + quality (Paris/arith) |
+| MoE host policy | `gemma4_moe.cpp` / `.h` | Lab load + decode |
+| Prefill SharedK-WMMA | `rocm_paged_attn.hip` (prefill path) | Prefill eng ~2k class @11–12k |
+| Decode KV splits / slide | `rocm_paged_attn.hip` | `VT_ATTN_DECODE_*` recipe |
+| Env surface | `docs/ENVIRONMENT.md` `VT_GEMMA4_*` / `VT_ATTN_*` | check-env-doc |
+
+## Out of scope
+- SSE keepalives (#316), ROCm sampler (#234), bare tool parser (#328)
+- CUDA SACRED gemma4-E4B text golden (dgx) — unchanged by ROCm HIP paths when `HasRocm` off
+- Full MoE token-exact vs vLLM on RDNA4 (no AMD CI runners)
+
+## Env recipe (lab binding)
+See `docs/ENVIRONMENT.md` and lab `gemma4-fp8-recipe.env`:
+`VT_GEMMA4_FP8_HW_CVT`, `VT_ATTN_DECODE_KV_SPLITS`, `VT_ATTN_DECODE_SLIDE_*`, resident experts, prefill GEMM_M / PEER_ACT / SharedK-WMMA.
+
+## Automated coverage in-tree
+1. **Device-leakage** — models/ must not call `vt::rocm::*` (CI `check-device-leakage`).
+2. **CPU unit** — `test_gemma4_rocm_fp8_seams` (this PR): fused_ops symbols resolve; env knobs parse inert defaults on CPU.
+3. **Existing** — `test_gemma4_paged_engine` / registry e2e remain CUDA/dgx optional skips.
+4. **Lab (not CI)** — exclusive decode_depth_curve + Paris/READY on dual R9700; evidence in contributor lab notes, not forced into STATUS ratchet growth.
+
+## Residuals (named, not silent)
+- HIP guards polish in dense `gemma4.cpp` paths
+- Broader parity matrix rows when AMD CI exists
+- Further decode micro-opts stay lab-recipe until KEEP+quality
+
+## Merge criteria (maintainer)
+- Spec present (this file)
+- Device-leakage OK; env documented
+- CPU seam test green
+- No SSE/sampler/toolcall scope creep
+- Sanitize ambient reds treated as main baseline unless unique product fail
+
+## Scope note (2026-08-11 rebuild on main)
+
+This tip is **ROCm FP8 MoE + SharedK-WMMA + fused_ops + expert LRU/prewarm**.
+
+**Explicitly deferred** (localai-bot hold on prior tip):
+- `ForwardGemma4Layers` extract / layer-loop restructure in `gemma4.cpp`
+- `Gemma4DecodeGraph` / pure-decode hipGraph driver
+- Any unguarded CUDA-path forward refactor requiring GB10 token-exact golden
+
+Rationale: those changes touch the gate model forward on all backends. ROCm kernels
+and env-gated MoE paths do not. Revisit as a **separate** PR with CUDA golden.
+
+`VT_GEMMA4_MLP_MOE_PARALLEL` is documented but **not** wired in this tip (was only
+in the deferred layer-loop path).

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -176,10 +176,23 @@ on CUDA/CPU builds beyond the documented behavior.
 
 | Variable | Default | What it does |
 |---|---|---|
-| `VT_GEMMA4_EXPERT_VRAM_MB` | unlimited (unset or `0`) | A positive MiB value caps the device expert-cache LRU; unset or `0` leaves the cache unlimited |
+| `VT_GEMMA4_EXPERT_VRAM_MB` | off (unset/`0`) | `N>0` enables device expert LRU with N MiB fill budget; unset/`0` = device expert LRU **off** (resident path uses `VT_GEMMA4_RESIDENT_*`). Evict only with `VT_GEMMA4_EXPERT_EVICT=1` |
 | `VT_GEMMA4_RESIDENT_EXPERTS` | unset | `=1` preloads the Gemma-4 MoE experts resident on the GPU(s) after the first use instead of streaming them per step (discrete-ROCm optimization). No-op (with a stderr note) on a binary built without `-DVLLM_CPP_HIP` |
 | `VT_GEMMA4_RESIDENT_GPUS` | `2` | Number of GPUs across which resident Gemma-4 experts are spread; clamped to the ROCm device count. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
 | `VT_GEMMA4_RESIDENT_MAX_LAYERS` | (all) | Caps how many MoE layers get resident-preloaded, to fit a smaller VRAM budget. Read only when `VT_GEMMA4_RESIDENT_EXPERTS=1` |
+| `VT_GEMMA4_RESIDENT_BF16` | unset | Force BF16 resident expert packs when set |
+| `VT_GEMMA4_RESIDENT_NATIVE` | unset | Prefer native FP8 resident packs when set |
+| `VT_ATTN_PREFILL_FLASH_SHAREDK` | on | ROCm Gemma-4 prefill: scoreless SharedK flash path (prod default). `0` forces DecodeGqa baseline for A/B |
+| `VT_ATTN_PREFILL_FLASH_WMMA` | off | Lab-only ROCm flash WMMA QK path; leave off for prod |
+| `VT_ATTN_PREFILL_SHAREDK_WMMA` | on | ROCm SharedK fused with rocWMMA QK on sliding d=256 (and global-Q d=512). `0` forces scalar SharedK |
+| `VT_GEMMA4_PREFILL_PEER_ACT` | on | Prefill MoE: run ExpertGeGLU on the expert GPU and peer activations only (not full weight PeerCopy). `0` restores weight PeerCopy |
+| `VT_GEMMA4_GPU0_HEADROOM_GB` | `12` | GiB kept free on GPU0 when packing resident experts (decode vs long-prefill trade). Lab dual R9700 + 49k KV: `8` survives 16k+ prefill; `6` OOMs ~11k |
+| `VT_GEMMA4_PREFILL_BATCH_MOE` | auto / `1` in lab recipe | `=1` group-by-expert prefill GEMM for `T>=64`; `=0` serial M=1 (slow). Unset = auto |
+| `VT_GEMMA4_MLP_MOE_PARALLEL` | off | `=1` run Gemma4 MLP and MoE on two HIP streams (lab; wall ~flat on R9700). Not wired in this PR tip (decode-graph-free split) |
+| `VT_ATTN_PREFILL_FLASH` | off | `=1` SGLang-style BM×BN GQA flash prefill (lab A/B) |
+| `VT_GEMMA4_PREFILL_GEMM_M` | `256` | Tokens per expert in prefill-batch GEMM chunks (`16..2048`). Larger M → fewer launches; lab `512` ~+37% prefill vs `64` |
+| `VT_GEMMA4_HOST_EXPERT_MB` | `512` | Host-side expert staging budget (MiB) for non-resident paths |
+| `VT_GEMMA4_LAYER_TRACE` | off | `=1` layer GPU-synced phase timers; `=2` per-layer heartbeats |
 | `VLLM_CPP_HTTP_FIXED_POOL` | `1` (fixed) | `=0` reverts the HTTP worker pool to the legacy dynamic mode. Production uses the capacity-derived fixed pool; the opt-out exists for same-binary A/B attribution |
 | `VT_ROCM_ATTN_CPU_REF` | unset | `=1` routes ROCm paged attention through the CPU reference kernel instead of the HIP kernel — a correctness A/B for the ROCm attention bring-up |
 | `VT_DEBUG_SAMPLED` | unset | `=1` prints the per-step sampled token id(s) to stderr (sampling-loop debug). Read-only; does not change output. Read once per token, so it does not stall the hot loop |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -316,7 +316,7 @@ CPU elementwise GEMM (f32/f16/bf16) runs AVX2 and AVX-512 tiers on x86 where the
 | XPU, TPU | Not started | CUDA, CPU, Metal and Vulkan are the built backends |
 | Custom logits processors on CUDA | Open, not root-caused | Segfaults in a CUDA build, 232/232 green on CPU |
 | Memory budgeting (`ROAD-V1-MEM`, #83) | M1+M2 landed (absolute bytes) | `--kv-cache-memory` sizes the KV pool from an absolute byte budget (ABI v16, group-aware divisor); `--num-blocks` overrides; `--gpu-memory-utilization` needs the M3 profile run (dgx-gated). See `specs/kv-sizing.md` |
-| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident experts + SharedK-WMMA prefill (RDNA4). Spec: `.agents/specs/gemma4-rocm-fp8-moe.md`. Env: `VT_GEMMA4_*` / `VT_ATTN_*`. CPU seam: `test_gemma4_rocm_fp8_seams`. Decode-graph / ForwardGemma4Layers extract **deferred** (CUDA gate hold) |
+| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident experts, SharedK-WMMA prefill (RDNA4); decode-graph and forward extract deferred. Env `VT_GEMMA4_*`/`VT_ATTN_*`, seam `test_gemma4_rocm_fp8_seams`. [spec](../.agents/specs/gemma4-rocm-fp8-moe.md) |
 
 ## How to read this page
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -316,7 +316,7 @@ CPU elementwise GEMM (f32/f16/bf16) runs AVX2 and AVX-512 tiers on x86 where the
 | XPU, TPU | Not started | CUDA, CPU, Metal and Vulkan are the built backends |
 | Custom logits processors on CUDA | Open, not root-caused | Segfaults in a CUDA build, 232/232 green on CPU |
 | Memory budgeting (`ROAD-V1-MEM`, #83) | M1+M2 landed (absolute bytes) | `--kv-cache-memory` sizes the KV pool from an absolute byte budget (ABI v16, group-aware divisor); `--num-blocks` overrides; `--gpu-memory-utilization` needs the M3 profile run (dgx-gated). See `specs/kv-sizing.md` |
-| Gemma4 MoE ROCm fused helpers + V1 sampler | Partial | `vt::fused_ops` seam; ROCm registers full V1 sample ops (temp/top-p/masks/penalties). Public: `VT_GEMMA4_EXPERT_VRAM_MB`, `VT_SERVER_MAX_{PROMPT_CHARS,NEW_TOKENS}` |
+| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident experts + SharedK-WMMA prefill (RDNA4). Spec: `.agents/specs/gemma4-rocm-fp8-moe.md`. Env: `VT_GEMMA4_*` / `VT_ATTN_*`. CPU seam: `test_gemma4_rocm_fp8_seams`. Decode-graph / ForwardGemma4Layers extract **deferred** (CUDA gate hold) |
 
 ## How to read this page
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1438,3 +1438,10 @@ waiting on the engine (long prefill / TTFT). Interval is `VT_SERVER_SSE_PING_S`
 (default 15s; `0` disables). Comment frames are not `data:` events and do not
 carry tokens. Token streaming still uses a timed wait on the request collector
 so deltas are not collapsed by a poll loop.
+
+## Gemma4 FP8 on ROCm (RDNA4)
+
+Dual-GPU resident FP8 MoE and SharedK-WMMA prefill are controlled via
+ENVIRONMENT.md (`VT_GEMMA4_RESIDENT_*`, `VT_ATTN_*`). Defaults stay safe off RDNA4.
+This PR does **not** restructure the Gemma-4 layer loop or enable decode hipGraph
+(those stay lab-only until a CUDA token-exact gate can land them).

--- a/include/vllm/model_executor/models/gemma4_moe.h
+++ b/include/vllm/model_executor/models/gemma4_moe.h
@@ -49,6 +49,13 @@ struct Gemma4FusedExperts {
   // Optional device-resident BF16 fused stacks after Prepare.
   mutable void* gate_up_dev = nullptr;
   mutable void* down_dev = nullptr;
+  // Native FP8 layer packs (preferred for is_fp8 resident). Per-expert
+  // dev_fp8_* / dev_s_* point into these bases; free bases on teardown only.
+  mutable void* fp8_gu_base = nullptr;   // u8 [E, 2I, H]
+  mutable void* fp8_dn_base = nullptr;   // u8 [E, H, I]
+  mutable void* fp8_sgu_base = nullptr;  // bf16 [E, 2I]
+  mutable void* fp8_sdn_base = nullptr;  // bf16 [E, H]
+  mutable bool fp8_native_resident = false;
   mutable int dev_id = -1;
   bool Empty() const { return gate_up.Empty() && fp8.empty(); }
 };
@@ -80,15 +87,48 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
                                    int num_gpus);
 size_t UploadGemma4ExpertsResidentForWeights(Gemma4Weights& weights, int num_gpus);
 
-// Peer-copy one resident expert (fused stacks on src_dev) into dst buffers on
+// Peer-copy one resident expert (fused BF16 stacks on src_dev) into dst buffers on
 // compute_dev. Returns false if peer path unavailable.
 bool PeerCopyGemma4ExpertSlice(int src_dev, const void* gate_up_base,
                                const void* down_base, int expert_id, int64_t I,
                                int64_t H, int compute_dev, void* gate_up_dst,
                                void* down_dst);
 
+// Peer-copy one native FP8 expert (weights+scales) into compute_dev dsts.
+bool PeerCopyGemma4Fp8ExpertSlice(int src_dev, const void* fp8_gu, const void* fp8_dn,
+                                  const void* s_gu, const void* s_dn, int64_t I, int64_t H,
+                                  int compute_dev, void* fp8_gu_dst, void* fp8_dn_dst,
+                                  void* s_gu_dst, void* s_dn_dst);
+
+// Decode T=1: run top-k FP8 ExpertGeGLU on expert_dev (weights stay put).
+// Peer-copies x (H bf16) to expert_dev and ysum back onto compute_q's device —
+// not the expert weights. Async peer + events when possible.
+// Returns false → caller falls back to weight peer-copy path.
+bool RunGemma4Fp8TopKOnExpertDevice(vt::Queue& compute_q, int expert_dev, void* ysum_compute,
+                                    const void* x_compute, const void* const* fp8_gu,
+                                    const void* const* s_gu, const void* const* fp8_dn,
+                                    const void* const* s_dn, const float* wts, int G, int I,
+                                    int H);
+
+// Prefill batch: one expert GeGLU for M token rows. Weights stay on expert_dev;
+// peer only x/y activations (M×H bf16). Sticky FP8→BF16 dequant on expert.
+// Returns false → caller falls back to weight PeerCopy path.
+bool RunGemma4Fp8ExpertGeGLUPrefillOnExpertDevice(vt::Queue& compute_q, int expert_dev,
+                                                  void* y_compute, const void* x_compute,
+                                                  const void* fp8_gu, const void* s_gu,
+                                                  const void* fp8_dn, const void* s_dn, int M,
+                                                  int I, int H);
+// Same, but contiguous FP8 bases + device idx/wts (no host pointer gather).
+bool RunGemma4Fp8TopKIndexedOnExpertDevice(vt::Queue& compute_q, int expert_dev, void* ysum_compute,
+                                           const void* x_compute, const void* gu_base,
+                                           const void* dn_base, const void* sgu_base,
+                                           const void* sdn_base, const int32_t* idx_compute,
+                                           const float* wts_compute, int G, int I, int H);
+
 // hipHostRegister BF16 expert cache for faster H2D (no-op if already pinned).
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex);
+// hipHostUnregister before dropping host BF16 cache (no-op if not pinned).
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex);
 
 // Dequant one FP8 expert into host BF16 gate_up[2I,H] and down[H,I] (caller-owned).
 // Fills permanent host cache (decode path). Prefer Ephemeral for bulk upload.

--- a/include/vt/backend.h
+++ b/include/vt/backend.h
@@ -75,6 +75,13 @@ class Backend {
   // device pointer to a host memcpy and segfaults.
   virtual bool DeviceMemoryIsHostAddressable() const { return false; }
 
+  // Optional device free/total VRAM probe (bytes). Default false = unknown.
+  // ROCm/CUDA override with hipMemGetInfo/cudaMemGetInfo so model code can
+  // size LRU caches without including vendor headers (device-leakage).
+  virtual bool DeviceMemoryInfo(size_t* /*free_bytes*/, size_t* /*total_bytes*/) const {
+    return false;
+  }
+
   // --- Device compute capability (BACKEND-CUDA-ARCH-ADDITIVITY seam-gap #4) ---
   // The architecture the backend is actually running on, as the familiar
   // `(major, minor)` pair (GB10/sm_121 -> {12, 1}). Before this, the capability

--- a/include/vt/fused_ops.h
+++ b/include/vt/fused_ops.h
@@ -27,7 +27,30 @@ void MatmulBTAlphaBeta(Queue& q, void* out, const void* a, const void* b, int M,
 void MatmulBTFp8Channel(Queue& q, void* out, const void* a, const void* b_fp8,
                         const void* scale_bf16, int M, int N, int K, float alpha, float beta);
 
+// Device FP8 E4M3 + BF16 channel scale → BF16 weights [N,K] (prefill hipBLAS path).
+void DequantFp8ChannelBf16(Queue& q, void* out_bf16, const void* fp8, const void* scale_bf16,
+                           int N, int K);
+
 bool ExpertGeGLUBf16TopKM1(Queue& q, void* ysum, const void* x, const void* const* w_gu,
                            const void* const* w_dn, const float* wts, int G, int I, int H);
+
+// Fused FP8 expert GeGLU top-k (T=1). Uses hipBLASLt FP8 when available, else fast HIP.
+bool ExpertGeGLUFp8TopKM1(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                          const void* const* s_gu, const void* const* fp8_dn,
+                          const void* const* s_dn, const float* wts, int G, int I, int H);
+bool ExpertGeGLUFp8TopKIndexed(Queue& q, void* ysum, const void* x, const void* gu_base,
+                               const void* dn_base, const void* sgu_base, const void* sdn_base,
+                               const int32_t* idx_dev, const float* wts_dev, int G, int I, int H);
+void ApplyExpertScaleRw(Queue& q, float* rw_dev, const int32_t* ri_dev, const float* escale_dev,
+                        int G, int E);
+// Pre-alloc ExpertGeGLU scratch on `dev` (call after resident expert upload).
+bool PrewarmExpertGeGLUFp8TopK(int dev, int G, int I, int H);
+
+// Prefill MoE: GPU gather / weighted scatter (no host accumulation).
+void MoeGatherRows(Queue& q, void* out_bf16, const void* in_bf16, const int32_t* token_ids_dev,
+                   int n, int H);
+void MoeWeightedScatterAdd(Queue& q, void* acc_bf16, const void* y_bf16,
+                           const int32_t* token_ids_dev, const float* weights_dev, int n, int H);
+void MoeZeroBf16(Queue& q, void* buf_bf16, int64_t nelem);
 
 }  // namespace vt

--- a/include/vt/rocm/rocm_device_bind.h
+++ b/include/vt/rocm/rocm_device_bind.h
@@ -1,0 +1,31 @@
+// Capture-aware current-device bind for ROCm.
+// hipSetDevice is illegal during hipGraph capture; stream launches carry device.
+// Outside capture, bind so peer-MoE can leave current device on the expert GPU.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include "vt/device.h"
+
+namespace vt::rocm {
+
+inline bool StreamIsCapturing(hipStream_t st) {
+  if (st == nullptr) return false;
+  hipStreamCaptureStatus status = hipStreamCaptureStatusNone;
+  if (hipStreamIsCapturing(st, &status) != hipSuccess) return false;
+  return status != hipStreamCaptureStatusNone;
+}
+
+// Bind process current device to q.device when not capturing. No-op if already set
+// or if the stream is mid-capture (graph-safe).
+inline void EnsureQueueDevice(const Queue& q) {
+  const int dev = q.device.index;
+  if (dev < 0) return;
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  if (StreamIsCapturing(st)) return;
+  int cur = -1;
+  if (hipGetDevice(&cur) == hipSuccess && cur == dev) return;
+  (void)hipSetDevice(dev);
+}
+
+}  // namespace vt::rocm

--- a/include/vt/rocm/rocm_matmul_batch.h
+++ b/include/vt/rocm/rocm_matmul_batch.h
@@ -33,4 +33,34 @@ void MatmulBTFp8ChannelRocm(Queue& q, void* out, const void* a, const void* b_fp
                             const void* scale_bf16, int M, int N, int K, float alpha,
                             float beta);
 
+// out_bf16[N,K] = scale[n] * f8_e4m3(w[n,k])  (device; for hipBLAS prefill)
+void DequantFp8ChannelBf16Rocm(Queue& q, void* out_bf16, const void* fp8,
+                               const void* scale_bf16, int N, int K);
+
+// Fused Expert GeGLU FP8 decode (T=1). Faster than 3× MatmulBTFp8Channel.
+bool ExpertGeGLUFp8M1Rocm(Queue& q, void* y, const void* x, const void* fp8_gu, const void* s_gu,
+                          const void* fp8_dn, const void* s_dn, int I, int H, float alpha,
+                          float beta);
+bool ExpertGeGLUFp8TopKM1Rocm(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                              const void* const* s_gu, const void* const* fp8_dn,
+                              const void* const* s_dn, const float* wts, int G, int I, int H);
+// Contiguous resident FP8 packs + device idx/wts (decode T=1, no host gather).
+bool ExpertGeGLUFp8TopKIndexedRocm(Queue& q, void* ysum, const void* x, const void* gu_base,
+                                   const void* dn_base, const void* sgu_base, const void* sdn_base,
+                                   const int32_t* idx_dev, const float* wts_dev, int G, int I,
+                                   int H);
+void ApplyExpertScaleRwRocm(Queue& q, float* rw_dev, const int32_t* ri_dev, const float* escale_dev,
+                            int G, int E);
+bool PrewarmExpertGeGLUFp8TopKIndexedRocm(int dev, int G, int I, int H);
+
+// Prefill MoE helpers (GPU-only gather / weighted scatter — no host hacc).
+// out[n,H] = in[token_ids[i], H] for i in [0,n)
+void MoeGatherRowsRocm(Queue& q, void* out_bf16, const void* in_bf16, const int32_t* token_ids,
+                       int n, int H);
+// acc[token_ids[i], :] += weight[i] * y[i, :]  (bf16 acc + bf16 y, float weights)
+void MoeWeightedScatterAddRocm(Queue& q, void* acc_bf16, const void* y_bf16,
+                               const int32_t* token_ids, const float* weights, int n, int H);
+// Zero bf16 buffer [rows*H]
+void MoeZeroBf16Rocm(Queue& q, void* buf_bf16, int64_t nelem);
+
 }  // namespace vt::rocm

--- a/src/vllm/model_executor/models/gemma4_moe.cpp
+++ b/src/vllm/model_executor/models/gemma4_moe.cpp
@@ -36,6 +36,9 @@ struct ExpertScratch {
   DBuf act;   // [T, I]
   DBuf gu_w;  // host-path [2I, H] weight upload
   DBuf down_w;
+  // Sticky H2D key (expert identity). Do NOT key on buffer pointers — ephemeral
+  // dequant reuses the same gu_tmp/dn_tmp addresses for every expert.
+  const void* sticky_key = nullptr;
   ExpertScratch(Dev d, int64_t T, int64_t I, int64_t H)
       : gu(d, DType::kBF16, {T, 2 * I}),
         act(d, DType::kBF16, {T, I}),
@@ -44,51 +47,135 @@ struct ExpertScratch {
 };
 
 void ExpertGeGLUHost(Dev d, DBuf& out, const Tensor& x, const uint16_t* gate_up_e,
-                     const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s) {
+                     const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s,
+                     const void* sticky_key = nullptr) {
+  const int64_t T = x.shape[0];
+  VT_CHECK(out.t().shape[0] >= T && out.t().shape[1] == H, "ExpertGeGLUHost out shape");
+  VT_CHECK(s.gu.t().shape[0] >= T && s.act.t().shape[0] >= T, "ExpertGeGLUHost scratch T");
   const size_t gu_b = static_cast<size_t>(2 * I * H) * sizeof(uint16_t);
   const size_t dn_b = static_cast<size_t>(H * I) * sizeof(uint16_t);
-  d.b.Copy(d.q, s.gu_w.ptr(), gate_up_e, gu_b);
-  d.b.Copy(d.q, s.down_w.ptr(), down_e, dn_b);
-  // One GEMM: x @ W_gu^T -> [T, 2I], then GeluAndMul (interleaved gate|up).
-  vt::MatmulBT(d.q, s.gu.t(), x, s.gu_w.t());
-  vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  vt::MatmulBT(d.q, out.t(), s.act.t(), s.down_w.t());
+  const void* key = sticky_key != nullptr ? sticky_key : static_cast<const void*>(gate_up_e);
+  if (s.sticky_key != key) {
+    d.b.Copy(d.q, s.gu_w.ptr(), gate_up_e, gu_b);
+    d.b.Copy(d.q, s.down_w.ptr(), down_e, dn_b);
+    s.sticky_key = key;
+  }
+  const vt::Device dev = d.q.device;
+  Tensor gu_act =
+      Tensor::Contiguous(s.gu.ptr(), DType::kBF16, dev, {T, 2 * I});
+  Tensor act = Tensor::Contiguous(s.act.ptr(), DType::kBF16, dev, {T, I});
+  Tensor out_view = Tensor::Contiguous(out.ptr(), DType::kBF16, dev, {T, H});
+  vt::MatmulBT(d.q, gu_act, x, s.gu_w.t());
+  vt::GeluAndMul(d.q, act, gu_act);
+  vt::MatmulBT(d.q, out_view, act, s.down_w.t());
+  // Per-expert drain: once-per-token-only still lost the server after pollution
+  // (connection refused). Keep barrier until a safer fused device path exists.
+  d.b.Synchronize(d.q);
 }
 
 void ExpertGeGLUDeviceAccum(Dev d, DBuf& out, const Tensor& x, const uint16_t* gate_up_e,
                             const uint16_t* down_e, int64_t I, int64_t H, ExpertScratch& s,
                             float alpha, float beta) {
   const int64_t T = x.shape[0];
+  VT_CHECK(s.gu.t().shape[0] >= T && s.act.t().shape[0] >= T, "ExpertGeGLUDeviceAccum scratch T");
   const vt::Device dev = d.q.device;
   // gate_up_e is contiguous [2I, H] — one BT GEMM instead of two.
   Tensor gu_w =
       Tensor::Contiguous(const_cast<uint16_t*>(gate_up_e), DType::kBF16, dev, {2 * I, H});
-  vt::MatmulBT(d.q, s.gu.t(), x, gu_w);
-  vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  vt::MatmulBTAlphaBeta(d.q, out.ptr(), s.act.ptr(), down_e, static_cast<int>(T),
+  Tensor gu_act =
+      Tensor::Contiguous(s.gu.ptr(), DType::kBF16, dev, {T, 2 * I});
+  Tensor act = Tensor::Contiguous(s.act.ptr(), DType::kBF16, dev, {T, I});
+  vt::MatmulBT(d.q, gu_act, x, gu_w);
+  vt::GeluAndMul(d.q, act, gu_act);
+  vt::MatmulBTAlphaBeta(d.q, out.ptr(), act.data, down_e, static_cast<int>(T),
                                   static_cast<int>(H), static_cast<int>(I), alpha, beta,
                                   DType::kBF16);
 }
 
 void ExpertGeGLUFp8Native(Dev d, DBuf& out, const Tensor& x, const void* fp8_gu,
                           const void* s_gu, const void* fp8_dn, const void* s_dn, int64_t I,
-                          int64_t H, ExpertScratch& s, float alpha, float beta) {
-  VT_CHECK(x.shape[0] == 1, "fp8 native: T==1 only");
-  vt::MatmulBTFp8Channel(d.q, s.gu.ptr(), x.data, fp8_gu, s_gu, /*M=*/1,
-                                   static_cast<int>(2 * I), static_cast<int>(H), 1.f, 0.f);
-  vt::GeluAndMul(d.q, s.act.t(), s.gu.t());
-  if (beta == 0.f) {
-    vt::MatmulBTFp8Channel(d.q, out.ptr(), s.act.ptr(), fp8_dn, s_dn, /*M=*/1,
-                                     static_cast<int>(H), static_cast<int>(I), alpha, 0.f);
-  } else {
-    DBuf ytmp(d, DType::kBF16, {1, H});
-    vt::MatmulBTFp8Channel(d.q, ytmp.ptr(), s.act.ptr(), fp8_dn, s_dn, /*M=*/1,
-                                     static_cast<int>(H), static_cast<int>(I), 1.f, 0.f);
-    vt::MulScalar(d.q, out.t(), out.t(), static_cast<double>(beta));
-    DBuf ysc(d, DType::kBF16, {1, H});
-    vt::MulScalar(d.q, ysc.t(), ytmp.t(), static_cast<double>(alpha));
-    vt::Add(d.q, out.t(), out.t(), ysc.t());
+                          int64_t H, ExpertScratch& s, float alpha, float beta,
+                          const void* weight_id = nullptr) {
+  const int64_t T = x.shape[0];
+  VT_CHECK(out.t().shape[0] >= T && out.t().shape[1] == H, "ExpertGeGLUFp8Native out");
+  VT_CHECK(s.gu.t().shape[0] >= T && s.act.t().shape[0] >= T, "ExpertGeGLUFp8Native scratch T");
+  // T==1 + beta=0: fused ExpertGeGLU (decode). Weights stay FP8.
+  if (T == 1 && beta == 0.f) {
+    const float wts[1] = {alpha};
+    if (vt::ExpertGeGLUFp8TopKM1(d.q, out.ptr(), x.data, &fp8_gu, &s_gu, &fp8_dn, &s_dn, wts,
+                                 /*G=*/1, static_cast<int>(I), static_cast<int>(H))) {
+      return;
+    }
   }
+  // Prefill T>1: custom Fp8ChannelGemmMKernel is serial-in-M (slow). Dequant FP8→BF16
+  // once on GPU, then hipBLAS MatmulBT (same path as ExpertGeGLUDeviceAccum).
+  // weight_id: stable expert identity when fp8_gu is an ephemeral peer staging ptr
+  // (same address for every expert — must NOT key sticky on that pointer alone).
+  const vt::Device dev = d.q.device;
+  const void* key = weight_id != nullptr ? weight_id : fp8_gu;
+  if (s.sticky_key != key) {
+    vt::DequantFp8ChannelBf16(d.q, s.gu_w.ptr(), fp8_gu, s_gu, static_cast<int>(2 * I),
+                              static_cast<int>(H));
+    vt::DequantFp8ChannelBf16(d.q, s.down_w.ptr(), fp8_dn, s_dn, static_cast<int>(H),
+                              static_cast<int>(I));
+    s.sticky_key = key;
+  }
+  Tensor gu_w = Tensor::Contiguous(s.gu_w.ptr(), DType::kBF16, dev, {2 * I, H});
+  Tensor gu_act = Tensor::Contiguous(s.gu.ptr(), DType::kBF16, dev, {T, 2 * I});
+  Tensor act = Tensor::Contiguous(s.act.ptr(), DType::kBF16, dev, {T, I});
+  vt::MatmulBT(d.q, gu_act, x, gu_w);
+  vt::GeluAndMul(d.q, act, gu_act);
+  vt::MatmulBTAlphaBeta(d.q, out.ptr(), act.data, s.down_w.ptr(), static_cast<int>(T),
+                        static_cast<int>(H), static_cast<int>(I), alpha, beta, DType::kBF16);
+}
+
+// Top-k FP8 native: gate_up×G → one GeluAndMul → down×G (alpha/beta mix). Decode M=1.
+bool ExpertGeGLUFp8TopKFusedGelu(Dev d, DBuf& ysum, const Tensor& x, const void* const* fp8_gu,
+                                 const void* const* s_gu, const void* const* fp8_dn,
+                                 const void* const* s_dn, const float* wts, int G, int64_t I,
+                                 int64_t H) {
+  if (G <= 0 || x.shape[0] != 1) return false;
+  struct Tls {
+    int dev = -1;
+    int Gcap = 0;
+    int64_t I = 0, H = 0;
+    std::optional<DBuf> gu;   // [G, 2I]
+    std::optional<DBuf> act;  // [G, I]
+  };
+  static thread_local Tls tls;
+  if (tls.dev != d.q.device.index || tls.Gcap < G || tls.I != I || tls.H != H) {
+    tls.gu.emplace(d, DType::kBF16, std::vector<int64_t>{G, 2 * I});
+    tls.act.emplace(d, DType::kBF16, std::vector<int64_t>{G, I});
+    tls.dev = d.q.device.index;
+    tls.Gcap = G;
+    tls.I = I;
+    tls.H = H;
+  }
+  const vt::Device dev = d.q.device;
+  const size_t gu_row = static_cast<size_t>(2 * I) * 2;
+  const size_t act_row = static_cast<size_t>(I) * 2;
+  const int Ngu = static_cast<int>(2 * I);
+  const int Nh = static_cast<int>(H);
+  const int Ki = static_cast<int>(I);
+  const int Kh = static_cast<int>(H);
+
+  for (int g = 0; g < G; ++g) {
+    void* gu_out = static_cast<char*>(tls.gu->ptr()) + static_cast<size_t>(g) * gu_row;
+    vt::MatmulBTFp8Channel(d.q, gu_out, x.data, fp8_gu[g], s_gu[g], /*M=*/1, Ngu, Kh, 1.f, 0.f);
+  }
+  Tensor gu_all = Tensor::Contiguous(static_cast<uint16_t*>(tls.gu->ptr()), DType::kBF16, dev,
+                                     {G, 2 * I});
+  Tensor act_all = Tensor::Contiguous(static_cast<uint16_t*>(tls.act->ptr()), DType::kBF16, dev,
+                                      {G, I});
+  vt::GeluAndMul(d.q, act_all, gu_all);
+  for (int g = 0; g < G; ++g) {
+    const float alpha = wts[g];
+    const float beta = (g == 0) ? 0.f : 1.f;
+    void* act_g = static_cast<char*>(tls.act->ptr()) + static_cast<size_t>(g) * act_row;
+    vt::MatmulBTFp8Channel(d.q, ysum.ptr(), act_g, fp8_dn[g], s_dn[g], /*M=*/1, Nh, Ki, alpha,
+                           beta);
+  }
+  return true;
 }
 
 // Top-k experts: all gate_up GEMMs → one GeluAndMul → all down GEMMs (alpha/beta mix).
@@ -159,13 +246,110 @@ bool ExpertGeGLUDeviceBatched(Dev /*d*/, DBuf& /*ysum*/, const Tensor& /*x*/,
 
 }  // namespace
 
-// Ensure FP8 expert has BF16 cache filled (idempotent).
+namespace {
+// Bound permanent host BF16 expert packs. Unbounded cache + hipHostRegister OOM'd
+// the 30G box (~27G RSS) during pollution. Default 2 GiB; override VT_GEMMA4_HOST_EXPERT_MB.
+struct HostExpertLru {
+  struct Slot {
+    const Gemma4Fp8ExpertMats* ex = nullptr;
+    size_t bytes = 0;
+    uint64_t tick = 0;
+  };
+  std::vector<Slot> slots;
+  size_t used = 0;
+  uint64_t tick = 1;
+
+  size_t BudgetBytes() const {
+    static const size_t b = []() -> size_t {
+      size_t mb = 2048;
+      if (const char* e = std::getenv("VT_GEMMA4_HOST_EXPERT_MB")) {
+        const long v = std::strtol(e, nullptr, 10);
+        if (v == 0) return size_t{0};
+        if (v > 0) mb = static_cast<size_t>(v);
+      }
+      return mb * static_cast<size_t>(1024ull * 1024ull);
+    }();
+    return b;
+  }
+
+  void EvictOne() {
+    if (slots.empty()) return;
+    size_t victim = 0;
+    for (size_t i = 1; i < slots.size(); ++i) {
+      if (slots[i].tick < slots[victim].tick) victim = i;
+    }
+    auto& s = slots[victim];
+    if (s.ex) {
+      UnpinGemma4Fp8ExpertHostCache(*s.ex);
+      s.ex->cached_gu.clear();
+      s.ex->cached_gu.shrink_to_fit();
+      s.ex->cached_dn.clear();
+      s.ex->cached_dn.shrink_to_fit();
+    }
+    used = used >= s.bytes ? used - s.bytes : 0;
+    slots.erase(slots.begin() + static_cast<std::ptrdiff_t>(victim));
+  }
+
+  void MakeRoom(size_t need) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) {
+      // No permanent host cache — caller should use ephemeral path.
+      return;
+    }
+    while (used + need > bud && !slots.empty()) EvictOne();
+  }
+
+  void Note(const Gemma4Fp8ExpertMats* ex, size_t bytes) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) return;
+    // Already tracked?
+    for (auto& s : slots) {
+      if (s.ex == ex) {
+        s.tick = tick++;
+        return;
+      }
+    }
+    MakeRoom(bytes);
+    if (used + bytes > bud) {
+      // Still no room for a single expert — keep this one untracked; drop immediately
+      // after use is caller's problem. Prefer: allow one oversize by evicting all.
+      while (!slots.empty()) EvictOne();
+    }
+    if (used + bytes > bud) return;
+    slots.push_back(Slot{ex, bytes, tick++});
+    used += bytes;
+  }
+
+  void Touch(const Gemma4Fp8ExpertMats* ex) {
+    for (auto& s : slots) {
+      if (s.ex == ex) {
+        s.tick = tick++;
+        return;
+      }
+    }
+  }
+};
+
+HostExpertLru& HostCacheLru() {
+  static HostExpertLru lru;
+  return lru;
+}
+}  // namespace
+
+// Ensure FP8 expert has BF16 cache filled (idempotent), under host LRU budget.
 void EnsureGemma4Fp8ExpertCached(const Gemma4Fp8ExpertMats& ex, int64_t I, int64_t H) {
   if (!ex.cached_gu.empty() && !ex.cached_dn.empty() &&
       static_cast<int64_t>(ex.cached_gu.size()) == 2 * I * H &&
       static_cast<int64_t>(ex.cached_dn.size()) == H * I) {
+    HostCacheLru().Touch(&ex);
     return;
   }
+  const size_t bytes =
+      (static_cast<size_t>(2 * I * H) + static_cast<size_t>(H * I)) * sizeof(uint16_t);
+  // Budget 0 → do not retain permanent packs (ephemeral-only mode).
+  if (HostCacheLru().BudgetBytes() == 0) return;
+
+  HostCacheLru().MakeRoom(bytes);
   ex.cached_gu.resize(static_cast<size_t>(2 * I * H));
   ex.cached_dn.resize(static_cast<size_t>(H * I));
   DequantFp8ChannelToBf16(ex.gate_w.bytes.data(),
@@ -178,6 +362,7 @@ void EnsureGemma4Fp8ExpertCached(const Gemma4Fp8ExpertMats& ex, int64_t I, int64
                           reinterpret_cast<const uint16_t*>(ex.down_s.bytes.data()), H, I,
                           ex.cached_dn.data());
   PinGemma4Fp8ExpertHostCache(ex);
+  HostCacheLru().Note(&ex, bytes);
 }
 
 // Dequant into caller buffers without retaining a permanent host BF16 cache.
@@ -204,10 +389,10 @@ void DequantGemma4Fp8ExpertToBf16Ephemeral(const Gemma4Fp8ExpertMats& ex, int64_
                           down_out);
 }
 
-// Host BF16 cache + device upload once (subsequent tokens use device GEMM path).
-// H2D is async on d.q — later GEMMs on the same stream see the data without a
-// device-wide Synchronize (was serializing every expert upload).
-// A positive VT_GEMMA4_EXPERT_VRAM_MB caps the expert LRU in MiB; unset/0 is unlimited.
+// Host BF16 cache + optional device upload. H2D is async on d.q.
+// VT_GEMMA4_EXPERT_VRAM_MB: unset/0 = device expert LRU off; N>0 = N MiB fill-only
+// budget (evict only with VT_GEMMA4_EXPERT_EVICT=1). Free VRAM probed via
+// Backend::DeviceMemoryInfo when admitting new experts.
 namespace {
 struct DevExpertLru {
   struct Slot {
@@ -224,22 +409,49 @@ struct DevExpertLru {
   std::vector<Slot> slots;
   size_t used = 0;
   size_t budget = 0;
+  bool budget_set = false;
   uint64_t tick = 1;
   int dev = -1;
 
   size_t BudgetBytes() {
-    if (budget) return budget;
-    size_t mb = 0;
+    if (budget_set) return budget;
+    // unset → 2048 MiB fill-only cache (no eviction by default). "0" → off.
+    // N>0 → N MiB. Eviction opt-in: VT_GEMMA4_EXPERT_EVICT=1.
     if (const char* e = std::getenv("VT_GEMMA4_EXPERT_VRAM_MB")) {
       const long v = std::strtol(e, nullptr, 10);
-      if (v >= 0) mb = static_cast<size_t>(v);
+      if (v == 0) {
+        budget = 0;
+        budget_set = true;
+        return 0;
+      }
+      if (v > 0) {
+        budget = static_cast<size_t>(v) * 1024ull * 1024ull;
+        budget_set = true;
+        return budget;
+      }
     }
-    budget = mb == 0 ? static_cast<size_t>(-1) : mb * 1024ull * 1024ull;
+    budget = 2048ull * 1024ull * 1024ull;  // fill-only default
+    budget_set = true;
     return budget;
+  }
+
+  bool Enabled() { return BudgetBytes() > 0; }
+
+  // Free VRAM via Backend::DeviceMemoryInfo (ROCm/CUDA). No HIP in this TU.
+  static bool FreeBytes(Dev d, size_t* free_out) {
+    *free_out = 0;
+    size_t free_b = 0, tot_b = 0;
+    if (!d.b.DeviceMemoryInfo(&free_b, &tot_b)) return false;
+    *free_out = free_b;
+    return true;
   }
 
   void EvictOne(Dev d) {
     if (slots.empty()) return;
+    // CRITICAL: async H2D/GEMM may still reference the victim. hipFree without
+    // a stream barrier races the compute stream and has been observed as a
+    // permanent kfd_wait hang (GPU idle, prefill done, no decode tokens).
+    d.b.Synchronize(d.q);
     size_t victim = 0;
     for (size_t i = 1; i < slots.size(); ++i)
       if (slots[i].tick < slots[victim].tick) victim = i;
@@ -262,17 +474,49 @@ struct DevExpertLru {
     slots.erase(slots.begin() + static_cast<std::ptrdiff_t>(victim));
   }
 
+  // Evict until bookkeeping budget AND free VRAM (if knowable) can take `need`.
+  // DEFAULT: no hipFree eviction — ROCm hangs in kfd_wait when we free under
+  // load (hoist/pollution). Fill until full, then caller falls back to host H2D.
+  // Opt-in eviction: VT_GEMMA4_EXPERT_EVICT=1.
+  bool MakeRoom(Dev d, size_t need) {
+    const size_t bud = BudgetBytes();
+    if (bud == 0) return false;
+    static const bool allow_evict = [] {
+      const char* e = std::getenv("VT_GEMMA4_EXPERT_EVICT");
+      return e && e[0] == '1';
+    }();
+    constexpr size_t kHeadroom = 1536ull << 20;  // 1.5 GiB after expert — hipMalloc hung at 512MiB
+    constexpr size_t kMaxSlots = 24;             // hard cap; further experts stay host
+    if (slots.size() >= kMaxSlots) return false;
+    if (allow_evict) {
+      while (used + need > bud && !slots.empty()) EvictOne(d);
+    }
+    if (used + need > bud) return false;
+    size_t free_b = 0;
+    // Refuse device upload if free VRAM unknown — Alloc-without-headroom has
+    // hung hipMalloc (hoist start without hoist-done under pollution).
+    if (!FreeBytes(d, &free_b)) return false;
+    if (allow_evict) {
+      int guard = 0;
+      while (free_b < need + kHeadroom && !slots.empty() && guard++ < 256) {
+        EvictOne(d);
+        if (!FreeBytes(d, &free_b)) return false;
+      }
+    }
+    return free_b >= need + kHeadroom;
+  }
+
   void Note(const Gemma4Fp8ExpertMats* ex, void* gu, void* dn, size_t bytes, Dev d,
             void* fp8_gu = nullptr, void* fp8_dn = nullptr, void* s_gu = nullptr,
             void* s_dn = nullptr) {
     if (dev != d.q.device.index) {
+      // Device change: drop bookkeeping only (buffers owned by prior device).
       slots.clear();
       used = 0;
       dev = d.q.device.index;
     }
     const size_t bud = BudgetBytes();
-    while (used + bytes > bud && !slots.empty()) EvictOne(d);
-    if (used + bytes > bud) return;
+    if (used + bytes > bud) return;  // no eviction — drop tracking if over
     slots.push_back(Slot{ex, gu, dn, fp8_gu, fp8_dn, s_gu, s_dn, bytes, tick++});
     used += bytes;
   }
@@ -295,11 +539,14 @@ DevExpertLru& ExpertLru() {
 
 bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t I,
                                    int64_t H) {
-  EnsureGemma4Fp8ExpertCached(ex, I, H);
+  // When device LRU disabled, do NOT host-cache-dequant here — that path was
+  // unbounded (every expert forever) and OOM'd the 30G host (~27G RSS) under pollution.
+  if (!ExpertLru().Enabled()) return false;
   if (ex.dev_gu != nullptr && ex.dev_dn != nullptr) {
     ExpertLru().Touch(&ex);
     return true;
   }
+  EnsureGemma4Fp8ExpertCached(ex, I, H);
   const size_t gu_b = static_cast<size_t>(2 * I * H) * sizeof(uint16_t);
   const size_t dn_b = static_cast<size_t>(H * I) * sizeof(uint16_t);
   const size_t total = gu_b + dn_b;
@@ -307,11 +554,13 @@ bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
   void* dn = nullptr;
   try {
     auto& lru = ExpertLru();
-    while (lru.used + total > lru.BudgetBytes() && !lru.slots.empty()) lru.EvictOne(d);
+    if (!lru.MakeRoom(d, total)) return false;
     gu = d.b.Alloc(gu_b);
     dn = d.b.Alloc(dn_b);
     d.b.Copy(d.q, gu, ex.cached_gu.data(), gu_b);
     d.b.Copy(d.q, dn, ex.cached_dn.data(), dn_b);
+    // Ensure H2D lands before any later free/evict on another admission path.
+    d.b.Synchronize(d.q);
     ex.dev_gu = gu;
     ex.dev_dn = dn;
     lru.Note(&ex, gu, dn, total, d);
@@ -330,6 +579,7 @@ bool EnsureGemma4Fp8ExpertOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
 
 // Upload FP8 weights + channel scales (no BF16 dequant). Half weight VRAM vs BF16 path.
 bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t I, int64_t H) {
+  if (!ExpertLru().Enabled()) return false;
   if (ex.dev_fp8_gu && ex.dev_fp8_dn && ex.dev_s_gu && ex.dev_s_dn) {
     ExpertLru().Touch(&ex);
     return true;
@@ -346,7 +596,7 @@ bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
   void *fgu = nullptr, *fdn = nullptr, *sgu = nullptr, *sdn = nullptr;
   try {
     auto& lru = ExpertLru();
-    while (lru.used + total > lru.BudgetBytes() && !lru.slots.empty()) lru.EvictOne(d);
+    if (!lru.MakeRoom(d, total)) return false;
     fgu = d.b.Alloc(gu_b);
     fdn = d.b.Alloc(dn_b);
     sgu = d.b.Alloc(sgu_b);
@@ -360,6 +610,7 @@ bool EnsureGemma4Fp8NativeOnDevice(Dev d, const Gemma4Fp8ExpertMats& ex, int64_t
     d.b.Copy(d.q, static_cast<char*>(sgu) + static_cast<size_t>(I) * 2, ex.up_s.bytes.data(),
              static_cast<size_t>(I) * 2);
     d.b.Copy(d.q, sdn, ex.down_s.bytes.data(), sdn_b);
+    d.b.Synchronize(d.q);
     ex.dev_fp8_gu = fgu;
     ex.dev_fp8_dn = fdn;
     ex.dev_s_gu = sgu;
@@ -412,7 +663,26 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   using clock = std::chrono::steady_clock;
   const auto t_all0 = profile ? clock::now() : clock::time_point{};
 
-  DBuf rn(d, DType::kBF16, {T, H});
+  // T=1 graph-stable router temps (capture bakes pointers).
+  struct RouterTls {
+    int dev = -1;
+    int64_t T = 0, H = 0, E = 0, K = 0;
+    std::optional<DBuf> rn, logits, rw, ri;
+  };
+  static thread_local RouterTls rt;
+  if (rt.dev != compute_dev || rt.T != T || rt.H != H || rt.E != E || rt.K != top_k ||
+      !rt.rn || !rt.logits || !rt.rw || !rt.ri) {
+    rt.rn.emplace(d, DType::kBF16, std::vector<int64_t>{T, H});
+    rt.logits.emplace(d, DType::kF32, std::vector<int64_t>{T, E});
+    rt.rw.emplace(d, DType::kF32, std::vector<int64_t>{T, top_k});
+    rt.ri.emplace(d, DType::kI32, std::vector<int64_t>{T, top_k});
+    rt.dev = compute_dev;
+    rt.T = T;
+    rt.H = H;
+    rt.E = E;
+    rt.K = top_k;
+  }
+  DBuf& rn = *rt.rn;
   // Identity RMS weight (ones) — TLS, upload once (was H2D every layer/token).
   {
     struct OnesTls {
@@ -435,16 +705,116 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   VT_CHECK(rproj.HasHostBytes() && rproj.nk && rproj.shape[0] == E && rproj.shape[1] == H,
            "gemma4 moe: router proj");
   Tensor wp = ResidentWeight(d, rproj);
-  DBuf logits(d, DType::kF32, {T, E});
+  DBuf& logits = *rt.logits;
   vt::MatmulBT(d.q, logits.t(), rn.t(), wp);
 
   // Device router top-k (softmax + greedy). Only D2H [T,K] weights/indices.
-  DBuf rw(d, DType::kF32, {T, top_k});
-  DBuf ri(d, DType::kI32, {T, top_k});
+  DBuf& rw = *rt.rw;
+  DBuf& ri = *rt.ri;
   vt::MoeRouterTopKArgs rargs;
   rargs.top_k = top_k;
   rargs.renormalize = true;
   vt::MoeRouterTopK(d.q, rw.t(), ri.t(), logits.t(), rargs);
+
+  const auto& ex = moe.experts;
+  const int64_t gu_stride = 2 * I * H;
+  const int64_t dn_stride = H * I;
+  const bool same_dev =
+      ex.gate_up_dev != nullptr && ex.down_dev != nullptr && ex.dev_id == compute_dev;
+  const bool fp8_res =
+      ex.fp8_native_resident && !ex.fp8.empty() && ex.fp8[0].dev_fp8_gu != nullptr &&
+      ex.fp8_gu_base != nullptr && ex.dev_id >= 0;
+  const bool fp8_res_same = fp8_res && ex.dev_id == compute_dev;
+  const bool fp8_res_peer = fp8_res && ex.dev_id != compute_dev;
+
+  // Decode T=1: fully device MoE — no router D2H, no host top-k gather.
+  if (T == 1 && fp8_res && top_k <= 8 && top_k > 0) {
+    // per-expert scale on device (once per layer/E).
+    struct EscTls {
+      int dev = -1;
+      int64_t E = 0;
+      const void* host_key = nullptr;
+      std::optional<DBuf> sc;
+    };
+    static thread_local EscTls esc;
+    float* escale_ptr = nullptr;
+    if (moe.per_expert_scale.HasHostBytes()) {
+      const void* hk = moe.per_expert_scale.bytes.data();
+      if (esc.dev != compute_dev || esc.E != E || esc.host_key != hk || !esc.sc) {
+        std::vector<float> hs(static_cast<size_t>(E), 1.f);
+        const auto* pe = reinterpret_cast<const uint16_t*>(moe.per_expert_scale.bytes.data());
+        for (int64_t e = 0; e < E; ++e) hs[static_cast<size_t>(e)] = vt::BF16ToF32(pe[e]);
+        esc.sc.emplace(d, DType::kF32, std::vector<int64_t>{E}, hs.data());
+        esc.dev = compute_dev;
+        esc.E = E;
+        esc.host_key = hk;
+      }
+      escale_ptr = static_cast<float*>(esc.sc->ptr());
+      vt::ApplyExpertScaleRw(d.q, static_cast<float*>(rw.ptr()), static_cast<const int32_t*>(ri.ptr()),
+                             escale_ptr, top_k, static_cast<int>(E));
+    }
+
+    // Stable T=1 acc for hipGraph (do not pool-Release).
+    struct AccFastTls {
+      int dev = -1;
+      int64_t H = 0;
+      std::optional<DBuf> acc;
+    };
+    static thread_local AccFastTls aft;
+    if (aft.dev != d.q.device.index || aft.H != H || !aft.acc) {
+      aft.acc.emplace(d, DType::kBF16, std::vector<int64_t>{T, H});
+      aft.dev = d.q.device.index;
+      aft.H = H;
+    }
+    DBuf& acc_fast = *aft.acc;
+    // expert_in is already [1,H] bf16 on device
+    const void* xin = expert_in.data;
+    void* yout = acc_fast.ptr();
+    bool ok = false;
+    if (fp8_res_same) {
+      ok = vt::ExpertGeGLUFp8TopKIndexed(
+          d.q, yout, xin, ex.fp8_gu_base, ex.fp8_dn_base, ex.fp8_sgu_base, ex.fp8_sdn_base,
+          static_cast<const int32_t*>(ri.ptr()), static_cast<const float*>(rw.ptr()), top_k,
+          static_cast<int>(I), static_cast<int>(H));
+    } else if (fp8_res_peer) {
+      ok = RunGemma4Fp8TopKIndexedOnExpertDevice(
+          d.q, ex.dev_id, yout, xin, ex.fp8_gu_base, ex.fp8_dn_base, ex.fp8_sgu_base,
+          ex.fp8_sdn_base, static_cast<const int32_t*>(ri.ptr()),
+          static_cast<const float*>(rw.ptr()), top_k, static_cast<int>(I), static_cast<int>(H));
+    }
+    if (ok) {
+      const auto t_router1 = profile ? clock::now() : clock::time_point{};
+      Gemma4MoeScratch r;
+      r.tensor = acc_fast.t();
+      r.storage = std::shared_ptr<void>(acc_fast.ptr(), [](void*) {});
+      if (profile) {
+        d.b.Synchronize(d.q);
+        const auto t_all1 = clock::now();
+        static std::atomic<uint64_t> ncalls{0};
+        static std::atomic<uint64_t> us_router{0};
+        static std::atomic<uint64_t> us_total{0};
+        const auto ur =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_router1 - t_all0).count();
+        const auto ut =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_all1 - t_all0).count();
+        us_router.fetch_add(static_cast<uint64_t>(ur), std::memory_order_relaxed);
+        us_total.fetch_add(static_cast<uint64_t>(ut), std::memory_order_relaxed);
+        const uint64_t c = ncalls.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (c == 1 || c % 64 == 0) {
+          const uint64_t tr = us_router.load(std::memory_order_relaxed);
+          const uint64_t tt = us_total.load(std::memory_order_relaxed);
+          std::fprintf(stderr,
+                       "gemma4 moe profile: calls=%llu router_us/call=%.1f expert+rest_us/call=%.1f "
+                       "total_us/call=%.1f (router%%=%.0f) [indexed-device]\n",
+                       static_cast<unsigned long long>(c), static_cast<double>(tr) / c,
+                       static_cast<double>(tt - tr) / c, static_cast<double>(tt) / c,
+                       tt ? 100.0 * static_cast<double>(tr) / static_cast<double>(tt) : 0.0);
+        }
+      }
+      return r;
+    }
+    // fall through to legacy host-gather path
+  }
 
   std::vector<float> hw(static_cast<size_t>(T * top_k));
   std::vector<int32_t> hi(static_cast<size_t>(T * top_k));
@@ -467,12 +837,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       if (e >= 0 && e < static_cast<int>(E)) hw[o] *= hscale[static_cast<size_t>(e)];
     }
   }
-
-  const auto& ex = moe.experts;
-  const int64_t gu_stride = 2 * I * H;
-  const int64_t dn_stride = H * I;
-  const bool same_dev =
-      ex.gate_up_dev != nullptr && ex.down_dev != nullptr && ex.dev_id == compute_dev;
+  const bool need_peer_sc = (!same_dev && ex.gate_up_dev && ex.down_dev && ex.dev_id >= 0) ||
+                            fp8_res_peer;
 
   const auto* gu_host = ex.gate_up.Empty()
                             ? nullptr
@@ -480,7 +846,28 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   const auto* dn_host =
       ex.down.Empty() ? nullptr : reinterpret_cast<const uint16_t*>(ex.down.bytes.data());
 
-  DBuf acc(d, DType::kBF16, {T, H});
+  // Graph-stable decode scratch: do not pool-Release acc when T==1 (hipGraph bakes ptr).
+  struct AccTls {
+    int dev = -1;
+    int64_t T = 0, H = 0;
+    std::optional<DBuf> acc;
+  };
+  static thread_local AccTls acc_tls;
+  DBuf* acc_ptr = nullptr;
+  std::optional<DBuf> acc_owned;
+  if (T == 1) {
+    if (acc_tls.dev != d.q.device.index || acc_tls.T != T || acc_tls.H != H || !acc_tls.acc) {
+      acc_tls.acc.emplace(d, DType::kBF16, std::vector<int64_t>{T, H});
+      acc_tls.dev = d.q.device.index;
+      acc_tls.T = T;
+      acc_tls.H = H;
+    }
+    acc_ptr = &*acc_tls.acc;
+  } else {
+    acc_owned.emplace(d, DType::kBF16, std::vector<int64_t>{T, H});
+    acc_ptr = &*acc_owned;
+  }
+  DBuf& acc = *acc_ptr;
   acc.Zero(d);
 
   // Reuse MoE decode scratch across layers (30 layers × every token was thrashing the pool).
@@ -490,7 +877,9 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     std::unique_ptr<ExpertScratch> esc;
     std::optional<DBuf> xin, ysum, y, ysc;
     std::optional<DBuf> gu_sc, dn_sc;
+    std::optional<DBuf> fp8_gu_sc, fp8_dn_sc, fp8_sgu_sc, fp8_sdn_sc;
     bool have_peer = false;
+    bool have_fp8_peer = false;
     std::vector<uint16_t> gu_tmp, dn_tmp;
   };
   static thread_local MoeTlsScratch tls;
@@ -502,7 +891,12 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     tls.ysc.emplace(d, DType::kBF16, std::vector<int64_t>{1, H});
     tls.gu_sc.reset();
     tls.dn_sc.reset();
+    tls.fp8_gu_sc.reset();
+    tls.fp8_dn_sc.reset();
+    tls.fp8_sgu_sc.reset();
+    tls.fp8_sdn_sc.reset();
     tls.have_peer = false;
+    tls.have_fp8_peer = false;
     tls.gu_tmp.clear();
     tls.dn_tmp.clear();
     tls.dev = compute_dev;
@@ -514,12 +908,17 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   DBuf& ysum = *tls.ysum;
   DBuf& y = *tls.y;
   DBuf& ysc = *tls.ysc;
-  const bool need_peer_sc =
-      ex.gate_up_dev != nullptr && ex.down_dev != nullptr && !same_dev;
-  if (need_peer_sc && !tls.have_peer) {
+  if (need_peer_sc && !fp8_res_peer && !tls.have_peer) {
     tls.gu_sc.emplace(d, DType::kBF16, std::vector<int64_t>{2 * I, H});
     tls.dn_sc.emplace(d, DType::kBF16, std::vector<int64_t>{H, I});
     tls.have_peer = true;
+  }
+  if (fp8_res_peer && !tls.have_fp8_peer) {
+    tls.fp8_gu_sc.emplace(d, DType::kI8, std::vector<int64_t>{2 * I * H});
+    tls.fp8_dn_sc.emplace(d, DType::kI8, std::vector<int64_t>{H * I});
+    tls.fp8_sgu_sc.emplace(d, DType::kBF16, std::vector<int64_t>{2 * I});
+    tls.fp8_sdn_sc.emplace(d, DType::kBF16, std::vector<int64_t>{H});
+    tls.have_fp8_peer = true;
   }
   std::optional<DBuf>& gu_sc = tls.gu_sc;
   std::optional<DBuf>& dn_sc = tls.dn_sc;
@@ -539,7 +938,10 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   }();
   static const bool fp8_native = [] {
     const char* e = std::getenv("VT_GEMMA4_FP8_NATIVE");
-    return e && e[0] == '1';
+    // Default ON: use fused FP8 expert kernels when packs/LRU available.
+    // =0 forces BF16 device/host paths only.
+    if (e == nullptr) return true;
+    return e[0] == '1';
   }();
   static const bool custom_expert = [] {
     const char* e = std::getenv("VT_GEMMA4_CUSTOM_EXPERT");
@@ -548,7 +950,284 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
   std::vector<uint16_t> hsum;
   if (host_axpy) hsum.assign(static_cast<size_t>(H), vt::F32ToBF16(0.f));
 
+  // Device expert cache: DECODE-ONLY (T==1), fill-only. NO bulk hoist — pre-upload
+  // of top_k experts hung hipMalloc (hoist without hoist-done). Lazy Ensure in the
+  // expert loop only. Prefill stays host. Opt out: EXPERT_VRAM_MB=0.
+  static const bool moe_trace = [] {
+    const char* e = std::getenv("VT_GEMMA4_LAYER_TRACE");
+    return e && e[0] == '2';
+  }();
+  const bool use_dev_expert_lru =
+      (T == 1) && ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr && ExpertLru().Enabled();
+  // Lazy Ensure only (below). Bulk hoist removed — was the pollution hang site.
+  (void)moe_trace;
+
+  // Prefill batch MoE: group tokens by expert, one hipBLAS GEMM per expert chunk.
+  // Auto ON when BF16 device-resident same-GPU OR native FP8 resident (any GPU —
+  // dequant ephemeral → BF16 GEMM). Native FP8 decode stays M=1 fused GEMV;
+  // without this, prefill is serial M=1 × T and crawls (~13 tok/s on 40k).
+  // Explicit VT_GEMMA4_PREFILL_BATCH_MOE=0/1 overrides.
+  // hipBLASLt FP8 W8A8 was microbench'd slower than BF16 GemmEx at all M on
+  // gfx1201 — do not route prefill through Lt FP8 (see fp8_lt_prefill_m log).
+  static const int prefill_batch_env = [] {
+    const char* e = std::getenv("VT_GEMMA4_PREFILL_BATCH_MOE");
+    if (e == nullptr) return -1;  // auto
+    return (e[0] == '1') ? 1 : 0;
+  }();
+  // Prefer fused M=1 FP8 for short T (decode + tiny prefills). Batch dequant+GEMM
+  // only pays off once enough tokens share experts (lab: T=818 ~3×, T=6k ~6×;
+  // T=13 was slower than fused M=1).
+  constexpr int64_t kPrefillBatchMinT = 64;
+  const bool prefill_batch_moe =
+      (T >= kPrefillBatchMinT) && !host_axpy &&
+      ((prefill_batch_env == 1) ||
+       (prefill_batch_env < 0 && (same_dev || fp8_res)));
+  if (prefill_batch_moe) {
+    // One-shot path breadcrumb (always on) so we can prove this arm fired.
+    static std::atomic<int> batch_enter{0};
+    if (batch_enter.fetch_add(1) < 3) {
+      std::fprintf(stderr,
+                   "INFO gemma4-moe ENTER prefill-batch T=%lld same_dev=%d fp8_res=%d "
+                   "fp8_res_same=%d env=%d\n",
+                   static_cast<long long>(T), same_dev ? 1 : 0, fp8_res ? 1 : 0,
+                   fp8_res_same ? 1 : 0, prefill_batch_env);
+      std::fflush(stderr);
+    }
+    const vt::Device dev = d.q.device;
+    std::vector<std::vector<int32_t>> etok(static_cast<size_t>(E));
+    std::vector<std::vector<float>> ewt(static_cast<size_t>(E));
+    for (int64_t t = 0; t < T; ++t) {
+      for (int k = 0; k < top_k; ++k) {
+        const size_t o = static_cast<size_t>(t * top_k + k);
+        const int e = static_cast<int>(hi[o]);
+        if (e < 0 || e >= static_cast<int>(E)) continue;
+        etok[static_cast<size_t>(e)].push_back(static_cast<int32_t>(t));
+        ewt[static_cast<size_t>(e)].push_back(hw[o]);
+      }
+    }
+    int64_t max_n = 0;
+    for (int64_t e = 0; e < E; ++e) {
+      max_n = std::max<int64_t>(max_n, static_cast<int64_t>(etok[static_cast<size_t>(e)].size()));
+    }
+    if (max_n > 0) {
+      // Cap GeGLU M per expert chunk. Larger M cuts launch count on long prefills
+      // (lab A/B via VT_GEMMA4_PREFILL_GEMM_M). Cap 8192 for hot experts.
+      static const int64_t kMaxGemmM = []() -> int64_t {
+        if (const char* e = std::getenv("VT_GEMMA4_PREFILL_GEMM_M")) {
+          const long v = std::strtol(e, nullptr, 10);
+          if (v >= 16 && v <= 8192) return static_cast<int64_t>(v);
+        }
+        return 2048;  // 2026-08-10: 512→2048 ~+80 eng @11k vs WMMA baseline
+      }();
+      // Peer-act: run GeGLU on expert GPU; peer only activations.
+      // Default ON — 2026-08-10 A/B @~11k: ~2016 → ~2056 eng (+40) after SharedK-WMMA+GEMM_M=2048.
+      // VT_GEMMA4_PREFILL_PEER_ACT=0 to disable (weight PeerCopy path).
+      static const bool kPrefillPeerAct = [] {
+        const char* e = std::getenv("VT_GEMMA4_PREFILL_PEER_ACT");
+        if (e == nullptr) return true;
+        return e[0] != '0';
+      }();
+      const int64_t scratch_n = std::min(max_n, kMaxGemmM);
+      ExpertScratch besc(d, scratch_n, I, H);
+      DBuf bx(d, DType::kBF16, {scratch_n, H});
+      DBuf by(d, DType::kBF16, {scratch_n, H});
+      // Device token-id / weight rows for gather+scatter (pure GPU path).
+      DBuf d_tids(d, DType::kI32, {scratch_n});
+      DBuf d_wts(d, DType::kF32, {scratch_n});
+      std::vector<int32_t> h_tids(static_cast<size_t>(scratch_n));
+      std::vector<float> h_wts(static_cast<size_t>(scratch_n));
+      // Zero MoE output accumulator on device (no host hacc).
+      vt::MoeZeroBf16(d.q, acc.ptr(), static_cast<int64_t>(T) * H);
+      int experts_run = 0;
+      int peer_act_hits = 0;
+      bool batch_ok = true;
+      for (int64_t e = 0; e < E; ++e) {
+              const auto& toks = etok[static_cast<size_t>(e)];
+              if (toks.empty()) continue;
+              const auto& wts_e = ewt[static_cast<size_t>(e)];
+              const int64_t n_all = static_cast<int64_t>(toks.size());
+
+              const uint16_t* gu_p = nullptr;
+              const uint16_t* dn_p = nullptr;
+              const uint16_t* gu_host_e = nullptr;
+              const uint16_t* dn_host_e = nullptr;
+              const void* fp8_gu_p = nullptr;
+              const void* fp8_dn_p = nullptr;
+              const void* s_gu_p = nullptr;
+              const void* s_dn_p = nullptr;
+              const void* fp8_weight_id = nullptr;
+              bool use_device_w = false;
+              bool use_fp8_dev = false;
+              bool use_peer_act = false;
+              if (same_dev) {
+                gu_p = static_cast<const uint16_t*>(ex.gate_up_dev) + e * gu_stride;
+                dn_p = static_cast<const uint16_t*>(ex.down_dev) + e * dn_stride;
+                use_device_w = true;
+              } else if (ex.is_fp8) {
+                auto& fex = ex.fp8[static_cast<size_t>(e)];
+                // Pure GPU: native FP8 packs. Same-device direct; peer-act preferred.
+                if (fex.dev_fp8_gu && fex.dev_fp8_dn && fex.dev_s_gu && fex.dev_s_dn) {
+                  if (ex.dev_id == compute_dev || ex.dev_id < 0) {
+                    fp8_gu_p = fex.dev_fp8_gu;
+                    fp8_dn_p = fex.dev_fp8_dn;
+                    s_gu_p = fex.dev_s_gu;
+                    s_dn_p = fex.dev_s_dn;
+                    fp8_weight_id = fex.dev_fp8_gu;
+                    use_fp8_dev = true;
+                  } else if (kPrefillPeerAct) {
+                    // Weights stay on expert_dev; GeGLU runs there (see chunk loop).
+                    fp8_gu_p = fex.dev_fp8_gu;
+                    fp8_dn_p = fex.dev_fp8_dn;
+                    s_gu_p = fex.dev_s_gu;
+                    s_dn_p = fex.dev_s_dn;
+                    fp8_weight_id = fex.dev_fp8_gu;
+                    use_peer_act = true;
+                  } else {
+                    struct PeerTls {
+                      int dev = -1;
+                      int64_t I = 0, H = 0;
+                      std::optional<DBuf> gu, dn, sgu, sdn;
+                    };
+                    static thread_local PeerTls pt;
+                    if (pt.dev != compute_dev || pt.I != I || pt.H != H) {
+                      pt.gu.emplace(d, DType::kI8, std::vector<int64_t>{2 * I * H});
+                      pt.dn.emplace(d, DType::kI8, std::vector<int64_t>{H * I});
+                      pt.sgu.emplace(d, DType::kBF16, std::vector<int64_t>{2 * I});
+                      pt.sdn.emplace(d, DType::kBF16, std::vector<int64_t>{H});
+                      pt.dev = compute_dev;
+                      pt.I = I;
+                      pt.H = H;
+                    }
+                    if (!PeerCopyGemma4Fp8ExpertSlice(ex.dev_id, fex.dev_fp8_gu, fex.dev_fp8_dn,
+                                                     fex.dev_s_gu, fex.dev_s_dn, I, H, compute_dev,
+                                                     pt.gu->ptr(), pt.dn->ptr(), pt.sgu->ptr(),
+                                                     pt.sdn->ptr())) {
+                      batch_ok = false;
+                      break;
+                    }
+                    fp8_gu_p = pt.gu->ptr();
+                    fp8_dn_p = pt.dn->ptr();
+                    s_gu_p = pt.sgu->ptr();
+                    s_dn_p = pt.sdn->ptr();
+                    fp8_weight_id = fex.dev_fp8_gu;
+                    use_fp8_dev = true;
+                  }
+                } else if (use_dev_expert_lru && !fp8_native &&
+                           EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
+                  gu_p = static_cast<const uint16_t*>(fex.dev_gu);
+                  dn_p = static_cast<const uint16_t*>(fex.dev_dn);
+                  use_device_w = true;
+                } else {
+                  batch_ok = false;
+                  break;
+                }
+              } else if (gu_host && dn_host) {
+                gu_host_e = gu_host + e * gu_stride;
+                dn_host_e = dn_host + e * dn_stride;
+              } else {
+                batch_ok = false;
+                break;
+              }
+
+              for (int64_t base = 0; base < n_all; base += kMaxGemmM) {
+                const int64_t n = std::min(kMaxGemmM, n_all - base);
+                for (int64_t i = 0; i < n; ++i) {
+                  h_tids[static_cast<size_t>(i)] = toks[static_cast<size_t>(base + i)];
+                  h_wts[static_cast<size_t>(i)] = wts_e[static_cast<size_t>(base + i)];
+                }
+                d.b.Copy(d.q, d_tids.ptr(), h_tids.data(),
+                         static_cast<size_t>(n) * sizeof(int32_t));
+                d.b.Copy(d.q, d_wts.ptr(), h_wts.data(), static_cast<size_t>(n) * sizeof(float));
+                // Gather expert_in rows → bx on GPU
+                vt::MoeGatherRows(d.q, bx.ptr(), expert_in.data,
+                                  static_cast<const int32_t*>(d_tids.ptr()), static_cast<int>(n),
+                                  static_cast<int>(H));
+                Tensor x = Tensor::Contiguous(bx.ptr(), DType::kBF16, dev, {n, H});
+                if (use_peer_act) {
+                  if (!RunGemma4Fp8ExpertGeGLUPrefillOnExpertDevice(
+                          d.q, ex.dev_id, by.ptr(), bx.ptr(), fp8_gu_p, s_gu_p, fp8_dn_p, s_dn_p,
+                          static_cast<int>(n), static_cast<int>(I), static_cast<int>(H))) {
+                    batch_ok = false;
+                    break;
+                  }
+                  ++peer_act_hits;
+                } else if (use_fp8_dev) {
+                  ExpertGeGLUFp8Native(d, by, x, fp8_gu_p, s_gu_p, fp8_dn_p, s_dn_p, I, H, besc, 1.f,
+                                       0.f, fp8_weight_id);
+                } else if (use_device_w) {
+                  ExpertGeGLUDeviceAccum(d, by, x, gu_p, dn_p, I, H, besc, 1.f, 0.f);
+                } else {
+                  ExpertGeGLUHost(d, by, x, gu_host_e, dn_host_e, I, H, besc,
+                                  ex.is_fp8 ? &ex.fp8[static_cast<size_t>(e)] : nullptr);
+                }
+                // Weighted scatter-add into acc on GPU (sequential experts → same token OK)
+                vt::MoeWeightedScatterAdd(d.q, acc.ptr(), by.ptr(),
+                                          static_cast<const int32_t*>(d_tids.ptr()),
+                                          static_cast<const float*>(d_wts.ptr()), static_cast<int>(n),
+                                          static_cast<int>(H));
+              }
+              if (!batch_ok) break;
+              ++experts_run;
+            }
+            if (batch_ok) {
+            // No host Synchronize: acc stays on-device; DualRmsNorm/next layer share
+            // the same queue. (Was a full-device stall after every MoE layer prefill.)
+            if (moe_trace) {
+              d.b.Synchronize(d.q);  // only so stderr timing is meaningful
+              std::fprintf(stderr,
+                           "INFO gemma4-moe prefill-batch T=%lld experts_run=%d max_n=%lld "
+                           "chunk=%lld fp8_res=%d same_dev=%d peer_act_hits=%d "
+                           "(gpu-fp8+scatter)\n",
+                           static_cast<long long>(T), experts_run, static_cast<long long>(max_n),
+                           static_cast<long long>(kMaxGemmM), fp8_res ? 1 : 0, same_dev ? 1 : 0,
+                           peer_act_hits);
+              std::fflush(stderr);
+            }
+            static std::atomic<int> peer_act_log{0};
+            if (peer_act_hits > 0 && peer_act_log.fetch_add(1) < 3) {
+              std::fprintf(stderr,
+                           "INFO gemma4-moe prefill PEER_ACT hits=%d experts_run=%d T=%lld "
+                           "(weights stayed on expert GPU)\n",
+                           peer_act_hits, experts_run, static_cast<long long>(T));
+              std::fflush(stderr);
+            }
+      Gemma4MoeScratch r;
+      r.tensor = acc.t();
+      const size_t alloc = acc.alloc_bytes();
+      void* p = acc.Release();
+      r.storage = std::shared_ptr<void>(p, [alloc](void* q) { Pool().Put(alloc, q); });
+      if (profile) {
+        const auto t_all1 = clock::now();
+        static std::atomic<uint64_t> ncalls{0};
+        static std::atomic<uint64_t> us_router{0};
+        static std::atomic<uint64_t> us_total{0};
+        const auto ur =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_router1 - t_all0).count();
+        const auto ut =
+            std::chrono::duration_cast<std::chrono::microseconds>(t_all1 - t_all0).count();
+        us_router.fetch_add(static_cast<uint64_t>(ur), std::memory_order_relaxed);
+        us_total.fetch_add(static_cast<uint64_t>(ut), std::memory_order_relaxed);
+        const uint64_t c = ncalls.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (c == 1 || c % 64 == 0) {
+          const uint64_t tr = us_router.load(std::memory_order_relaxed);
+          const uint64_t tt = us_total.load(std::memory_order_relaxed);
+          std::fprintf(stderr,
+                       "gemma4 moe profile: calls=%llu router_us/call=%.1f expert+rest_us/call=%.1f "
+                       "total_us/call=%.1f (router%%=%.0f) [prefill-batch-gpu-scatter]\n",
+                       static_cast<unsigned long long>(c), static_cast<double>(tr) / c,
+                       static_cast<double>(tt - tr) / c, static_cast<double>(tt) / c,
+                       tt ? 100.0 * static_cast<double>(tr) / static_cast<double>(tt) : 0.0);
+        }
+      }
+      return r;
+      }  // batch_ok — else fall through to serial GPU MoE
+    }
+  }
+
   for (int64_t t = 0; t < T; ++t) {
+    // Drain previous token's device work before starting the next (prefill only).
+    if (T > 1 && t > 0) d.b.Synchronize(d.q);
+
     std::vector<int> idx(static_cast<size_t>(top_k));
     std::vector<float> wts(static_cast<size_t>(top_k));
     for (int i = 0; i < top_k; ++i) {
@@ -567,35 +1246,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     }
     // device path: first expert MulScalar writes ysum (no Zero needed)
 
-    // Prefetch BF16 caches for this token's top-k experts in parallel (cold only).
-    if (ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr) {
-      bool any_cold = false;
-      for (int i = 0; i < top_k; ++i) {
-        const auto& fex = ex.fp8[static_cast<size_t>(idx[static_cast<size_t>(i)])];
-        if (fex.cached_gu.empty() || fex.cached_dn.empty()) {
-          any_cold = true;
-          break;
-        }
-      }
-      if (any_cold) {
-        Fp8DequantBeginOuterParallel();
-        std::vector<std::thread> pref;
-        pref.reserve(static_cast<size_t>(top_k));
-        for (int i = 0; i < top_k; ++i) {
-          const int e = idx[static_cast<size_t>(i)];
-          pref.emplace_back([&, e] {
-            EnsureGemma4Fp8ExpertCached(ex.fp8[static_cast<size_t>(e)], I, H);
-          });
-        }
-        for (auto& th : pref) th.join();
-        Fp8DequantEndOuterParallel();
-      }
-    }
-
-    // Prefetch: queue device expert H2D for all top-k before any GEMM (same stream).
-    // Skip when fused resident packs exist (same_dev or peer) — those are the source of truth
-    // and VRAM is already tight after full resident upload.
-    if (ex.is_fp8 && !same_dev && ex.gate_up_dev == nullptr) {
+    // Decode-only device Ensure (Touch/fallback). Prefill skips device LRU.
+    if (use_dev_expert_lru) {
       for (int i = 0; i < top_k; ++i) {
         const int e = idx[static_cast<size_t>(i)];
         if (e >= 0 && e < static_cast<int>(E)) {
@@ -634,8 +1286,8 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       }
     }
 
-    // Batched path: VT_GEMMA4_BATCH_EXPERTS=1 (default off).
-    if (batch_experts && ex.is_fp8 && !host_axpy) {
+    // Batched path: VT_GEMMA4_BATCH_EXPERTS=1 (default off). Decode-only device.
+    if (batch_experts && ex.is_fp8 && !host_axpy && T == 1) {
       std::vector<const uint16_t*> gu_ptrs;
       std::vector<const uint16_t*> dn_ptrs;
       gu_ptrs.reserve(static_cast<size_t>(top_k));
@@ -660,9 +1312,63 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
       }
     }
 
-    // Fused-Gelu top-k: gate_up×G → one GeluAndMul → down×G (default BF16 device path).
+    // Fused-Gelu top-k FP8 native (resident or LRU). xin is always 1×H in this loop.
+    if (!host_axpy && (fp8_native || fp8_res) && ex.is_fp8) {
+      std::vector<const void*> fgu, sgu, fdn, sdn;
+      fgu.reserve(static_cast<size_t>(top_k));
+      sgu.reserve(static_cast<size_t>(top_k));
+      fdn.reserve(static_cast<size_t>(top_k));
+      sdn.reserve(static_cast<size_t>(top_k));
+      bool ok = true;
+      for (int i = 0; i < top_k && ok; ++i) {
+        const int e = idx[static_cast<size_t>(i)];
+        const auto& fex = ex.fp8[static_cast<size_t>(e)];
+        if (fex.dev_fp8_gu && fex.dev_fp8_dn && fex.dev_s_gu && fex.dev_s_dn) {
+          fgu.push_back(fex.dev_fp8_gu);
+          sgu.push_back(fex.dev_s_gu);
+          fdn.push_back(fex.dev_fp8_dn);
+          sdn.push_back(fex.dev_s_dn);
+        } else if (!fp8_res_peer && EnsureGemma4Fp8NativeOnDevice(d, fex, I, H)) {
+          fgu.push_back(fex.dev_fp8_gu);
+          sgu.push_back(fex.dev_s_gu);
+          fdn.push_back(fex.dev_fp8_dn);
+          sdn.push_back(fex.dev_s_dn);
+        } else {
+          ok = false;
+        }
+      }
+      bool ran = false;
+      void* acc_row = static_cast<char*>(acc.ptr()) +
+                      static_cast<size_t>(t) * static_cast<size_t>(H) * 2;
+      if (ok && static_cast<int>(fgu.size()) == top_k) {
+        if (fp8_res_peer) {
+          // Weights stay on expert GPU; move activations only (Phase-1 peer tax fix).
+          // Write straight into acc row — skip ysum staging copy.
+          ran = RunGemma4Fp8TopKOnExpertDevice(
+              d.q, ex.dev_id, acc_row, xin.ptr(), fgu.data(), sgu.data(), fdn.data(),
+              sdn.data(), wts.data(), top_k, static_cast<int>(I), static_cast<int>(H));
+        } else {
+          ran = vt::ExpertGeGLUFp8TopKM1(d.q, acc_row, xin.ptr(), fgu.data(), sgu.data(),
+                                         fdn.data(), sdn.data(), wts.data(), top_k,
+                                         static_cast<int>(I), static_cast<int>(H));
+          if (!ran) {
+            ran = ExpertGeGLUFp8TopKFusedGelu(d, ysum, xin.t(), fgu.data(), sgu.data(), fdn.data(),
+                                              sdn.data(), wts.data(), top_k, I, H);
+            if (ran) {
+              d.b.Copy(d.q, acc_row, ysum.ptr(), static_cast<size_t>(H) * 2);
+            }
+          }
+        }
+      }
+      if (ran) {
+        continue;
+      }
+    }
+
+    // Fused-Gelu top-k BF16 device path (resident gate_up_dev or LRU BF16).
     // Optional custom RDNA4 expert kernels: VT_GEMMA4_CUSTOM_EXPERT=1
-    if (!host_axpy && T == 1 && !fp8_native) {
+    // Always try when BF16 stacks are on this GPU; peer BF16 uses serial+PeerCopy.
+    if (!host_axpy && !fp8_res) {
       std::vector<const uint16_t*> gu_p, dn_p;
       gu_p.reserve(static_cast<size_t>(top_k));
       dn_p.reserve(static_cast<size_t>(top_k));
@@ -710,6 +1416,7 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
               d.q,
               static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
               ysum.ptr(), static_cast<size_t>(H) * 2);
+          d.b.Synchronize(d.q);
           continue;
         }
       }
@@ -728,7 +1435,23 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
             static_cast<const uint16_t*>(ex.down_dev) + static_cast<int64_t>(e) * dn_stride;
         ExpertGeGLUDeviceAccum(d, ysum, xin.t(), gu, dn, I, H, esc, ww, beta);
         fused_mix = true;
-      } else if (fp8_native && ex.is_fp8 && T == 1) {
+      } else if (fp8_res_same && ex.is_fp8) {
+        const auto& fex = ex.fp8[static_cast<size_t>(e)];
+        ExpertGeGLUFp8Native(d, ysum, xin.t(), fex.dev_fp8_gu, fex.dev_s_gu, fex.dev_fp8_dn,
+                             fex.dev_s_dn, I, H, esc, ww, beta);
+        fused_mix = true;
+      } else if (fp8_res_peer && ex.is_fp8 && tls.fp8_gu_sc && tls.fp8_dn_sc && tls.fp8_sgu_sc &&
+                 tls.fp8_sdn_sc) {
+        const auto& fex = ex.fp8[static_cast<size_t>(e)];
+        if (PeerCopyGemma4Fp8ExpertSlice(ex.dev_id, fex.dev_fp8_gu, fex.dev_fp8_dn, fex.dev_s_gu,
+                                         fex.dev_s_dn, I, H, compute_dev, tls.fp8_gu_sc->ptr(),
+                                         tls.fp8_dn_sc->ptr(), tls.fp8_sgu_sc->ptr(),
+                                         tls.fp8_sdn_sc->ptr())) {
+          ExpertGeGLUFp8Native(d, ysum, xin.t(), tls.fp8_gu_sc->ptr(), tls.fp8_sgu_sc->ptr(),
+                               tls.fp8_dn_sc->ptr(), tls.fp8_sdn_sc->ptr(), I, H, esc, ww, beta);
+          fused_mix = true;
+        }
+      } else if (fp8_native && ex.is_fp8) {
         const auto& fex = ex.fp8[static_cast<size_t>(e)];
         if (EnsureGemma4Fp8NativeOnDevice(d, fex, I, H)) {
           ExpertGeGLUFp8Native(d, ysum, xin.t(), fex.dev_fp8_gu, fex.dev_s_gu, fex.dev_fp8_dn,
@@ -745,32 +1468,42 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
         } else if (ex.is_fp8) {
           const auto& fex = ex.fp8[static_cast<size_t>(e)];
           DequantGemma4Fp8ExpertToBf16Ephemeral(fex, I, H, gu_tmp.data(), dn_tmp.data());
-          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc);
+          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc, &fex);
         } else {
           VT_CHECK(gu_host && dn_host, "gemma4 moe: peer fail no host");
           ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
-                          dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc);
+                          dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc,
+                          gu_host + static_cast<int64_t>(e) * gu_stride);
         }
       } else if (ex.is_fp8) {
-        const auto& fex = ex.fp8[static_cast<size_t>(e)];
-        if (EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
-          ExpertGeGLUDeviceAccum(d, ysum, xin.t(), static_cast<const uint16_t*>(fex.dev_gu),
-                                 static_cast<const uint16_t*>(fex.dev_dn), I, H, esc, ww,
-                                 beta);
-          fused_mix = true;
-        } else {
-          EnsureGemma4Fp8ExpertCached(fex, I, H);
-          ExpertGeGLUHost(d, y, xin.t(), fex.cached_gu.data(), fex.cached_dn.data(), I, H,
-                          esc);
-        }
-      } else if (gu_host && dn_host) {
-        ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
-                        dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc);
+      const auto& fex = ex.fp8[static_cast<size_t>(e)];
+      if (EnsureGemma4Fp8ExpertOnDevice(d, fex, I, H)) {
+        ExpertGeGLUDeviceAccum(d, ysum, xin.t(), static_cast<const uint16_t*>(fex.dev_gu),
+                               static_cast<const uint16_t*>(fex.dev_dn), I, H, esc, ww,
+                               beta);
+        fused_mix = true;
       } else {
-        VT_CHECK(false, "gemma4 moe: no expert weights");
+        // Prefer bounded host BF16 LRU; fall back to stack ephemeral dequant.
+        EnsureGemma4Fp8ExpertCached(fex, I, H);
+        if (!fex.cached_gu.empty() && !fex.cached_dn.empty()) {
+          ExpertGeGLUHost(d, y, xin.t(), fex.cached_gu.data(), fex.cached_dn.data(), I, H, esc,
+                          &fex);
+        } else {
+          DequantGemma4Fp8ExpertToBf16Ephemeral(fex, I, H, gu_tmp.data(), dn_tmp.data());
+          ExpertGeGLUHost(d, y, xin.t(), gu_tmp.data(), dn_tmp.data(), I, H, esc, &fex);
+        }
+      }
+      } else if (gu_host && dn_host) {
+      ExpertGeGLUHost(d, y, xin.t(), gu_host + static_cast<int64_t>(e) * gu_stride,
+                      dn_host + static_cast<int64_t>(e) * dn_stride, I, H, esc,
+                      gu_host + static_cast<int64_t>(e) * gu_stride);
+      } else {
+      VT_CHECK(false, "gemma4 moe: no expert weights");
       }
 
-      if (fused_mix) continue;  // already accumulated into ysum
+      if (fused_mix) {
+        continue;  // already accumulated into ysum (same stream)
+      }
 
       if (host_axpy) {
         d.b.Synchronize(d.q);
@@ -794,13 +1527,20 @@ Gemma4MoeScratch RunGemma4Moe(vt::Queue& q, const Gemma4MoeLayerWeights& moe,
     d.b.Copy(d.q,
              static_cast<char*>(acc.ptr()) + static_cast<size_t>(t) * static_cast<size_t>(H) * 2,
              ysum.ptr(), static_cast<size_t>(H) * 2);
+    // One drain per token after all top_k experts (prefill + decode).
+    d.b.Synchronize(d.q);
   }
 
   Gemma4MoeScratch r;
   r.tensor = acc.t();
-  const size_t alloc = acc.alloc_bytes();
-  void* p = acc.Release();
-  r.storage = std::shared_ptr<void>(p, [alloc](void* q) { Pool().Put(alloc, q); });
+  if (T == 1) {
+    // TLS-owned: non-owning view for DualRmsNorm; next call overwrites same buffer.
+    r.storage = std::shared_ptr<void>(acc.ptr(), [](void*) {});
+  } else {
+    const size_t alloc = acc.alloc_bytes();
+    void* p = acc.Release();
+    r.storage = std::shared_ptr<void>(p, [alloc](void* q) { Pool().Put(alloc, q); });
+  }
 
   if (profile) {
     d.b.Synchronize(d.q);
@@ -860,7 +1600,27 @@ bool PeerCopyGemma4ExpertSlice(int, const void*, const void*, int, int64_t, int6
                                void*) {
   return false;
 }
+bool PeerCopyGemma4Fp8ExpertSlice(int, const void*, const void*, const void*, const void*, int64_t,
+                                  int64_t, int, void*, void*, void*, void*) {
+  return false;
+}
+bool RunGemma4Fp8TopKOnExpertDevice(vt::Queue&, int, void*, const void*, const void* const*,
+                                    const void* const*, const void* const*, const void* const*,
+                                    const float*, int, int, int) {
+  return false;
+}
+bool RunGemma4Fp8ExpertGeGLUPrefillOnExpertDevice(vt::Queue&, int, void*, const void*, const void*,
+                                                  const void*, const void*, const void*, int, int,
+                                                  int) {
+  return false;
+}
+bool RunGemma4Fp8TopKIndexedOnExpertDevice(vt::Queue&, int, void*, const void*, const void*,
+                                           const void*, const void*, const void*, const int32_t*,
+                                           const float*, int, int, int) {
+  return false;
+}
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats&) {}
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats&) {}
 #endif  // VLLM_CPP_HIP
 
 }  // namespace vllm

--- a/src/vllm/model_executor/models/gemma4_registry.cpp
+++ b/src/vllm/model_executor/models/gemma4_registry.cpp
@@ -14,6 +14,7 @@
 // towers are G2/G3 (skipped by the weight loader). See gemma4-multimodal.md.
 #include "vllm/model_executor/models/model_registry.h"
 
+#include <set>
 #include <algorithm>
 #include <memory>
 #include <optional>
@@ -26,6 +27,7 @@
 
 #include "vllm/model_executor/models/gemma4.h"
 #include "vllm/model_executor/models/gemma4_moe.h"
+#include "vt/fused_ops.h"
 #include "vllm/model_executor/models/qwen3_5.h"         // ForwardLogits (shared carrier)
 #include "vllm/model_executor/models/qwen3_5_common.h"  // HostLogits
 #include "vllm/v1/kv_cache_dtype.h"
@@ -105,6 +107,30 @@ void PrepareGemma4ForConditionalGeneration(LoadedModel& model,
   if (const char* g = std::getenv("VT_GEMMA4_RESIDENT_GPUS"))
     ngpu = std::max(1, std::atoi(g));
   UploadGemma4ExpertsResidentForWeights(w, ngpu);
+  // Pre-warm ExpertGeGLU scratch on every GPU that holds resident experts (no mid-decode malloc).
+  {
+    std::set<int> devs;
+    int G = 8, I = 0, H = 0;
+    for (const auto& layer : w.layers) {
+      if (!layer.moe.enabled || !layer.moe.experts.fp8_native_resident) continue;
+      devs.insert(layer.moe.experts.dev_id);
+      if (I == 0) {
+        I = static_cast<int>(layer.moe.experts.intermediate);
+        H = static_cast<int>(layer.moe.experts.hidden);
+        G = layer.moe.top_k > 0 ? layer.moe.top_k : 8;
+      }
+    }
+    if (I > 0 && H > 0) {
+      for (int d : devs) {
+        if (d < 0) continue;
+        if (!vt::PrewarmExpertGeGLUFp8TopK(d, G, I, H)) {
+          std::fprintf(stderr, "gemma4: ExpertGeGLU prewarm failed on gpu %d\n", d);
+        } else {
+          std::fprintf(stderr, "gemma4: ExpertGeGLU prewarm ok gpu %d G=%d I=%d H=%d\n", d, G, I, H);
+        }
+      }
+    }
+  }
 }
 
 ForwardLogits ForwardGemma4ForConditionalGeneration(

--- a/src/vt/fused_ops.cpp
+++ b/src/vt/fused_ops.cpp
@@ -140,6 +140,23 @@ void MatmulBTFp8Channel(Queue& q, void* out, const void* a, const void* b_fp8,
   throw std::runtime_error("vt::MatmulBTFp8Channel: ROCm-only in this build");
 }
 
+void DequantFp8ChannelBf16(Queue& q, void* out_bf16, const void* fp8, const void* scale_bf16,
+                           int N, int K) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    rocm::DequantFp8ChannelBf16Rocm(q, out_bf16, fp8, scale_bf16, N, K);
+    return;
+  }
+#endif
+  (void)q;
+  (void)out_bf16;
+  (void)fp8;
+  (void)scale_bf16;
+  (void)N;
+  (void)K;
+  throw std::runtime_error("vt::DequantFp8ChannelBf16: ROCm-only in this build");
+}
+
 bool ExpertGeGLUBf16TopKM1(Queue& q, void* ysum, const void* x, const void* const* w_gu,
                            const void* const* w_dn, const float* wts, int G, int I, int H) {
 #if defined(VLLM_CPP_HIP)
@@ -157,6 +174,110 @@ bool ExpertGeGLUBf16TopKM1(Queue& q, void* ysum, const void* x, const void* cons
   (void)I;
   (void)H;
   return false;
+}
+
+bool ExpertGeGLUFp8TopKM1(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                          const void* const* s_gu, const void* const* fp8_dn,
+                          const void* const* s_dn, const float* wts, int G, int I, int H) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    return rocm::ExpertGeGLUFp8TopKM1Rocm(q, ysum, x, fp8_gu, s_gu, fp8_dn, s_dn, wts, G, I, H);
+  }
+#endif
+  (void)q;
+  (void)ysum;
+  (void)x;
+  (void)fp8_gu;
+  (void)s_gu;
+  (void)fp8_dn;
+  (void)s_dn;
+  (void)wts;
+  (void)G;
+  (void)I;
+  (void)H;
+  return false;
+}
+
+bool ExpertGeGLUFp8TopKIndexed(Queue& q, void* ysum, const void* x, const void* gu_base,
+                               const void* dn_base, const void* sgu_base, const void* sdn_base,
+                               const int32_t* idx_dev, const float* wts_dev, int G, int I, int H) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    return rocm::ExpertGeGLUFp8TopKIndexedRocm(q, ysum, x, gu_base, dn_base, sgu_base, sdn_base,
+                                               idx_dev, wts_dev, G, I, H);
+  }
+#endif
+  (void)q; (void)ysum; (void)x; (void)gu_base; (void)dn_base; (void)sgu_base; (void)sdn_base;
+  (void)idx_dev; (void)wts_dev; (void)G; (void)I; (void)H;
+  return false;
+}
+
+void ApplyExpertScaleRw(Queue& q, float* rw_dev, const int32_t* ri_dev, const float* escale_dev,
+                        int G, int E) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    rocm::ApplyExpertScaleRwRocm(q, rw_dev, ri_dev, escale_dev, G, E);
+    return;
+  }
+#endif
+  (void)q; (void)rw_dev; (void)ri_dev; (void)escale_dev; (void)G; (void)E;
+}
+
+bool PrewarmExpertGeGLUFp8TopK(int dev, int G, int I, int H) {
+#if defined(VLLM_CPP_HIP)
+  return rocm::PrewarmExpertGeGLUFp8TopKIndexedRocm(dev, G, I, H);
+#else
+  (void)dev; (void)G; (void)I; (void)H;
+  return false;
+#endif
+}
+
+void MoeGatherRows(Queue& q, void* out_bf16, const void* in_bf16, const int32_t* token_ids_dev,
+                   int n, int H) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    rocm::MoeGatherRowsRocm(q, out_bf16, in_bf16, token_ids_dev, n, H);
+    return;
+  }
+#endif
+  (void)q;
+  (void)out_bf16;
+  (void)in_bf16;
+  (void)token_ids_dev;
+  (void)n;
+  (void)H;
+  throw std::runtime_error("vt::MoeGatherRows: ROCm-only in this build");
+}
+
+void MoeWeightedScatterAdd(Queue& q, void* acc_bf16, const void* y_bf16,
+                           const int32_t* token_ids_dev, const float* weights_dev, int n, int H) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    rocm::MoeWeightedScatterAddRocm(q, acc_bf16, y_bf16, token_ids_dev, weights_dev, n, H);
+    return;
+  }
+#endif
+  (void)q;
+  (void)acc_bf16;
+  (void)y_bf16;
+  (void)token_ids_dev;
+  (void)weights_dev;
+  (void)n;
+  (void)H;
+  throw std::runtime_error("vt::MoeWeightedScatterAdd: ROCm-only in this build");
+}
+
+void MoeZeroBf16(Queue& q, void* buf_bf16, int64_t nelem) {
+#if defined(VLLM_CPP_HIP)
+  if (q.device.type == DeviceType::kROCM) {
+    rocm::MoeZeroBf16Rocm(q, buf_bf16, nelem);
+    return;
+  }
+#endif
+  (void)q;
+  (void)buf_bf16;
+  (void)nelem;
+  throw std::runtime_error("vt::MoeZeroBf16: ROCm-only in this build");
 }
 
 }  // namespace vt

--- a/src/vt/rocm/rocm_backend.hip
+++ b/src/vt/rocm/rocm_backend.hip
@@ -248,6 +248,15 @@ class RocmBackend final : public Backend {
 
   bool UnifiedMemory() const override { return unified_memory_; }
 
+  bool DeviceMemoryInfo(size_t* free_bytes, size_t* total_bytes) const override {
+    size_t free_b = 0, tot_b = 0;
+    if (hipSetDevice(device_) != hipSuccess) return false;
+    if (hipMemGetInfo(&free_b, &tot_b) != hipSuccess) return false;
+    if (free_bytes) *free_bytes = free_b;
+    if (total_bytes) *total_bytes = tot_b;
+    return true;
+  }
+
  private:
   int device_ = 0;
   bool unified_memory_ = false;

--- a/src/vt/rocm/rocm_fp8_channel_gemv.hip
+++ b/src/vt/rocm/rocm_fp8_channel_gemv.hip
@@ -1,8 +1,15 @@
-// FP8 E4M3 weight + BF16 per-row channel scale × BF16 activation GEMV (M=1).
-// y[n] = alpha * scale[n] * sum_k x[k]*f8(W[n,k]) + beta * y[n]
-// Opt-in via VT_GEMMA4_FP8_NATIVE path in gemma4 MoE.
+// Fast FP8-E4M3FN weight × BF16 activation kernels for Gemma-4 MoE.
+// Channel scales BF16 per output row: y[m,n] = alpha * scale[n] * dot(x[m], dequant(W[n])) + beta*y
+//
+// M=1: fused Expert GeGLU (decode).
+// M>1: weight stays FP8 — one dequant of W row into LDS, then all M acts (prefill batch).
+// No host/device expand of full expert packs to BF16.
 #include <hip/hip_bf16.h>
 #include <hip/hip_runtime.h>
+#include <vector>
+
+#include <cstdint>
+#include <cstdio>
 
 #include "vt/device.h"
 #include "vt/dtype.h"
@@ -10,43 +17,135 @@
 namespace vt::rocm {
 namespace {
 
-// IEEE fp8-e4m3fn (matches vllm::F8E4M3ToF32)
+constexpr int kBlock = 256;
+
 __device__ inline float F8E4M3ToF32(uint8_t byte) {
   const uint32_t sign = static_cast<uint32_t>(byte >> 7) & 0x1U;
   const uint32_t exp = static_cast<uint32_t>(byte >> 3) & 0xFU;
   const uint32_t mant = static_cast<uint32_t>(byte) & 0x7U;
   const float sm = sign ? -1.0f : 1.0f;
-  if (exp == 0xFU && mant == 0x7U) return 0.f;  // NaN → 0 in matmul
+  if (exp == 0xFU && mant == 0x7U) return 0.f;
   if (exp == 0U) return sm * (static_cast<float>(mant) * (1.0f / 512.0f));
   const float mantissa = 1.0f + static_cast<float>(mant) * (1.0f / 8.0f);
   return sm * ldexpf(mantissa, static_cast<int>(exp) - 7);
 }
 
-// x in LDS; each thread owns output rows
-__global__ void Fp8ChannelGemvKernel(__hip_bfloat16* __restrict__ y,
-                                     const __hip_bfloat16* __restrict__ x,
-                                     const uint8_t* __restrict__ W,  // [N,K]
-                                     const __hip_bfloat16* __restrict__ scale,  // [N]
-                                     int N, int K, float alpha, float beta) {
-  extern __shared__ float smem[];
-  float* x_cache = smem;
-  for (int k = static_cast<int>(threadIdx.x); k < K; k += static_cast<int>(blockDim.x)) {
-    x_cache[k] = __bfloat162float(x[k]);
+// Shared 256-entry FP8 E4M3 LUT — much cheaper than ldexpf per weight load.
+__device__ inline void FillF8Lut(float lut[256]) {
+  const int tid = static_cast<int>(threadIdx.x);
+  if (tid < 256) lut[tid] = F8E4M3ToF32(static_cast<uint8_t>(tid));
+  __syncthreads();
+}
+
+__device__ inline float BlockSum256(float v) {
+  __shared__ float sm[256];
+  const int tid = static_cast<int>(threadIdx.x);
+  sm[tid] = v;
+  __syncthreads();
+#pragma unroll
+  for (int s = 128; s > 0; s >>= 1) {
+    if (tid < s) sm[tid] += sm[tid + s];
+    __syncthreads();
+  }
+  return sm[0];
+}
+
+// Fewer barriers than BlockSum256 — warp reduce then 8-way (blockDim=256).
+__device__ inline float WarpSum(float v) {
+#pragma unroll
+  for (int o = 16; o > 0; o >>= 1) v += __shfl_down(v, o);
+  return v;
+}
+__device__ inline float BlockSumFast(float v) {
+  __shared__ float wsum[8];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  v = WarpSum(v);
+  if (lane == 0) wsum[warp] = v;
+  __syncthreads();
+  // Only warp 0 reduces the 8 warp sums; publish to wsum[0] for all warps.
+  if (warp == 0) {
+    v = (lane < 8) ? wsum[lane] : 0.f;
+    v = WarpSum(v);
+    if (lane == 0) wsum[0] = v;
   }
   __syncthreads();
+  return wsum[0];
+}
 
-  for (int n = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x); n < N;
-       n += static_cast<int>(gridDim.x * blockDim.x)) {
-    const uint8_t* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
-    float acc = 0.f;
-    int k = 0;
-    for (; k + 3 < K; k += 4) {
-      acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
-      acc += x_cache[k + 1] * F8E4M3ToF32(wrow[k + 1]);
-      acc += x_cache[k + 2] * F8E4M3ToF32(wrow[k + 2]);
-      acc += x_cache[k + 3] * F8E4M3ToF32(wrow[k + 3]);
+__device__ inline float gelu_tanh(float g) {
+  const float inner = 0.7978845608028654f * (g + 0.044715f * g * g * g);
+  return 0.5f * g * (1.f + tanhf(inner));
+}
+
+__device__ inline float DotFp8Row(const float* __restrict__ x_cache, const uint8_t* __restrict__ wrow,
+                                  int K) {
+  float acc = 0.f;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int K16 = K & ~15;
+  for (int k = tid * 16; k < K16; k += kBlock * 16) {
+    float a0 = 0.f, a1 = 0.f, a2 = 0.f, a3 = 0.f;
+#pragma unroll
+    for (int t = 0; t < 4; ++t) {
+      const int base = k + t * 4;
+      a0 += x_cache[base + 0] * F8E4M3ToF32(wrow[base + 0]);
+      a1 += x_cache[base + 1] * F8E4M3ToF32(wrow[base + 1]);
+      a2 += x_cache[base + 2] * F8E4M3ToF32(wrow[base + 2]);
+      a3 += x_cache[base + 3] * F8E4M3ToF32(wrow[base + 3]);
     }
-    for (; k < K; ++k) acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
+    acc += (a0 + a1) + (a2 + a3);
+  }
+  for (int k = K16 + tid; k < K; k += kBlock) {
+    acc += x_cache[k] * F8E4M3ToF32(wrow[k]);
+  }
+  return BlockSum256(acc);
+}
+
+// Dot x_bf16[K] with pre-dequantized float weight row w_f[K].
+__device__ inline float DotBf16xFloat(const __hip_bfloat16* __restrict__ xrow,
+                                      const float* __restrict__ w_f, int K) {
+  float acc = 0.f;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int K4 = K & ~3;
+  for (int k = tid * 4; k < K4; k += kBlock * 4) {
+    acc += __bfloat162float(xrow[k + 0]) * w_f[k + 0];
+    acc += __bfloat162float(xrow[k + 1]) * w_f[k + 1];
+    acc += __bfloat162float(xrow[k + 2]) * w_f[k + 2];
+    acc += __bfloat162float(xrow[k + 3]) * w_f[k + 3];
+  }
+  for (int k = K4 + tid; k < K; k += kBlock) {
+    acc += __bfloat162float(xrow[k]) * w_f[k];
+  }
+  return BlockSum256(acc);
+}
+
+// M=1 GEMV: grid N, shmem K floats for x. FP8 via shared LUT.
+__global__ void Fp8ChannelGemvFastKernel(__hip_bfloat16* __restrict__ y,
+                                         const __hip_bfloat16* __restrict__ x,
+                                         const uint8_t* __restrict__ W,  // [N,K]
+                                         const __hip_bfloat16* __restrict__ scale, int N, int K,
+                                         float alpha, float beta) {
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  extern __shared__ float smem[];
+  float* x_cache = smem;
+  const int tid = static_cast<int>(threadIdx.x);
+  for (int k = tid; k < K; k += kBlock) x_cache[k] = __bfloat162float(x[k]);
+  __syncthreads();
+
+  const int n = static_cast<int>(blockIdx.x);
+  if (n >= N) return;
+  const uint8_t* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
+  float acc = 0.f;
+  const int K16 = K & ~15;
+  for (int k = tid * 16; k < K16; k += kBlock * 16) {
+#pragma unroll
+    for (int t = 0; t < 16; ++t) acc += x_cache[k + t] * lut[wrow[k + t]];
+  }
+  for (int k = K16 + tid; k < K; k += kBlock) acc += x_cache[k] * lut[wrow[k]];
+  acc = BlockSum256(acc);
+  if (tid == 0) {
     const float s = __bfloat162float(scale[n]);
     float v = alpha * s * acc;
     if (beta != 0.f) v += beta * __bfloat162float(y[n]);
@@ -54,22 +153,644 @@ __global__ void Fp8ChannelGemvKernel(__hip_bfloat16* __restrict__ y,
   }
 }
 
+// M>=1 GEMM: y[M,N] = alpha * (x[M,K] @ W[N,K]^T) * scale[N] + beta * y
+// grid = N. Dequant weight row once into LDS; stream all M activations.
+// shmem = K floats (weight row). Weights stay FP8 in global memory.
+__global__ void Fp8ChannelGemmMKernel(__hip_bfloat16* __restrict__ y,  // [M,N]
+                                      const __hip_bfloat16* __restrict__ x,  // [M,K]
+                                      const uint8_t* __restrict__ W,         // [N,K]
+                                      const __hip_bfloat16* __restrict__ scale, int M, int N,
+                                      int K, float alpha, float beta) {
+  extern __shared__ float smem[];
+  float* w_f = smem;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int n = static_cast<int>(blockIdx.x);
+  if (n >= N) return;
+
+  __shared__ float lut[256];
+  // Fill lut once (all threads); then dequant W row via lut into w_f.
+  {
+    if (tid < 256) lut[tid] = F8E4M3ToF32(static_cast<uint8_t>(tid));
+    __syncthreads();
+  }
+  const uint8_t* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
+  for (int k = tid; k < K; k += kBlock) w_f[k] = lut[wrow[k]];
+  __syncthreads();
+
+  const float s = __bfloat162float(scale[n]);
+  for (int m = 0; m < M; ++m) {
+    const __hip_bfloat16* xrow = x + static_cast<int64_t>(m) * static_cast<int64_t>(K);
+    float acc = DotBf16xFloat(xrow, w_f, K);
+    if (tid == 0) {
+      __hip_bfloat16* ymn = y + static_cast<int64_t>(m) * static_cast<int64_t>(N) + n;
+      float v = alpha * s * acc;
+      if (beta != 0.f) v += beta * __bfloat162float(*ymn);
+      *ymn = __float2bfloat16(v);
+    }
+    // ensure all threads done before next m reuses reduction sm in DotBf16xFloat
+    __syncthreads();
+  }
+}
+
+// Fused gate|up act T=1: grid = I. LUT + optional global x_f32.
+__global__ void ExpertFp8ActKernel(float* __restrict__ act, const __hip_bfloat16* __restrict__ x,
+                                   const uint8_t* __restrict__ w_gu,
+                                   const __hip_bfloat16* __restrict__ s_gu, int I, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  if (i >= I) return;
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  extern __shared__ float smem[];
+  float* x_cache = smem;
+  const int tid = static_cast<int>(threadIdx.x);
+  for (int h = tid; h < H; h += kBlock) x_cache[h] = __bfloat162float(x[h]);
+  __syncthreads();
+
+  const uint8_t* grow = w_gu + static_cast<int64_t>(i) * H;
+  const uint8_t* urow = w_gu + static_cast<int64_t>(I + i) * H;
+  float gate = 0.f, up = 0.f;
+  const int H16 = H & ~15;
+  for (int h = tid * 16; h < H16; h += kBlock * 16) {
+#pragma unroll
+    for (int t = 0; t < 16; ++t) {
+      const int hh = h + t;
+      const float xv = x_cache[hh];
+      gate += xv * lut[grow[hh]];
+      up += xv * lut[urow[hh]];
+    }
+  }
+  for (int h = H16 + tid; h < H; h += kBlock) {
+    const float xv = x_cache[h];
+    gate += xv * lut[grow[h]];
+    up += xv * lut[urow[h]];
+  }
+  gate = BlockSum256(gate);
+  up = BlockSum256(up);
+  if (tid == 0) {
+    const float sg = __bfloat162float(s_gu[i]);
+    const float su = __bfloat162float(s_gu[I + i]);
+    act[i] = gelu_tanh(sg * gate) * (su * up);
+  }
+}
+
+__global__ void ExpertFp8DownKernel(__hip_bfloat16* __restrict__ y, const float* __restrict__ act,
+                                    const uint8_t* __restrict__ w_dn,
+                                    const __hip_bfloat16* __restrict__ s_dn, int I, int H,
+                                    float alpha, float beta) {
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  const int h = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (h >= H) return;
+  const uint8_t* drow = w_dn + static_cast<int64_t>(h) * I;
+  float acc = 0.f;
+  int i = 0;
+  for (; i + 3 < I; i += 4) {
+    acc += act[i] * lut[drow[i]];
+    acc += act[i + 1] * lut[drow[i + 1]];
+    acc += act[i + 2] * lut[drow[i + 2]];
+    acc += act[i + 3] * lut[drow[i + 3]];
+  }
+  for (; i < I; ++i) acc += act[i] * lut[drow[i]];
+  const float sd = __bfloat162float(s_dn[h]);
+  float v = alpha * sd * acc;
+  if (beta != 0.f) v += beta * __bfloat162float(y[h]);
+  y[h] = __float2bfloat16(v);
+}
+
+__global__ void Bf16ToF32VecKernel(float* __restrict__ out, const __hip_bfloat16* __restrict__ in,
+                                   int n) {
+  const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (i < n) out[i] = __bfloat162float(in[i]);
+}
+
+struct ActBuf {
+  float* p = nullptr;
+  int cap = 0;
+};
+ActBuf& TlsAct() {
+  static thread_local ActBuf b;
+  return b;
+}
+bool EnsureAct(int I) {
+  auto& b = TlsAct();
+  if (b.cap >= I && b.p) return true;
+  if (b.p) (void)hipFree(b.p);
+  b.p = nullptr;
+  b.cap = 0;
+  if (hipMalloc(&b.p, static_cast<size_t>(I) * sizeof(float)) != hipSuccess) return false;
+  b.cap = I;
+  return true;
+}
+
 }  // namespace
 
-// out[1,N] bf16, a[1,K] bf16, b_fp8[N,K], scale_bf16[N]
 void MatmulBTFp8ChannelRocm(Queue& q, void* out, const void* a, const void* b_fp8,
                             const void* scale_bf16, int M, int N, int K, float alpha,
                             float beta) {
-  if (M != 1 || N <= 0 || K <= 0) return;
+  if (M <= 0 || N <= 0 || K <= 0 || !out || !a || !b_fp8 || !scale_bf16) return;
   hipStream_t s = static_cast<hipStream_t>(q.handle);
-  constexpr int kBlock = 256;
-  const int grid = (N + kBlock - 1) / kBlock;
   const size_t shmem = static_cast<size_t>(K) * sizeof(float);
-  if (shmem > 48 * 1024) return;  // caller must fall back
-  Fp8ChannelGemvKernel<<<grid, kBlock, shmem, s>>>(
+  if (shmem > 48 * 1024) return;
+
+  if (M == 1) {
+    Fp8ChannelGemvFastKernel<<<N, kBlock, shmem, s>>>(
+        static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
+        static_cast<const uint8_t*>(b_fp8), static_cast<const __hip_bfloat16*>(scale_bf16), N, K,
+        alpha, beta);
+    return;
+  }
+
+  // Prefill / multi-token: keep W in FP8; dequant one row at a time into LDS.
+  // NOTE: serial-in-M — prefer DequantFp8ChannelBf16Rocm + hipBLAS for large M.
+  Fp8ChannelGemmMKernel<<<N, kBlock, shmem, s>>>(
       static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
-      static_cast<const uint8_t*>(b_fp8), static_cast<const __hip_bfloat16*>(scale_bf16), N, K,
+      static_cast<const uint8_t*>(b_fp8), static_cast<const __hip_bfloat16*>(scale_bf16), M, N, K,
       alpha, beta);
+}
+
+// out[n,k] = scale[n] * f8_e4m3_to_f32(w[n,k]) as bf16
+__global__ void Fp8ChannelDequantBf16Kernel(__hip_bfloat16* __restrict__ out,
+                                            const uint8_t* __restrict__ w,
+                                            const __hip_bfloat16* __restrict__ scale, int N,
+                                            int K) {
+  const int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + static_cast<int64_t>(threadIdx.x);
+  const int64_t total = static_cast<int64_t>(N) * static_cast<int64_t>(K);
+  if (idx >= total) return;
+  const int n = static_cast<int>(idx / K);
+  const float s = __bfloat162float(scale[n]);
+  const float v = s * F8E4M3ToF32(w[idx]);
+  out[idx] = __float2bfloat16(v);
+}
+
+void DequantFp8ChannelBf16Rocm(Queue& q, void* out_bf16, const void* fp8, const void* scale_bf16,
+                               int N, int K) {
+  if (!out_bf16 || !fp8 || !scale_bf16 || N <= 0 || K <= 0) return;
+  hipStream_t s = static_cast<hipStream_t>(q.handle);
+  const int64_t total = static_cast<int64_t>(N) * static_cast<int64_t>(K);
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  Fp8ChannelDequantBf16Kernel<<<blocks, threads, 0, s>>>(
+      static_cast<__hip_bfloat16*>(out_bf16), static_cast<const uint8_t*>(fp8),
+      static_cast<const __hip_bfloat16*>(scale_bf16), N, K);
+}
+
+bool ExpertGeGLUFp8M1Rocm(Queue& q, void* y, const void* x, const void* fp8_gu, const void* s_gu,
+                          const void* fp8_dn, const void* s_dn, int I, int H, float alpha,
+                          float beta) {
+  if (!y || !x || !fp8_gu || !s_gu || !fp8_dn || !s_dn || I <= 0 || H <= 0) return false;
+  const size_t shmem = static_cast<size_t>(H) * sizeof(float);
+  if (shmem > 48 * 1024) return false;
+  if (!EnsureAct(I)) return false;
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  float* act = TlsAct().p;
+  ExpertFp8ActKernel<<<I, kBlock, shmem, st>>>(
+      act, static_cast<const __hip_bfloat16*>(x), static_cast<const uint8_t*>(fp8_gu),
+      static_cast<const __hip_bfloat16*>(s_gu), I, H);
+  const int grid_dn = (H + kBlock - 1) / kBlock;
+  ExpertFp8DownKernel<<<grid_dn, kBlock, 0, st>>>(
+      static_cast<__hip_bfloat16*>(y), act, static_cast<const uint8_t*>(fp8_dn),
+      static_cast<const __hip_bfloat16*>(s_dn), I, H, alpha, beta);
+  return hipGetLastError() == hipSuccess;
+}
+
+// --- True top-k fused FP8 ExpertGeGLU (decode T=1) ---------------------------
+// 1 act grid (I) looping G + 1 down. (Multi-row/LDS-act tiled variants regressed
+// on gfx1201 lab A/B 2026-08-09 — keep this path.)
+constexpr int kMaxTopK = 8;
+
+// grid = I — x already expanded to float in global (L2-resident); no per-block x smem.
+__global__ void ExpertFp8ActTopKKernel(float* __restrict__ act,  // [G,I]
+                                       const float* __restrict__ x_f,  // [H]
+                                       const uint8_t* const* __restrict__ w_gu,
+                                       const __hip_bfloat16* const* __restrict__ s_gu, int G,
+                                       int I, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  if (i >= I) return;
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  const int tid = static_cast<int>(threadIdx.x);
+
+  for (int g = 0; g < G; ++g) {
+    const uint8_t* gu = w_gu[g];
+    const __hip_bfloat16* sg = s_gu[g];
+    const uint8_t* grow = gu + static_cast<int64_t>(i) * H;
+    const uint8_t* urow = gu + static_cast<int64_t>(I + i) * H;
+    float gate = 0.f, up = 0.f;
+    const int H16 = H & ~15;
+    for (int h = tid * 16; h < H16; h += kBlock * 16) {
+#pragma unroll
+      for (int t = 0; t < 16; ++t) {
+        const int hh = h + t;
+        const float xv = x_f[hh];
+        gate += xv * lut[grow[hh]];
+        up += xv * lut[urow[hh]];
+      }
+    }
+    for (int h = H16 + tid; h < H; h += kBlock) {
+      const float xv = x_f[h];
+      gate += xv * lut[grow[h]];
+      up += xv * lut[urow[h]];
+    }
+    gate = BlockSumFast(gate);
+    up = BlockSumFast(up);
+    if (tid == 0) {
+      const float sgate = __bfloat162float(sg[i]);
+      const float sup = __bfloat162float(sg[I + i]);
+      act[static_cast<int64_t>(g) * I + i] = gelu_tanh(sgate * gate) * (sup * up);
+    }
+    __syncthreads();
+  }
+}
+
+__global__ void ExpertFp8DownTopKKernel(__hip_bfloat16* __restrict__ ysum,
+                                        const float* __restrict__ act,  // [G,I]
+                                        const uint8_t* const* __restrict__ w_dn,
+                                        const __hip_bfloat16* const* __restrict__ s_dn,
+                                        const float* __restrict__ wts, int G, int I, int H) {
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  const int h = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (h >= H) return;
+  float acc = 0.f;
+  for (int g = 0; g < G; ++g) {
+    const uint8_t* drow = w_dn[g] + static_cast<int64_t>(h) * I;
+    const float* arow = act + static_cast<int64_t>(g) * I;
+    float dot = 0.f;
+    int i = 0;
+    for (; i + 3 < I; i += 4) {
+      dot += arow[i] * lut[drow[i]];
+      dot += arow[i + 1] * lut[drow[i + 1]];
+      dot += arow[i + 2] * lut[drow[i + 2]];
+      dot += arow[i + 3] * lut[drow[i + 3]];
+    }
+    for (; i < I; ++i) dot += arow[i] * lut[drow[i]];
+    acc += wts[g] * __bfloat162float(s_dn[g][h]) * dot;
+  }
+  ysum[h] = __float2bfloat16(acc);
+}
+
+struct TopKTls {
+  const void** d_fgu = nullptr;
+  const void** d_sgu = nullptr;
+  const void** d_fdn = nullptr;
+  const void** d_sdn = nullptr;
+  float* d_wts = nullptr;
+  float* d_act = nullptr;
+  int act_cap = 0;
+};
+TopKTls& TlsTopK() {
+  static thread_local TopKTls t;
+  return t;
+}
+
+bool ExpertGeGLUFp8TopKM1Rocm(Queue& q, void* ysum, const void* x, const void* const* fp8_gu,
+                              const void* const* s_gu, const void* const* fp8_dn,
+                              const void* const* s_dn, const float* wts, int G, int I, int H) {
+  if (G <= 0 || G > kMaxTopK || !ysum || !x || !fp8_gu || !s_gu || !fp8_dn || !s_dn || !wts)
+    return false;
+  if (I <= 0 || H <= 0) return false;
+  // Act no longer needs H*f32 dynamic smem (x expanded to global).
+  if (H <= 0) return false;
+
+  const int dev = q.device.index;
+  if (dev < 0 || dev >= 8) return false;
+  {
+    int cur = -1;
+    if (hipGetDevice(&cur) != hipSuccess || cur != dev) {
+      if (hipSetDevice(dev) != hipSuccess) return false;
+    }
+  }
+
+  // Per-device TLS: dual-GPU expert-run must not reuse GPU0 scratch on GPU1.
+  struct TopKDevTls {
+    const void** d_fgu = nullptr;
+    const void** d_sgu = nullptr;
+    const void** d_fdn = nullptr;
+    const void** d_sdn = nullptr;
+    float* d_wts = nullptr;
+    float* d_act = nullptr;
+    float* d_xf = nullptr;
+    int act_cap = 0;
+    int xf_cap = 0;
+    int bound_dev = -1;
+  };
+  static thread_local TopKDevTls slots[8];
+  auto& tls = slots[dev];
+  if (tls.bound_dev != dev) {
+    tls = TopKDevTls{};
+    tls.bound_dev = dev;
+  }
+
+  const int act_need = G * I;
+  if (tls.act_cap < act_need || !tls.d_act) {
+    if (tls.d_act) (void)hipFree(tls.d_act);
+    tls.d_act = nullptr;
+    tls.act_cap = 0;
+    if (hipMalloc(&tls.d_act, static_cast<size_t>(act_need) * sizeof(float)) != hipSuccess)
+      return false;
+    tls.act_cap = act_need;
+  }
+  if (tls.xf_cap < H || !tls.d_xf) {
+    if (tls.d_xf) (void)hipFree(tls.d_xf);
+    tls.d_xf = nullptr;
+    tls.xf_cap = 0;
+    if (hipMalloc(&tls.d_xf, static_cast<size_t>(H) * sizeof(float)) != hipSuccess) return false;
+    tls.xf_cap = H;
+  }
+  if (!tls.d_fgu) {
+    if (hipMalloc(&tls.d_fgu, sizeof(void*) * kMaxTopK) != hipSuccess) return false;
+    if (hipMalloc(&tls.d_sgu, sizeof(void*) * kMaxTopK) != hipSuccess) return false;
+    if (hipMalloc(&tls.d_fdn, sizeof(void*) * kMaxTopK) != hipSuccess) return false;
+    if (hipMalloc(&tls.d_sdn, sizeof(void*) * kMaxTopK) != hipSuccess) return false;
+    if (hipMalloc(&tls.d_wts, sizeof(float) * kMaxTopK) != hipSuccess) return false;
+  }
+
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  if (hipMemcpyAsync(tls.d_fgu, fp8_gu, sizeof(void*) * static_cast<size_t>(G),
+                     hipMemcpyHostToDevice, st) != hipSuccess)
+    return false;
+  if (hipMemcpyAsync(tls.d_sgu, s_gu, sizeof(void*) * static_cast<size_t>(G), hipMemcpyHostToDevice,
+                     st) != hipSuccess)
+    return false;
+  if (hipMemcpyAsync(tls.d_fdn, fp8_dn, sizeof(void*) * static_cast<size_t>(G),
+                     hipMemcpyHostToDevice, st) != hipSuccess)
+    return false;
+  if (hipMemcpyAsync(tls.d_sdn, s_dn, sizeof(void*) * static_cast<size_t>(G), hipMemcpyHostToDevice,
+                     st) != hipSuccess)
+    return false;
+  if (hipMemcpyAsync(tls.d_wts, wts, sizeof(float) * static_cast<size_t>(G), hipMemcpyHostToDevice,
+                     st) != hipSuccess)
+    return false;
+
+  // Expand x once → L2; act blocks read x_f (no 704× smem fills of H).
+  {
+    const int xt = 256;
+    const int xg = (H + xt - 1) / xt;
+    Bf16ToF32VecKernel<<<xg, xt, 0, st>>>(tls.d_xf, static_cast<const __hip_bfloat16*>(x), H);
+  }
+  dim3 grid_act(static_cast<unsigned>(I));
+  ExpertFp8ActTopKKernel<<<grid_act, kBlock, 0, st>>>(
+      tls.d_act, tls.d_xf, reinterpret_cast<const uint8_t* const*>(tls.d_fgu),
+      reinterpret_cast<const __hip_bfloat16* const*>(tls.d_sgu), G, I, H);
+
+  const int grid_dn = (H + kBlock - 1) / kBlock;
+  ExpertFp8DownTopKKernel<<<grid_dn, kBlock, 0, st>>>(
+      static_cast<__hip_bfloat16*>(ysum), tls.d_act,
+      reinterpret_cast<const uint8_t* const*>(tls.d_fdn),
+      reinterpret_cast<const __hip_bfloat16* const*>(tls.d_sdn), tls.d_wts, G, I, H);
+
+  return hipGetLastError() == hipSuccess;
+}
+
+// Contiguous FP8 packs + device top-k indices (no host pointer gather / D2H).
+// grid = (I, G) — one block per (intermediate row, expert); experts run in parallel.
+// gu_base [E,2I,H] u8, sgu [E,2I] bf16.
+// x is BF16 [H] — convert on load (skips separate Bf16ToF32 launch + d_xf write).
+__global__ void ExpertFp8ActTopKIndexedKernel(float* __restrict__ act,
+                                              const __hip_bfloat16* __restrict__ x,
+                                              const uint8_t* __restrict__ gu_base,
+                                              const __hip_bfloat16* __restrict__ sgu_base,
+                                              const int32_t* __restrict__ idx, int G, int I, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  const int g = static_cast<int>(blockIdx.y);
+  if (i >= I || g >= G) return;
+  __shared__ float lut[256];
+  FillF8Lut(lut);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int e = idx[g];
+
+  const size_t gu_one = static_cast<size_t>(2) * static_cast<size_t>(I) * static_cast<size_t>(H);
+  const size_t sgu_one = static_cast<size_t>(2) * static_cast<size_t>(I);
+  const uint8_t* gu = gu_base + static_cast<size_t>(e) * gu_one;
+  const __hip_bfloat16* sg = sgu_base + static_cast<size_t>(e) * sgu_one;
+  const uint8_t* grow = gu + static_cast<int64_t>(i) * H;
+  const uint8_t* urow = gu + static_cast<int64_t>(I + i) * H;
+
+  float gate = 0.f, up = 0.f;
+  const int H16 = H & ~15;
+  for (int h = tid * 16; h < H16; h += kBlock * 16) {
+#pragma unroll
+    for (int tt = 0; tt < 16; ++tt) {
+      const int hh = h + tt;
+      const float xv = __bfloat162float(x[hh]);
+      gate += xv * lut[grow[hh]];
+      up += xv * lut[urow[hh]];
+    }
+  }
+  for (int h = H16 + tid; h < H; h += kBlock) {
+    const float xv = __bfloat162float(x[h]);
+    gate += xv * lut[grow[h]];
+    up += xv * lut[urow[h]];
+  }
+  gate = BlockSumFast(gate);
+  up = BlockSumFast(up);
+  if (tid == 0) {
+    const float sgate = __bfloat162float(sg[i]);
+    const float sup = __bfloat162float(sg[I + i]);
+    act[static_cast<int64_t>(g) * I + i] = gelu_tanh(sgate * gate) * (sup * up);
+  }
+}
+
+__global__ void ExpertFp8DownTopKIndexedKernel(__hip_bfloat16* __restrict__ ysum,
+                                               const float* __restrict__ act,
+                                               const uint8_t* __restrict__ dn_base,
+                                               const __hip_bfloat16* __restrict__ sdn_base,
+                                               const int32_t* __restrict__ idx,
+                                               const float* __restrict__ wts, int G, int I, int H) {
+  __shared__ float lut[256];
+  __shared__ int sidx[kMaxTopK];
+  __shared__ float swts[kMaxTopK];
+  FillF8Lut(lut);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (tid < G) {
+    sidx[tid] = idx[tid];
+    swts[tid] = wts[tid];
+  }
+  __syncthreads();
+  const int h = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (h >= H) return;
+  const size_t dn_one = static_cast<size_t>(H) * static_cast<size_t>(I);
+  const size_t sdn_one = static_cast<size_t>(H);
+  float acc = 0.f;
+  for (int g = 0; g < G; ++g) {
+    const int e = sidx[g];
+    const uint8_t* drow = dn_base + static_cast<size_t>(e) * dn_one + static_cast<size_t>(h) * I;
+    const float* arow = act + static_cast<int64_t>(g) * I;
+    float dot = 0.f;
+    int i = 0;
+    for (; i + 3 < I; i += 4) {
+      dot += arow[i] * lut[drow[i]];
+      dot += arow[i + 1] * lut[drow[i + 1]];
+      dot += arow[i + 2] * lut[drow[i + 2]];
+      dot += arow[i + 3] * lut[drow[i + 3]];
+    }
+    for (; i < I; ++i) dot += arow[i] * lut[drow[i]];
+    const __hip_bfloat16* sd = sdn_base + static_cast<size_t>(e) * sdn_one;
+    acc += swts[g] * __bfloat162float(sd[h]) * dot;
+  }
+  ysum[h] = __float2bfloat16(acc);
+}
+
+__global__ void ApplyExpertScaleRwKernel(float* __restrict__ rw, const int32_t* __restrict__ ri,
+                                         const float* __restrict__ escale, int G, int E) {
+  const int g = static_cast<int>(threadIdx.x);
+  if (g >= G) return;
+  const int e = ri[g];
+  if (e >= 0 && e < E) rw[g] *= escale[e];
+}
+
+struct IdxTls {
+  float* d_act = nullptr;
+  float* d_xf = nullptr;
+  int act_cap = 0;
+  int xf_cap = 0;
+  int bound_dev = -1;
+};
+IdxTls& IdxTlsSlot(int dev) {
+  static thread_local IdxTls slots[8];
+  return slots[dev];
+}
+
+// Alloc-only (safe to call at Prepare). Graph-safe: no hipSetDevice/hipMalloc once warm.
+bool EnsureIdxTls(int dev, int G, int I, int H) {
+  if (dev < 0 || dev >= 8 || G <= 0 || G > kMaxTopK || I <= 0 || H <= 0) return false;
+  auto& tls = IdxTlsSlot(dev);
+  const int act_need = G * I;
+  if (tls.bound_dev == dev && tls.d_act && tls.d_xf && tls.act_cap >= act_need &&
+      tls.xf_cap >= H)
+    return true;  // hot path: no device API
+  if (hipSetDevice(dev) != hipSuccess) return false;
+  if (tls.bound_dev != dev) {
+    tls = IdxTls{};
+    tls.bound_dev = dev;
+  }
+  if (tls.act_cap < act_need || !tls.d_act) {
+    if (tls.d_act) (void)hipFree(tls.d_act);
+    tls.d_act = nullptr;
+    tls.act_cap = 0;
+    if (hipMalloc(&tls.d_act, static_cast<size_t>(act_need) * sizeof(float)) != hipSuccess)
+      return false;
+    tls.act_cap = act_need;
+  }
+  if (tls.xf_cap < H || !tls.d_xf) {
+    if (tls.d_xf) (void)hipFree(tls.d_xf);
+    tls.d_xf = nullptr;
+    tls.xf_cap = 0;
+    if (hipMalloc(&tls.d_xf, static_cast<size_t>(H) * sizeof(float)) != hipSuccess) return false;
+    tls.xf_cap = H;
+  }
+  return true;
+}
+
+bool ExpertGeGLUFp8TopKIndexedRocm(Queue& q, void* ysum, const void* x, const void* gu_base,
+                                   const void* dn_base, const void* sgu_base, const void* sdn_base,
+                                   const int32_t* idx_dev, const float* wts_dev, int G, int I,
+                                   int H) {
+  if (G <= 0 || G > kMaxTopK || !ysum || !x || !gu_base || !dn_base || !sgu_base || !sdn_base ||
+      !idx_dev || !wts_dev)
+    return false;
+  if (I <= 0 || H <= 0) return false;
+  const int dev = q.device.index;
+  if (!EnsureIdxTls(dev, G, I, H)) return false;
+  auto& tls = IdxTlsSlot(dev);
+
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  dim3 grid_act(static_cast<unsigned>(I), static_cast<unsigned>(G));
+  ExpertFp8ActTopKIndexedKernel<<<grid_act, kBlock, 0, st>>>(
+      tls.d_act, static_cast<const __hip_bfloat16*>(x), static_cast<const uint8_t*>(gu_base),
+      static_cast<const __hip_bfloat16*>(sgu_base), idx_dev, G, I, H);
+  const int grid_dn = (H + kBlock - 1) / kBlock;
+  ExpertFp8DownTopKIndexedKernel<<<grid_dn, kBlock, 0, st>>>(
+      static_cast<__hip_bfloat16*>(ysum), tls.d_act, static_cast<const uint8_t*>(dn_base),
+      static_cast<const __hip_bfloat16*>(sdn_base), idx_dev, wts_dev, G, I, H);
+  return hipGetLastError() == hipSuccess;
+}
+
+void ApplyExpertScaleRwRocm(Queue& q, float* rw_dev, const int32_t* ri_dev, const float* escale_dev,
+                            int G, int E) {
+  if (!rw_dev || !ri_dev || !escale_dev || G <= 0) return;
+  hipStream_t st = static_cast<hipStream_t>(q.handle);
+  ApplyExpertScaleRwKernel<<<1, G, 0, st>>>(rw_dev, ri_dev, escale_dev, G, E);
+}
+
+// Pre-allocate per-device ExpertGeGLU scratch (act + x_f) so decode never hipMalloc mid-step.
+bool PrewarmExpertGeGLUFp8TopKIndexedRocm(int dev, int G, int I, int H) {
+  return EnsureIdxTls(dev, G, I, H);
+}
+
+// --- Prefill MoE gather / weighted scatter (device-only) ---
+
+__global__ void MoeGatherRowsKernel(__hip_bfloat16* __restrict__ out,
+                                    const __hip_bfloat16* __restrict__ in,
+                                    const int32_t* __restrict__ tids, int n, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  if (i >= n) return;
+  const int t = tids[i];
+  const __hip_bfloat16* src = in + static_cast<int64_t>(t) * H;
+  __hip_bfloat16* dst = out + static_cast<int64_t>(i) * H;
+  for (int h = static_cast<int>(threadIdx.x); h < H; h += static_cast<int>(blockDim.x)) {
+    dst[h] = src[h];
+  }
+}
+
+// One block per (row i); threads walk H. Atomic not needed if tokens unique per expert chunk
+// (same token can appear once per expert with top-k — different experts write different
+// increments to same acc row → need atomics on bf16 via float CAS or float acc).
+// Use float staging: each thread does atomicAdd on float buffer — too heavy.
+// Simpler: serialize rows with one warp per row doing non-atomic read-modify-write
+// when we guarantee single-threaded updates per (token,h) within a launch.
+// For top-k, same token appears in multiple experts → concurrent expert launches are
+// sequential in host loop, so within one scatter launch each token appears once.
+// Safe non-atomic RMW per (i) row.
+__global__ void MoeWeightedScatterAddKernel(__hip_bfloat16* __restrict__ acc,
+                                            const __hip_bfloat16* __restrict__ y,
+                                            const int32_t* __restrict__ tids,
+                                            const float* __restrict__ wts, int n, int H) {
+  const int i = static_cast<int>(blockIdx.x);
+  if (i >= n) return;
+  const int t = tids[i];
+  const float w = wts[i];
+  const __hip_bfloat16* src = y + static_cast<int64_t>(i) * H;
+  __hip_bfloat16* dst = acc + static_cast<int64_t>(t) * H;
+  for (int h = static_cast<int>(threadIdx.x); h < H; h += static_cast<int>(blockDim.x)) {
+    const float v = w * __bfloat162float(src[h]) + __bfloat162float(dst[h]);
+    dst[h] = __float2bfloat16(v);
+  }
+}
+
+__global__ void MoeZeroBf16Kernel(__hip_bfloat16* __restrict__ buf, int64_t nelem) {
+  const int64_t i =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + static_cast<int64_t>(threadIdx.x);
+  if (i < nelem) buf[i] = __float2bfloat16(0.f);
+}
+
+void MoeGatherRowsRocm(Queue& q, void* out_bf16, const void* in_bf16, const int32_t* token_ids,
+                       int n, int H) {
+  if (n <= 0 || H <= 0 || !out_bf16 || !in_bf16 || !token_ids) return;
+  hipStream_t s = static_cast<hipStream_t>(q.handle);
+  MoeGatherRowsKernel<<<n, kBlock, 0, s>>>(
+      static_cast<__hip_bfloat16*>(out_bf16), static_cast<const __hip_bfloat16*>(in_bf16),
+      token_ids, n, H);
+}
+
+void MoeWeightedScatterAddRocm(Queue& q, void* acc_bf16, const void* y_bf16,
+                               const int32_t* token_ids, const float* weights, int n, int H) {
+  if (n <= 0 || H <= 0 || !acc_bf16 || !y_bf16 || !token_ids || !weights) return;
+  hipStream_t s = static_cast<hipStream_t>(q.handle);
+  // Threads in a block share a row — need sync between h-loop iterations? No, each h
+  // unique per thread. Multiple threads write different h of same row — OK.
+  MoeWeightedScatterAddKernel<<<n, kBlock, 0, s>>>(
+      static_cast<__hip_bfloat16*>(acc_bf16), static_cast<const __hip_bfloat16*>(y_bf16),
+      token_ids, weights, n, H);
+}
+
+void MoeZeroBf16Rocm(Queue& q, void* buf_bf16, int64_t nelem) {
+  if (!buf_bf16 || nelem <= 0) return;
+  hipStream_t s = static_cast<hipStream_t>(q.handle);
+  const int block = 256;
+  const int grid = static_cast<int>((nelem + block - 1) / block);
+  MoeZeroBf16Kernel<<<grid, block, 0, s>>>(static_cast<__hip_bfloat16*>(buf_bf16), nelem);
 }
 
 }  // namespace vt::rocm

--- a/src/vt/rocm/rocm_gemma4_experts.hip
+++ b/src/vt/rocm/rocm_gemma4_experts.hip
@@ -1,4 +1,5 @@
 // ROCm upload of Gemma-4 MoE expert stacks (BF16 fused or FP8→BF16 dequant).
+#include <cstring>
 // Packs GPU0 first (compute device), then GPU1. FP8 streams per-expert to
 // avoid ~30G host OOM from permanent BF16 caches / full-layer host buffers.
 #include <hip/hip_runtime.h>
@@ -12,9 +13,23 @@
 
 #include "vllm/model_executor/models/gemma4.h"
 #include "vllm/model_executor/models/gemma4_moe.h"
+#include "vt/backend.h"
+#include "vt/dtype.h"
+#include "vt/fused_ops.h"
+#include "vt/ops.h"
 
 namespace vllm {
 namespace {
+// hipDeviceEnablePeerAccess leaves hipErrorPeerAccessAlreadyEnabled sticky;
+// later Check(hipGetLastError()) would false-fail (seen on peer-act GeluAndMul).
+inline void EnablePeerAccessQuiet(int peer_dev) {
+  const hipError_t pe = hipDeviceEnablePeerAccess(peer_dev, 0);
+  if (pe != hipSuccess && pe != hipErrorPeerAccessAlreadyEnabled) {
+    // best-effort; unsupported P2P falls back to staging copies elsewhere
+  }
+  (void)hipGetLastError();  // clear sticky
+}
+
 
 void Check(hipError_t e, const char* w) {
   if (e != hipSuccess)
@@ -26,8 +41,17 @@ bool DeviceHasRoom(int dev, size_t need_bytes) {
   size_t free_b = 0, tot_b = 0;
   if (hipMemGetInfo(&free_b, &tot_b) != hipSuccess) return true;
   // GPU0 is compute: dense weights + KV + activations need real headroom.
-  // 12 GiB: prior 10 GiB still OOM'd gelu after 42 GiB dual-GPU resident pack.
-  const size_t headroom = (dev == 0) ? (12ull << 30) : (512ull << 20);
+  // Default 12 GiB (lab dual-GPU). Override: VT_GEMMA4_GPU0_HEADROOM_GB (e.g. 4 for
+  // single-GPU resident + short KV / graph experiments).
+  static const size_t gpu0_headroom = []() -> size_t {
+    const char* e = std::getenv("VT_GEMMA4_GPU0_HEADROOM_GB");
+    if (e && e[0]) {
+      const int g = std::atoi(e);
+      if (g >= 0 && g <= 24) return static_cast<size_t>(g) << 30;
+    }
+    return static_cast<size_t>(12ull << 30);
+  }();
+  const size_t headroom = (dev == 0) ? gpu0_headroom : (512ull << 20);
   return free_b >= need_bytes + headroom;
 }
 
@@ -45,6 +69,110 @@ bool AllocLayerDev(int dev, size_t gu_bytes, size_t dn_bytes, void** gu, void** 
   return true;
 }
 
+bool AllocFour(int dev, size_t a, size_t b, size_t c, size_t d, void** pa, void** pb, void** pc,
+               void** pd) {
+  if (!DeviceHasRoom(dev, a + b + c + d)) return false;
+  Check(hipSetDevice(dev), "hipSetDevice");
+  *pa = *pb = *pc = *pd = nullptr;
+  if (hipMalloc(pa, a) != hipSuccess) return false;
+  if (hipMalloc(pb, b) != hipSuccess) {
+    (void)hipFree(*pa);
+    *pa = nullptr;
+    return false;
+  }
+  if (hipMalloc(pc, c) != hipSuccess) {
+    (void)hipFree(*pa);
+    (void)hipFree(*pb);
+    *pa = *pb = nullptr;
+    return false;
+  }
+  if (hipMalloc(pd, d) != hipSuccess) {
+    (void)hipFree(*pa);
+    (void)hipFree(*pb);
+    (void)hipFree(*pc);
+    *pa = *pb = *pc = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// Native FP8 resident: keep u8 weights + BF16 channel scales on device (no BF16 expand).
+// ~½ VRAM vs UploadFp8LayerStreaming BF16 path. Per-expert pointers alias layer packs.
+bool UploadFp8NativeLayer(Gemma4FusedExperts& ex, int dev) {
+  const int64_t E = ex.num_experts;
+  const int64_t I = ex.intermediate;
+  const int64_t H = ex.hidden;
+  if (E <= 0 || I <= 0 || H <= 0 || ex.fp8.size() != static_cast<size_t>(E)) return false;
+
+  const size_t gu_one = static_cast<size_t>(2 * I * H);       // u8
+  const size_t dn_one = static_cast<size_t>(H * I);           // u8
+  const size_t sgu_one = static_cast<size_t>(2 * I) * 2;      // bf16
+  const size_t sdn_one = static_cast<size_t>(H) * 2;          // bf16
+  const size_t gu_bytes = gu_one * static_cast<size_t>(E);
+  const size_t dn_bytes = dn_one * static_cast<size_t>(E);
+  const size_t sgu_bytes = sgu_one * static_cast<size_t>(E);
+  const size_t sdn_bytes = sdn_one * static_cast<size_t>(E);
+
+  void *gu = nullptr, *dn = nullptr, *sgu = nullptr, *sdn = nullptr;
+  if (!AllocFour(dev, gu_bytes, dn_bytes, sgu_bytes, sdn_bytes, &gu, &dn, &sgu, &sdn))
+    return false;
+
+  std::vector<uint8_t> gu_pack(gu_one);
+  for (int64_t e = 0; e < E; ++e) {
+    auto& fex = ex.fp8[static_cast<size_t>(e)];
+    VT_CHECK(fex.gate_w.HasHostBytes() && fex.up_w.HasHostBytes() && fex.down_w.HasHostBytes(),
+             "fp8 native resident: missing weights");
+    VT_CHECK(fex.gate_s.HasHostBytes() && fex.up_s.HasHostBytes() && fex.down_s.HasHostBytes(),
+             "fp8 native resident: missing scales");
+    // Pack gate|up FP8 contiguous [2I, H]
+    const size_t half = static_cast<size_t>(I * H);
+    std::memcpy(gu_pack.data(), fex.gate_w.bytes.data(), half);
+    std::memcpy(gu_pack.data() + half, fex.up_w.bytes.data(), half);
+    Check(hipMemcpy(static_cast<char*>(gu) + static_cast<size_t>(e) * gu_one, gu_pack.data(),
+                    gu_one, hipMemcpyHostToDevice),
+          "H2D fp8 gu");
+    Check(hipMemcpy(static_cast<char*>(dn) + static_cast<size_t>(e) * dn_one,
+                    fex.down_w.bytes.data(), dn_one, hipMemcpyHostToDevice),
+          "H2D fp8 dn");
+    // scales: gate then up → [2I]
+    Check(hipMemcpy(static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one,
+                    fex.gate_s.bytes.data(), static_cast<size_t>(I) * 2, hipMemcpyHostToDevice),
+          "H2D sgu g");
+    Check(hipMemcpy(static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one +
+                        static_cast<size_t>(I) * 2,
+                    fex.up_s.bytes.data(), static_cast<size_t>(I) * 2, hipMemcpyHostToDevice),
+          "H2D sgu u");
+    Check(hipMemcpy(static_cast<char*>(sdn) + static_cast<size_t>(e) * sdn_one,
+                    fex.down_s.bytes.data(), sdn_one, hipMemcpyHostToDevice),
+          "H2D sdn");
+
+    // Drop host BF16 caches if any
+    fex.cached_gu.clear();
+    fex.cached_gu.shrink_to_fit();
+    fex.cached_dn.clear();
+    fex.cached_dn.shrink_to_fit();
+
+    fex.dev_fp8_gu = static_cast<char*>(gu) + static_cast<size_t>(e) * gu_one;
+    fex.dev_fp8_dn = static_cast<char*>(dn) + static_cast<size_t>(e) * dn_one;
+    fex.dev_s_gu = static_cast<char*>(sgu) + static_cast<size_t>(e) * sgu_one;
+    fex.dev_s_dn = static_cast<char*>(sdn) + static_cast<size_t>(e) * sdn_one;
+    // Clear BF16 device expert slots (owned by LRU if any)
+    fex.dev_gu = nullptr;
+    fex.dev_dn = nullptr;
+  }
+
+  ex.fp8_gu_base = gu;
+  ex.fp8_dn_base = dn;
+  ex.fp8_sgu_base = sgu;
+  ex.fp8_sdn_base = sdn;
+  ex.fp8_native_resident = true;
+  ex.gate_up_dev = nullptr;
+  ex.down_dev = nullptr;
+  ex.dev_id = dev;
+  return true;
+}
+
+// Legacy: FP8 → BF16 expand on device (2× VRAM). Opt-in VT_GEMMA4_RESIDENT_BF16=1.
 bool UploadFp8LayerStreaming(Gemma4FusedExperts& ex, int dev) {
   const int64_t E = ex.num_experts;
   const int64_t I = ex.intermediate;
@@ -135,6 +263,20 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
 
   int fill_dev = 0;
 
+  // FP8 resident mode:
+  // Default: native FP8 packs (½ VRAM + fast fused ExpertGeGLU FP8 kernels).
+  // VT_GEMMA4_RESIDENT_BF16=1 forces BF16 expand (hipBLAS reference / A/B).
+  static const bool force_bf16 = [] {
+    const char* e = std::getenv("VT_GEMMA4_RESIDENT_BF16");
+    return e && e[0] == '1';
+  }();
+  static const bool force_native = [] {
+    const char* e = std::getenv("VT_GEMMA4_RESIDENT_NATIVE");
+    // Default ON when unset. =0 disables native (use BF16 expand).
+    if (e == nullptr) return true;
+    return e[0] == '1';
+  }();
+
   for (size_t li = 0; li < layers.size(); ++li) {
     if (ok_layers >= max_layers) break;
     auto& moe = layers[li];
@@ -143,23 +285,35 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
     const int64_t E = ex.num_experts;
     const int64_t I = ex.intermediate;
     const int64_t H = ex.hidden;
+    const bool want_native = ex.is_fp8 && !force_bf16 && force_native;
     const size_t layer_bytes =
-        static_cast<size_t>(E * 2 * I * H) * 2 + static_cast<size_t>(E * H * I) * 2;
+        want_native
+            ? (static_cast<size_t>(E) * (static_cast<size_t>(2 * I * H) + static_cast<size_t>(H * I) +
+                                         static_cast<size_t>(2 * I) * 2 + static_cast<size_t>(H) * 2))
+            : (static_cast<size_t>(E * 2 * I * H) * 2 + static_cast<size_t>(E * H * I) * 2);
 
     bool ok = false;
-    if (ex.is_fp8)
-      ok = UploadFp8LayerStreaming(ex, fill_dev);
-    else
+    if (ex.is_fp8) {
+      if (want_native)
+        ok = UploadFp8NativeLayer(ex, fill_dev);
+      else
+        ok = UploadFp8LayerStreaming(ex, fill_dev);
+    } else {
       ok = UploadBf16Layer(ex, fill_dev);
+    }
 
     if (!ok && fill_dev + 1 < num_gpus) {
       ++fill_dev;
       std::fprintf(stderr, "gemma4 moe: GPU%d full after %d layers; continuing on GPU%d\n",
                    fill_dev - 1, ok_layers, fill_dev);
-      if (ex.is_fp8)
-        ok = UploadFp8LayerStreaming(ex, fill_dev);
-      else
+      if (ex.is_fp8) {
+        if (want_native)
+          ok = UploadFp8NativeLayer(ex, fill_dev);
+        else
+          ok = UploadFp8LayerStreaming(ex, fill_dev);
+      } else {
         ok = UploadBf16Layer(ex, fill_dev);
+      }
     }
     if (!ok) {
       std::fprintf(stderr, "gemma4 moe: resident upload stopped at layer %zu (OOM)\n", li);
@@ -167,8 +321,10 @@ size_t UploadGemma4ExpertsResident(std::vector<Gemma4MoeLayerWeights>& layers,
     }
     total += layer_bytes;
     ++ok_layers;
-    std::fprintf(stderr, "gemma4 moe: resident layer %zu -> gpu %d (%.2f GiB cumulative)\n", li,
-                 ex.dev_id, total / (1024.0 * 1024.0 * 1024.0));
+    std::fprintf(stderr,
+                 "gemma4 moe: resident layer %zu -> gpu %d %s (%.2f GiB cumulative)\n", li,
+                 ex.dev_id, ex.fp8_native_resident ? "fp8-native" : "bf16",
+                 total / (1024.0 * 1024.0 * 1024.0));
     std::fflush(stderr);
   }
   Check(hipSetDevice(0), "hipSetDevice0");
@@ -226,6 +382,467 @@ bool PeerCopyGemma4ExpertSlice(int src_dev, const void* gate_up_base, const void
   return true;
 }
 
+bool PeerCopyGemma4Fp8ExpertSlice(int src_dev, const void* fp8_gu, const void* fp8_dn,
+                                  const void* s_gu, const void* s_dn, int64_t I, int64_t H,
+                                  int compute_dev, void* fp8_gu_dst, void* fp8_dn_dst,
+                                  void* s_gu_dst, void* s_dn_dst) {
+  if (!fp8_gu || !fp8_dn || !s_gu || !s_dn || !fp8_gu_dst || !fp8_dn_dst || !s_gu_dst ||
+      !s_dn_dst)
+    return false;
+  if (src_dev < 0 || compute_dev < 0) return false;
+  const size_t gu_b = static_cast<size_t>(2 * I * H);
+  const size_t dn_b = static_cast<size_t>(H * I);
+  const size_t sgu_b = static_cast<size_t>(2 * I) * 2;
+  const size_t sdn_b = static_cast<size_t>(H) * 2;
+  auto copy1 = [&](void* dst, const void* src, size_t n) -> bool {
+    if (src_dev == compute_dev) {
+      Check(hipSetDevice(compute_dev), "fp8 peer same");
+      return hipMemcpy(dst, src, n, hipMemcpyDeviceToDevice) == hipSuccess;
+    }
+    if (hipMemcpyPeer(dst, compute_dev, const_cast<void*>(src), src_dev, n) == hipSuccess)
+      return true;
+    std::vector<char> tmp(n);
+    Check(hipSetDevice(src_dev), "fp8 peer fb src");
+    if (hipMemcpy(tmp.data(), src, n, hipMemcpyDeviceToHost) != hipSuccess) return false;
+    Check(hipSetDevice(compute_dev), "fp8 peer fb dst");
+    return hipMemcpy(dst, tmp.data(), n, hipMemcpyHostToDevice) == hipSuccess;
+  };
+  if (!copy1(fp8_gu_dst, fp8_gu, gu_b)) return false;
+  if (!copy1(fp8_dn_dst, fp8_dn, dn_b)) return false;
+  if (!copy1(s_gu_dst, s_gu, sgu_b)) return false;
+  if (!copy1(s_dn_dst, s_dn, sdn_b)) return false;
+  Check(hipSetDevice(compute_dev), "fp8 peer restore");
+  return true;
+}
+
+bool RunGemma4Fp8TopKOnExpertDevice(vt::Queue& compute_q, int expert_dev, void* ysum_compute,
+                                    const void* x_compute, const void* const* fp8_gu,
+                                    const void* const* s_gu, const void* const* fp8_dn,
+                                    const void* const* s_dn, const float* wts, int G, int I,
+                                    int H) {
+  const int compute_dev = compute_q.device.index;
+  if (expert_dev < 0 || compute_dev < 0 || !ysum_compute || !x_compute || !fp8_gu || !s_gu ||
+      !fp8_dn || !s_dn || !wts || G <= 0 || I <= 0 || H <= 0)
+    return false;
+
+  struct Tls {
+    int cdev = -1;
+    int edev = -1;
+    vt::Queue cq{};  // only used when expert==compute and we need a stable q
+    vt::Queue eq{};
+    void* x = nullptr;
+    void* y = nullptr;
+    hipEvent_t ev_c = nullptr;
+    hipEvent_t ev_e = nullptr;
+    int H = 0;
+    bool eq_live = false;
+    bool cq_live = false;
+    bool peer_ok = false;
+  };
+  static thread_local Tls tls;
+  const size_t hb = static_cast<size_t>(H) * 2;  // bf16
+  hipStream_t cst = static_cast<hipStream_t>(compute_q.handle);
+
+  // Same device: run on compute_q directly (no Create/Destroy per call).
+  if (expert_dev == compute_dev) {
+    return vt::ExpertGeGLUFp8TopKM1(compute_q, ysum_compute, x_compute, fp8_gu, s_gu, fp8_dn, s_dn,
+                                    wts, G, I, H);
+  }
+
+  vt::Device edev{vt::DeviceType::kROCM, expert_dev};
+  if (tls.edev != expert_dev || tls.cdev != compute_dev || tls.H != H || !tls.x || !tls.y) {
+    if (tls.x) {
+      Check(hipSetDevice(tls.edev >= 0 ? tls.edev : expert_dev), "free x");
+      (void)hipFree(tls.x);
+      tls.x = nullptr;
+    }
+    if (tls.y) {
+      Check(hipSetDevice(tls.edev >= 0 ? tls.edev : expert_dev), "free y");
+      (void)hipFree(tls.y);
+      tls.y = nullptr;
+    }
+    if (tls.eq_live) {
+      vt::DestroyQueue(tls.eq);
+      tls.eq_live = false;
+    }
+    if (tls.ev_c) {
+      (void)hipEventDestroy(tls.ev_c);
+      tls.ev_c = nullptr;
+    }
+    if (tls.ev_e) {
+      (void)hipEventDestroy(tls.ev_e);
+      tls.ev_e = nullptr;
+    }
+    Check(hipSetDevice(expert_dev), "expert alloc");
+    if (hipMalloc(&tls.x, hb) != hipSuccess) return false;
+    if (hipMalloc(&tls.y, hb) != hipSuccess) {
+      (void)hipFree(tls.x);
+      tls.x = nullptr;
+      return false;
+    }
+    tls.eq = vt::CreateQueue(edev);
+    tls.eq_live = true;
+    Check(hipSetDevice(compute_dev), "ev c");
+    Check(hipEventCreateWithFlags(&tls.ev_c, hipEventDisableTiming), "ev_c");
+    Check(hipSetDevice(expert_dev), "ev e");
+    Check(hipEventCreateWithFlags(&tls.ev_e, hipEventDisableTiming), "ev_e");
+    // Best-effort P2P enable (ignore already-enabled / unsupported).
+    Check(hipSetDevice(compute_dev), "p2p c");
+    EnablePeerAccessQuiet(expert_dev);
+    Check(hipSetDevice(expert_dev), "p2p e");
+    EnablePeerAccessQuiet(compute_dev);
+    tls.edev = expert_dev;
+    tls.cdev = compute_dev;
+    tls.H = H;
+    tls.peer_ok = true;
+  }
+
+  hipStream_t est = static_cast<hipStream_t>(tls.eq.handle);
+
+  // Steady-state: stream-ordered peer, no per-hop hipSetDevice.
+  if (hipEventRecord(tls.ev_c, cst) != hipSuccess) return false;
+  if (hipStreamWaitEvent(est, tls.ev_c, 0) != hipSuccess) return false;
+
+  bool x_ok =
+      hipMemcpyPeerAsync(tls.x, expert_dev, const_cast<void*>(x_compute), compute_dev, hb, est) ==
+      hipSuccess;
+  if (!x_ok) {
+    // Host staging fallback (sync).
+    std::vector<char> tmp(hb);
+    Check(hipSetDevice(compute_dev), "x d2h");
+    if (hipStreamSynchronize(cst) != hipSuccess) return false;
+    if (hipMemcpy(tmp.data(), x_compute, hb, hipMemcpyDeviceToHost) != hipSuccess) return false;
+    Check(hipSetDevice(expert_dev), "x h2d");
+    if (hipMemcpyAsync(tls.x, tmp.data(), hb, hipMemcpyHostToDevice, est) != hipSuccess)
+      return false;
+  }
+
+  if (!vt::ExpertGeGLUFp8TopKM1(tls.eq, tls.y, tls.x, fp8_gu, s_gu, fp8_dn, s_dn, wts, G, I, H))
+    return false;
+
+  // expert → compute: record expert done, wait on compute stream, async peer y.
+  if (hipEventRecord(tls.ev_e, est) != hipSuccess) return false;
+  if (hipStreamWaitEvent(cst, tls.ev_e, 0) != hipSuccess) return false;
+
+  bool y_ok =
+      hipMemcpyPeerAsync(ysum_compute, compute_dev, tls.y, expert_dev, hb, cst) == hipSuccess;
+  if (!y_ok) {
+    std::vector<char> tmp(hb);
+    Check(hipSetDevice(expert_dev), "y d2h");
+    if (hipStreamSynchronize(est) != hipSuccess) return false;
+    if (hipMemcpy(tmp.data(), tls.y, hb, hipMemcpyDeviceToHost) != hipSuccess) return false;
+    Check(hipSetDevice(compute_dev), "y h2d");
+    if (hipMemcpyAsync(ysum_compute, tmp.data(), hb, hipMemcpyHostToDevice, cst) != hipSuccess)
+      return false;
+  }
+  if (hipSetDevice(compute_dev) != hipSuccess) return false;
+  return true;
+}
+
+// Decode T=1 indexed: bases stay on expert_dev; peer only x + tiny idx/wts + y.
+bool RunGemma4Fp8TopKIndexedOnExpertDevice(vt::Queue& compute_q, int expert_dev, void* ysum_compute,
+                                           const void* x_compute, const void* gu_base,
+                                           const void* dn_base, const void* sgu_base,
+                                           const void* sdn_base, const int32_t* idx_compute,
+                                           const float* wts_compute, int G, int I, int H) {
+  const int compute_dev = compute_q.device.index;
+  if (expert_dev < 0 || compute_dev < 0 || !ysum_compute || !x_compute || !gu_base || !dn_base ||
+      !sgu_base || !sdn_base || !idx_compute || !wts_compute || G <= 0 || I <= 0 || H <= 0)
+    return false;
+
+  if (expert_dev == compute_dev) {
+    return vt::ExpertGeGLUFp8TopKIndexed(compute_q, ysum_compute, x_compute, gu_base, dn_base,
+                                         sgu_base, sdn_base, idx_compute, wts_compute, G, I, H);
+  }
+
+  struct Tls {
+    int cdev = -1, edev = -1, H = 0, Gcap = 0;
+    vt::Queue eq{};
+    void* x = nullptr;
+    void* y = nullptr;
+    int32_t* idx = nullptr;
+    float* wts = nullptr;
+    hipEvent_t ev_c = nullptr, ev_e = nullptr;
+    bool eq_live = false;
+  };
+  static thread_local Tls tls;
+  const size_t hb = static_cast<size_t>(H) * 2;
+  hipStream_t cst = static_cast<hipStream_t>(compute_q.handle);
+  vt::Device edev{vt::DeviceType::kROCM, expert_dev};
+
+  if (tls.edev != expert_dev || tls.cdev != compute_dev || tls.H != H || tls.Gcap < G || !tls.x) {
+    if (tls.x) {
+      Check(hipSetDevice(tls.edev >= 0 ? tls.edev : expert_dev), "free");
+      (void)hipFree(tls.x);
+      (void)hipFree(tls.y);
+      (void)hipFree(tls.idx);
+      (void)hipFree(tls.wts);
+      tls.x = tls.y = nullptr;
+      tls.idx = nullptr;
+      tls.wts = nullptr;
+    }
+    if (tls.eq_live) {
+      vt::DestroyQueue(tls.eq);
+      tls.eq_live = false;
+    }
+    if (tls.ev_c) {
+      (void)hipEventDestroy(tls.ev_c);
+      tls.ev_c = nullptr;
+    }
+    if (tls.ev_e) {
+      (void)hipEventDestroy(tls.ev_e);
+      tls.ev_e = nullptr;
+    }
+    Check(hipSetDevice(expert_dev), "idx alloc");
+    if (hipMalloc(&tls.x, hb) != hipSuccess) return false;
+    if (hipMalloc(&tls.y, hb) != hipSuccess) {
+      (void)hipFree(tls.x);
+      tls.x = nullptr;
+      return false;
+    }
+    if (hipMalloc(&tls.idx, sizeof(int32_t) * 8) != hipSuccess) return false;
+    if (hipMalloc(&tls.wts, sizeof(float) * 8) != hipSuccess) return false;
+    tls.eq = vt::CreateQueue(edev);
+    tls.eq_live = true;
+    Check(hipSetDevice(compute_dev), "ev");
+    Check(hipEventCreateWithFlags(&tls.ev_c, hipEventDisableTiming), "ev_c");
+    Check(hipSetDevice(expert_dev), "ev e");
+    Check(hipEventCreateWithFlags(&tls.ev_e, hipEventDisableTiming), "ev_e");
+    Check(hipSetDevice(compute_dev), "p2p");
+    EnablePeerAccessQuiet(expert_dev);
+    Check(hipSetDevice(expert_dev), "p2p e");
+    EnablePeerAccessQuiet(compute_dev);
+    tls.edev = expert_dev;
+    tls.cdev = compute_dev;
+    tls.H = H;
+    tls.Gcap = 8;
+  }
+
+  hipStream_t est = static_cast<hipStream_t>(tls.eq.handle);
+  // Steady-state: no hipSetDevice between stream ops (graph-prep + less driver tax).
+  if (hipEventRecord(tls.ev_c, cst) != hipSuccess) return false;
+  if (hipStreamWaitEvent(est, tls.ev_c, 0) != hipSuccess) return false;
+
+  auto peer = [&](void* dst, const void* src, size_t n) -> bool {
+    return hipMemcpyPeerAsync(dst, expert_dev, const_cast<void*>(src), compute_dev, n, est) ==
+           hipSuccess;
+  };
+  if (!peer(tls.x, x_compute, hb)) return false;
+  if (!peer(tls.idx, idx_compute, sizeof(int32_t) * static_cast<size_t>(G))) return false;
+  if (!peer(tls.wts, wts_compute, sizeof(float) * static_cast<size_t>(G))) return false;
+
+  if (!vt::ExpertGeGLUFp8TopKIndexed(tls.eq, tls.y, tls.x, gu_base, dn_base, sgu_base, sdn_base,
+                                     tls.idx, tls.wts, G, I, H))
+    return false;
+
+  if (hipEventRecord(tls.ev_e, est) != hipSuccess) return false;
+  if (hipStreamWaitEvent(cst, tls.ev_e, 0) != hipSuccess) return false;
+  if (hipMemcpyPeerAsync(ysum_compute, compute_dev, tls.y, expert_dev, hb, cst) != hipSuccess)
+    return false;
+  if (hipSetDevice(compute_dev) != hipSuccess) return false;
+  return true;
+}
+
+// Prefill: run ExpertGeGLU for M rows on expert_dev (weights resident there).
+// Peer only activations M×H bf16 — not multi-GB FP8 expert packs.
+bool RunGemma4Fp8ExpertGeGLUPrefillOnExpertDevice(vt::Queue& compute_q, int expert_dev,
+                                                  void* y_compute, const void* x_compute,
+                                                  const void* fp8_gu, const void* s_gu,
+                                                  const void* fp8_dn, const void* s_dn, int M,
+                                                  int I, int H) {
+  const int compute_dev = compute_q.device.index;
+  if (expert_dev < 0 || compute_dev < 0 || !y_compute || !x_compute || !fp8_gu || !s_gu ||
+      !fp8_dn || !s_dn || M <= 0 || I <= 0 || H <= 0)
+    return false;
+
+  // Same device: caller should use local ExpertGeGLU; still support for safety.
+  if (expert_dev == compute_dev) {
+    vt::Device dev = compute_q.device;
+    // Dequant sticky into TLS then GEMM on compute_q.
+    struct SameTls {
+      int dev = -1;
+      int I = 0, H = 0, Mcap = 0;
+      const void* sticky = nullptr;
+      void* gu_w = nullptr;
+      void* dn_w = nullptr;
+      void* gu_act = nullptr;
+      void* act = nullptr;
+    };
+    static thread_local SameTls tls;
+    const size_t gu_w_b = static_cast<size_t>(2 * I) * static_cast<size_t>(H) * 2;
+    const size_t dn_w_b = static_cast<size_t>(H) * static_cast<size_t>(I) * 2;
+    const size_t gu_act_b = static_cast<size_t>(M) * static_cast<size_t>(2 * I) * 2;
+    const size_t act_b = static_cast<size_t>(M) * static_cast<size_t>(I) * 2;
+    if (tls.dev != compute_dev || tls.I != I || tls.H != H || tls.Mcap < M || !tls.gu_w) {
+      auto freep = [&](void*& p) {
+        if (p) {
+          (void)hipFree(p);
+          p = nullptr;
+        }
+      };
+      freep(tls.gu_w);
+      freep(tls.dn_w);
+      freep(tls.gu_act);
+      freep(tls.act);
+      Check(hipSetDevice(compute_dev), "same alloc");
+      if (hipMalloc(&tls.gu_w, gu_w_b) != hipSuccess) return false;
+      if (hipMalloc(&tls.dn_w, dn_w_b) != hipSuccess) return false;
+      // Cap act buffers to at least M; grow only.
+      size_t gu_act_cap = static_cast<size_t>(std::max(M, 64)) * static_cast<size_t>(2 * I) * 2;
+      size_t act_cap = static_cast<size_t>(std::max(M, 64)) * static_cast<size_t>(I) * 2;
+      if (hipMalloc(&tls.gu_act, gu_act_cap) != hipSuccess) return false;
+      if (hipMalloc(&tls.act, act_cap) != hipSuccess) return false;
+      tls.dev = compute_dev;
+      tls.I = I;
+      tls.H = H;
+      tls.Mcap = std::max(M, 64);
+      tls.sticky = nullptr;
+    }
+    if (tls.sticky != fp8_gu) {
+      vt::DequantFp8ChannelBf16(compute_q, tls.gu_w, fp8_gu, s_gu, 2 * I, H);
+      vt::DequantFp8ChannelBf16(compute_q, tls.dn_w, fp8_dn, s_dn, H, I);
+      tls.sticky = fp8_gu;
+    }
+    vt::Tensor x = vt::Tensor::Contiguous(const_cast<void*>(x_compute), vt::DType::kBF16, dev,
+                                          {M, H});
+    vt::Tensor gu_w = vt::Tensor::Contiguous(tls.gu_w, vt::DType::kBF16, dev, {2 * I, H});
+    vt::Tensor gu_act = vt::Tensor::Contiguous(tls.gu_act, vt::DType::kBF16, dev, {M, 2 * I});
+    vt::Tensor act = vt::Tensor::Contiguous(tls.act, vt::DType::kBF16, dev, {M, I});
+    vt::MatmulBT(compute_q, gu_act, x, gu_w);
+    vt::GeluAndMul(compute_q, act, gu_act);
+    vt::MatmulBTAlphaBeta(compute_q, y_compute, act.data, tls.dn_w, M, H, I, 1.f, 0.f,
+                          vt::DType::kBF16);
+    return true;
+  }
+
+  struct Tls {
+    int cdev = -1, edev = -1;
+    int I = 0, H = 0, Mcap = 0;
+    const void* sticky = nullptr;
+    vt::Queue eq{};
+    bool eq_live = false;
+    void* x = nullptr;
+    void* y = nullptr;
+    void* gu_w = nullptr;
+    void* dn_w = nullptr;
+    void* gu_act = nullptr;
+    void* act = nullptr;
+    hipEvent_t ev_c = nullptr, ev_e = nullptr;
+  };
+  static thread_local Tls tls;
+  const size_t row_b = static_cast<size_t>(H) * 2;
+  const size_t xy_need = static_cast<size_t>(M) * row_b;
+  const size_t gu_w_b = static_cast<size_t>(2 * I) * static_cast<size_t>(H) * 2;
+  const size_t dn_w_b = static_cast<size_t>(H) * static_cast<size_t>(I) * 2;
+  hipStream_t cst = static_cast<hipStream_t>(compute_q.handle);
+  vt::Device edev{vt::DeviceType::kROCM, expert_dev};
+
+  auto freep = [](int dev, void*& p) {
+    if (!p) return;
+    (void)hipSetDevice(dev);
+    (void)hipFree(p);
+    p = nullptr;
+  };
+
+  if (tls.edev != expert_dev || tls.cdev != compute_dev || tls.I != I || tls.H != H ||
+      tls.Mcap < M || !tls.x) {
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.x);
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.y);
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.gu_w);
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.dn_w);
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.gu_act);
+    freep(tls.edev >= 0 ? tls.edev : expert_dev, tls.act);
+    if (tls.eq_live) {
+      vt::DestroyQueue(tls.eq);
+      tls.eq_live = false;
+    }
+    if (tls.ev_c) {
+      (void)hipEventDestroy(tls.ev_c);
+      tls.ev_c = nullptr;
+    }
+    if (tls.ev_e) {
+      (void)hipEventDestroy(tls.ev_e);
+      tls.ev_e = nullptr;
+    }
+    const int Mcap = std::max(M, 64);
+    Check(hipSetDevice(expert_dev), "peer-act expert alloc");
+    if (hipMalloc(&tls.x, static_cast<size_t>(Mcap) * row_b) != hipSuccess) return false;
+    if (hipMalloc(&tls.y, static_cast<size_t>(Mcap) * row_b) != hipSuccess) return false;
+    if (hipMalloc(&tls.gu_w, gu_w_b) != hipSuccess) return false;
+    if (hipMalloc(&tls.dn_w, dn_w_b) != hipSuccess) return false;
+    if (hipMalloc(&tls.gu_act, static_cast<size_t>(Mcap) * static_cast<size_t>(2 * I) * 2) !=
+        hipSuccess)
+      return false;
+    if (hipMalloc(&tls.act, static_cast<size_t>(Mcap) * static_cast<size_t>(I) * 2) != hipSuccess)
+      return false;
+    tls.eq = vt::CreateQueue(edev);
+    tls.eq_live = true;
+    Check(hipSetDevice(compute_dev), "peer-act ev_c");
+    Check(hipEventCreateWithFlags(&tls.ev_c, hipEventDisableTiming), "ev_c");
+    Check(hipSetDevice(expert_dev), "peer-act ev_e");
+    Check(hipEventCreateWithFlags(&tls.ev_e, hipEventDisableTiming), "ev_e");
+    Check(hipSetDevice(compute_dev), "p2p c");
+    EnablePeerAccessQuiet(expert_dev);
+    Check(hipSetDevice(expert_dev), "p2p e");
+    EnablePeerAccessQuiet(compute_dev);
+    tls.edev = expert_dev;
+    tls.cdev = compute_dev;
+    tls.I = I;
+    tls.H = H;
+    tls.Mcap = Mcap;
+    tls.sticky = nullptr;
+  }
+
+  hipStream_t est = static_cast<hipStream_t>(tls.eq.handle);
+  if (hipEventRecord(tls.ev_c, cst) != hipSuccess) return false;
+  if (hipStreamWaitEvent(est, tls.ev_c, 0) != hipSuccess) return false;
+
+  bool x_ok = hipMemcpyPeerAsync(tls.x, expert_dev, const_cast<void*>(x_compute), compute_dev,
+                                 xy_need, est) == hipSuccess;
+  if (!x_ok) {
+    std::vector<char> tmp(xy_need);
+    Check(hipSetDevice(compute_dev), "x d2h");
+    if (hipStreamSynchronize(cst) != hipSuccess) return false;
+    if (hipMemcpy(tmp.data(), x_compute, xy_need, hipMemcpyDeviceToHost) != hipSuccess)
+      return false;
+    Check(hipSetDevice(expert_dev), "x h2d");
+    if (hipMemcpyAsync(tls.x, tmp.data(), xy_need, hipMemcpyHostToDevice, est) != hipSuccess)
+      return false;
+  }
+
+  if (tls.sticky != fp8_gu) {
+    Check(hipSetDevice(expert_dev), "dequant setdev");
+    vt::DequantFp8ChannelBf16(tls.eq, tls.gu_w, fp8_gu, s_gu, 2 * I, H);
+    vt::DequantFp8ChannelBf16(tls.eq, tls.dn_w, fp8_dn, s_dn, H, I);
+    tls.sticky = fp8_gu;
+  }
+
+  Check(hipSetDevice(expert_dev), "geglu setdev");
+  vt::Tensor x = vt::Tensor::Contiguous(tls.x, vt::DType::kBF16, edev, {M, H});
+  vt::Tensor gu_w = vt::Tensor::Contiguous(tls.gu_w, vt::DType::kBF16, edev, {2 * I, H});
+  vt::Tensor gu_act = vt::Tensor::Contiguous(tls.gu_act, vt::DType::kBF16, edev, {M, 2 * I});
+  vt::Tensor act = vt::Tensor::Contiguous(tls.act, vt::DType::kBF16, edev, {M, I});
+  vt::MatmulBT(tls.eq, gu_act, x, gu_w);
+  vt::GeluAndMul(tls.eq, act, gu_act);
+  vt::MatmulBTAlphaBeta(tls.eq, tls.y, act.data, tls.dn_w, M, H, I, 1.f, 0.f, vt::DType::kBF16);
+
+  if (hipEventRecord(tls.ev_e, est) != hipSuccess) return false;
+  if (hipStreamWaitEvent(cst, tls.ev_e, 0) != hipSuccess) return false;
+  bool y_ok =
+      hipMemcpyPeerAsync(y_compute, compute_dev, tls.y, expert_dev, xy_need, cst) == hipSuccess;
+  if (!y_ok) {
+    std::vector<char> tmp(xy_need);
+    Check(hipSetDevice(expert_dev), "y d2h");
+    if (hipStreamSynchronize(est) != hipSuccess) return false;
+    if (hipMemcpy(tmp.data(), tls.y, xy_need, hipMemcpyDeviceToHost) != hipSuccess) return false;
+    Check(hipSetDevice(compute_dev), "y h2d");
+    if (hipMemcpyAsync(y_compute, tmp.data(), xy_need, hipMemcpyHostToDevice, cst) != hipSuccess)
+      return false;
+  }
+  if (hipSetDevice(compute_dev) != hipSuccess) return false;
+  return true;
+}
+
 void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex) {
   if (ex.host_pinned) return;
   if (ex.cached_gu.empty() || ex.cached_dn.empty()) return;
@@ -239,6 +856,17 @@ void PinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex) {
       (e2 == hipSuccess || e2 == hipErrorHostMemoryAlreadyRegistered)) {
     ex.host_pinned = true;
   }
+}
+
+void UnpinGemma4Fp8ExpertHostCache(const Gemma4Fp8ExpertMats& ex) {
+  if (!ex.host_pinned) return;
+  if (!ex.cached_gu.empty()) {
+    (void)hipHostUnregister(const_cast<uint16_t*>(ex.cached_gu.data()));
+  }
+  if (!ex.cached_dn.empty()) {
+    (void)hipHostUnregister(const_cast<uint16_t*>(ex.cached_dn.data()));
+  }
+  ex.host_pinned = false;
 }
 
 }  // namespace vllm

--- a/src/vt/rocm/rocm_matmul_hipblaslt.hip
+++ b/src/vt/rocm/rocm_matmul_hipblaslt.hip
@@ -4,28 +4,13 @@
 //
 // MatmulBT: out[M,N] = a[M,K] @ b[N,K]^T  (b = Linear weight row-major)
 // Matmul:   out[M,N] = a[M,K] @ b[K,N]
-#include <hip/hip_bf16.h>
-#include <hip/hip_runtime.h>
-// hipBLAS ships TWO generations of the *Ex entry points and picks between them
-// in the header. The legacy generation takes `hipblasDatatype_t` (HIPBLAS_R_*);
-// the current one takes the HIP-wide `hipDataType` (HIP_R_*). This file is
-// written entirely against the current one — every data type below is HIP_R_*,
-// and the compute type is already the current `hipblasComputeType_t` — but it
-// never ASKED for it, so it only compiled on a ROCm new enough to make that
-// generation the default (7.x, where the row was developed on gfx1201).
-//
-// On ROCm 6.4 the legacy generation is the default, the two enums are distinct
-// types with no implicit conversion, and all six *Ex call sites fail with
-// "no matching function for call to 'hipblasGemmEx' ... no known conversion
-// from 'const hipDataType' to 'hipblasDatatype_t' for 9th argument" (issue #201,
-// gfx1100). Selecting the generation the file is written for fixes all six at
-// the include, rather than teaching six call sites to switch enums.
-//
-// Must precede <hipblas/hipblas.h>: it is what the header dispatches on. Newer
-// hipBLAS, where this generation is already the default, ignores it.
+// Required on ROCm 6.x for hipblasGemmEx overloads (#201/#132).
 #ifndef HIPBLAS_V2
 #define HIPBLAS_V2
 #endif
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
 #include <hipblaslt/hipblaslt.h>
 
@@ -41,6 +26,7 @@
 #include <vector>
 
 #include "vt/ops.h"
+#include "vt/rocm/rocm_device_bind.h"
 
 namespace vt::rocm {
 namespace {
@@ -90,12 +76,18 @@ BlasCtx GetBlas(int device, hipStream_t stream) {
     hipblasHandle_t handle = nullptr;
   };
   static thread_local Tls tls;
+  // Bind current device outside capture so create/setStream see the right GPU
+  // after peer-MoE left current on the expert device.
+  if (!StreamIsCapturing(stream)) {
+    int cur = -1;
+    if (hipGetDevice(&cur) != hipSuccess || cur != device) (void)hipSetDevice(device);
+  }
   if (tls.handle == nullptr || tls.dev != device) {
     if (tls.handle) {
-      // device switch rare — destroy old handle
       (void)hipblasDestroy(tls.handle);
       tls.handle = nullptr;
     }
+    if (!StreamIsCapturing(stream)) (void)hipSetDevice(device);
     CheckBlas(hipblasCreate(&tls.handle), "hipblasCreate");
     tls.dev = device;
     tls.stream = nullptr;
@@ -136,48 +128,77 @@ hipblasComputeType_t GemmCompute(DType dt) {
   return k;
 }
 
-// VT_ROCM_GEMV=1 enables naive M=1 BF16 GEMV (default OFF — hipblas faster on gfx1201).
+// VT_ROCM_GEMV: 1=force custom M=1 BF16 GEMV, 0/unset=hipblas (faster on gfx1201 lab).
 bool GemvEnabled() {
   static const bool on = [] {
     if (const char* e = std::getenv("VT_ROCM_GEMV")) return e[0] == '1';
-    return false;
+    return false;  // hipblasGemmEx wins A/B 2026-08-09 (~52 vs ~40 t/s)
   }();
   return on;
 }
 
 // y[n] = alpha * dot(x[0:K], W[n,0:K]) + beta * y[n]
-// W row-major [N,K].
-// Strategy: cache x in LDS; each block owns a tile of output rows.
-// VT_ROCM_GEMV=1 to enable (default off — A/B vs hipblas).
-__global__ void Bf16GemvBTKernel(__hip_bfloat16* __restrict__ y,
-                                 const __hip_bfloat16* __restrict__ x,
-                                 const __hip_bfloat16* __restrict__ W, int N, int K,
-                                 float alpha, float beta) {
-  // Dynamic shared: x_cache[K] floats
+// grid = N — one block per output row; x cached in LDS; block-reduce over K.
+__global__ void Bf16GemvBTRowKernel(__hip_bfloat16* __restrict__ y,
+                                    const __hip_bfloat16* __restrict__ x,
+                                    const __hip_bfloat16* __restrict__ W, int N, int K,
+                                    float alpha, float beta) {
+  const int n = static_cast<int>(blockIdx.x);
+  if (n >= N) return;
   extern __shared__ float smem[];
   float* x_cache = smem;
-
-  // Cooperative load of x into LDS
-  for (int k = static_cast<int>(threadIdx.x); k < K; k += static_cast<int>(blockDim.x)) {
-    x_cache[k] = __bfloat162float(x[k]);
-  }
+  const int tid = static_cast<int>(threadIdx.x);
+  constexpr int kBlock = 256;
+  for (int k = tid; k < K; k += kBlock) x_cache[k] = __bfloat162float(x[k]);
   __syncthreads();
 
-  // Each thread owns one or more output rows
-  for (int n = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x); n < N;
-       n += static_cast<int>(gridDim.x * blockDim.x)) {
-    const __hip_bfloat16* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
-    float acc = 0.f;
-    // Unroll-friendly scalar loop; x from LDS
-    int k = 0;
-    for (; k + 3 < K; k += 4) {
-      acc += x_cache[k] * __bfloat162float(wrow[k]);
-      acc += x_cache[k + 1] * __bfloat162float(wrow[k + 1]);
-      acc += x_cache[k + 2] * __bfloat162float(wrow[k + 2]);
-      acc += x_cache[k + 3] * __bfloat162float(wrow[k + 3]);
-    }
-    for (; k < K; ++k) acc += x_cache[k] * __bfloat162float(wrow[k]);
-    float v = alpha * acc;
+  const __hip_bfloat16* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
+  float acc = 0.f;
+  const int K16 = K & ~15;
+  for (int k = tid * 16; k < K16; k += kBlock * 16) {
+#pragma unroll
+    for (int t = 0; t < 16; ++t) acc += x_cache[k + t] * __bfloat162float(wrow[k + t]);
+  }
+  for (int k = K16 + tid; k < K; k += kBlock) acc += x_cache[k] * __bfloat162float(wrow[k]);
+
+  __shared__ float red[256];
+  red[tid] = acc;
+  __syncthreads();
+#pragma unroll
+  for (int s = 128; s > 0; s >>= 1) {
+    if (tid < s) red[tid] += red[tid + s];
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float v = alpha * red[0];
+    if (beta != 0.f) v += beta * __bfloat162float(y[n]);
+    y[n] = __float2bfloat16(v);
+  }
+}
+
+// Fallback when K*f32 LDS too big: no x cache, threads stride K from global.
+__global__ void Bf16GemvBTRowNoLdsKernel(__hip_bfloat16* __restrict__ y,
+                                         const __hip_bfloat16* __restrict__ x,
+                                         const __hip_bfloat16* __restrict__ W, int N, int K,
+                                         float alpha, float beta) {
+  const int n = static_cast<int>(blockIdx.x);
+  if (n >= N) return;
+  const int tid = static_cast<int>(threadIdx.x);
+  constexpr int kBlock = 256;
+  const __hip_bfloat16* wrow = W + static_cast<int64_t>(n) * static_cast<int64_t>(K);
+  float acc = 0.f;
+  for (int k = tid; k < K; k += kBlock)
+    acc += __bfloat162float(x[k]) * __bfloat162float(wrow[k]);
+  __shared__ float red[256];
+  red[tid] = acc;
+  __syncthreads();
+#pragma unroll
+  for (int s = 128; s > 0; s >>= 1) {
+    if (tid < s) red[tid] += red[tid + s];
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float v = alpha * red[0];
     if (beta != 0.f) v += beta * __bfloat162float(y[n]);
     y[n] = __float2bfloat16(v);
   }
@@ -187,12 +208,16 @@ void Bf16GemvBT(hipStream_t s, void* out, const void* a, const void* b, int N, i
                 float alpha, float beta) {
   constexpr int kBlock = 256;
   if (K <= 0 || N <= 0) return;
-  const int grid = (N + kBlock - 1) / kBlock;
   const size_t shmem = static_cast<size_t>(K) * sizeof(float);
-  if (shmem > 48 * 1024) return;  // caller falls through if we no-op — keep K small
-  Bf16GemvBTKernel<<<grid, kBlock, shmem, s>>>(
-      static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
-      static_cast<const __hip_bfloat16*>(b), N, K, alpha, beta);
+  if (shmem <= 48 * 1024) {
+    Bf16GemvBTRowKernel<<<N, kBlock, shmem, s>>>(
+        static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
+        static_cast<const __hip_bfloat16*>(b), N, K, alpha, beta);
+  } else {
+    Bf16GemvBTRowNoLdsKernel<<<N, kBlock, 0, s>>>(
+        static_cast<__hip_bfloat16*>(out), static_cast<const __hip_bfloat16*>(a),
+        static_cast<const __hip_bfloat16*>(b), N, K, alpha, beta);
+  }
 }
 
 // VT_ROCM_HIPBLASLT=1 enables. Default OFF — heuristic path aborted on gfx1201 in lab.
@@ -417,6 +442,7 @@ void MatmulKernelRocm(Queue& q, Tensor& out, const Tensor& a, const Tensor& b) {
 //   opB=N, B is KxM col = row A[M,K] with ld=a_rs
 //   C is NxM col = row out[M,N] ld=N
 void MatmulBTKernelRocm(Queue& q, Tensor& out, const Tensor& a, const Tensor& b) {
+  EnsureQueueDevice(q);
   const bool bf16 = a.dtype == DType::kBF16 && b.dtype == DType::kBF16;
   const bool f32 = a.dtype == DType::kF32 && b.dtype == DType::kF32;
   if (!bf16 && !f32) {

--- a/src/vt/rocm/rocm_paged_attn.hip
+++ b/src/vt/rocm/rocm_paged_attn.hip
@@ -3,6 +3,11 @@
 // Supports bf16/f32 query x bf16/f32 KV (mixed allowed).
 #include <hip/hip_bf16.h>
 #include <hip/hip_runtime.h>
+// rocWMMA only on gfx12 (R9700). Fat builds also emit gfx1036 — must not include there.
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#include <rocwmma/rocwmma.hpp>
+#define VT_ROCWMMA_OK 1
+#endif
 
 #include <cmath>
 #include <cstdint>
@@ -118,7 +123,14 @@ __device__ inline float Softcap(float s, float cap) {
   return cap > 0.f ? cap * tanhf(s / cap) : s;
 }
 
+// gfx1201: exp2 is the native path; expf often lowers slower. Used in online softmax.
+__device__ inline float FastExp(float x) {
+  return __builtin_amdgcn_exp2f(x * 1.4426950408889634f);  // x * log2(e)
+}
+
 // One block per (query_token, q_head). Online softmax matches CUDA.
+// Fast-path: num_reqs==1 skips linear request scan (Hermes/single-seq decode).
+// Vectorized x4 Q·K / V when head_dim % 4 == 0 (Gemma-4 Dh is).
 template <typename TQ, typename TKV, typename TO>
 __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
                                 const TKV* v_cache, const int32_t* block_table,
@@ -133,16 +145,23 @@ __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
   if (h >= hq) return;
 
   int64_t r = -1, q0 = 0, q1 = 0;
-  for (int64_t rr = 0; rr < num_reqs; ++rr) {
-    const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
-    if (t >= a && t < b) {
-      r = rr;
-      q0 = a;
-      q1 = b;
-      break;
+  if (num_reqs == 1) {
+    r = 0;
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+    if (t < q0 || t >= q1) return;
+  } else {
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t >= a && t < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
     }
+    if (r < 0) return;
   }
-  if (r < 0) return;
 
   const int64_t query_len = q1 - q0;
   const int64_t seqlen = seq_lens[r];
@@ -162,8 +181,8 @@ __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
   if (jmax > seqlen - 1) jmax = seqlen - 1;
   const int64_t g = h / (hq / num_kv_heads);
   const int64_t qoff = (t * hq + h) * d;
+  const bool vec4 = (d % 4) == 0;
 
-  // shared: acc[d] + red[blockDim]
   extern __shared__ float smem[];
   float* acc = smem;
   float* red = smem + d;
@@ -182,8 +201,19 @@ __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
       const int64_t off = j % block_size;
       const int64_t kbase = blk * kc_blk + off * kc_pg + g * kc_hd;
       float part = 0.f;
-      for (int64_t e = threadIdx.x; e < d; e += blockDim.x)
-        part += Ld(query, qoff + e) * Ld(k_cache, kbase + e);
+      if (vec4) {
+        const int64_t nvec = d >> 2;
+        for (int64_t v = threadIdx.x; v < nvec; v += blockDim.x) {
+          const int64_t e = v << 2;
+          part += Ld(query, qoff + e) * Ld(k_cache, kbase + e);
+          part += Ld(query, qoff + e + 1) * Ld(k_cache, kbase + e + 1);
+          part += Ld(query, qoff + e + 2) * Ld(k_cache, kbase + e + 2);
+          part += Ld(query, qoff + e + 3) * Ld(k_cache, kbase + e + 3);
+        }
+      } else {
+        for (int64_t e = threadIdx.x; e < d; e += blockDim.x)
+          part += Ld(query, qoff + e) * Ld(k_cache, kbase + e);
+      }
       red[threadIdx.x] = part;
       __syncthreads();
       for (int stride = (int)blockDim.x / 2; stride > 0; stride >>= 1) {
@@ -198,8 +228,19 @@ __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
       const float corr = expf(s_m - m_new);
       const float pw = expf(s - m_new);
       const int64_t vbase = blk * vc_blk + off * vc_pg + g * vc_hd;
-      for (int64_t e = threadIdx.x; e < d; e += blockDim.x)
-        acc[e] = acc[e] * corr + pw * Ld(v_cache, vbase + e);
+      if (vec4) {
+        const int64_t nvec = d >> 2;
+        for (int64_t v = threadIdx.x; v < nvec; v += blockDim.x) {
+          const int64_t e = v << 2;
+          acc[e] = acc[e] * corr + pw * Ld(v_cache, vbase + e);
+          acc[e + 1] = acc[e + 1] * corr + pw * Ld(v_cache, vbase + e + 1);
+          acc[e + 2] = acc[e + 2] * corr + pw * Ld(v_cache, vbase + e + 2);
+          acc[e + 3] = acc[e + 3] * corr + pw * Ld(v_cache, vbase + e + 3);
+        }
+      } else {
+        for (int64_t e = threadIdx.x; e < d; e += blockDim.x)
+          acc[e] = acc[e] * corr + pw * Ld(v_cache, vbase + e);
+      }
       __syncthreads();
       if (threadIdx.x == 0) {
         s_l = s_l * corr + pw;
@@ -212,6 +253,1391 @@ __global__ void PagedAttnOnline(TO* out, const TQ* query, const TKV* k_cache,
   const float inv = (s_l > 0.f) ? (1.f / s_l) : 0.f;
   for (int64_t e = threadIdx.x; e < d; e += blockDim.x) St(out, qoff + e, acc[e] * inv);
 }
+
+// ===========================================================================
+// DECODE-oriented path (ported from cuda_paged_attn DecodeOpt). d==256 bf16.
+// 8 warps stride KV; warp-shuffle Q·K; register online softmax; no per-key
+// block sync. Grid (total_q, hq), block 256.
+// ===========================================================================
+constexpr int kDecWarps = 8;
+constexpr int kDecEpl = 8;  // 32 lanes * 8 = 256 head_dim
+
+// EPL elems/lane: 8 → d=256, 16 → d=512 (32 lanes).
+template <int EPL>
+__device__ inline void LoadRowEplBf16(const __hip_bfloat16* p, int64_t base, int lane, float r[EPL]) {
+  static_assert(EPL == 8 || EPL == 16, "EPL");
+  const uint4* u = reinterpret_cast<const uint4*>(p + base);
+  if constexpr (EPL == 8) {
+    const uint4 w = u[lane];
+    const __hip_bfloat16* h = reinterpret_cast<const __hip_bfloat16*>(&w);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) r[i] = __bfloat162float(h[i]);
+  } else {
+    const uint4 w0 = u[lane];
+    const uint4 w1 = u[lane + 32];
+    const __hip_bfloat16* h0 = reinterpret_cast<const __hip_bfloat16*>(&w0);
+    const __hip_bfloat16* h1 = reinterpret_cast<const __hip_bfloat16*>(&w1);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) r[i] = __bfloat162float(h0[i]);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) r[i + 8] = __bfloat162float(h1[i]);
+  }
+}
+
+template <int EPL>
+__device__ inline void StoreRowEplBf16(__hip_bfloat16* p, int64_t base, int lane, const float r[EPL]) {
+  static_assert(EPL == 8 || EPL == 16, "EPL");
+  if constexpr (EPL == 8) {
+    __hip_bfloat16 tmp[8];
+#pragma unroll
+    for (int i = 0; i < 8; ++i) tmp[i] = __float2bfloat16(r[i]);
+    reinterpret_cast<uint4*>(p + base)[lane] = *reinterpret_cast<const uint4*>(tmp);
+  } else {
+    __hip_bfloat16 t0[8], t1[8];
+#pragma unroll
+    for (int i = 0; i < 8; ++i) t0[i] = __float2bfloat16(r[i]);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) t1[i] = __float2bfloat16(r[i + 8]);
+    uint4* u = reinterpret_cast<uint4*>(p + base);
+    u[lane] = *reinterpret_cast<const uint4*>(t0);
+    u[lane + 32] = *reinterpret_cast<const uint4*>(t1);
+  }
+}
+
+__device__ inline void LoadRow8Bf16(const __hip_bfloat16* p, int64_t base, int lane, float r[8]) {
+  LoadRowEplBf16<8>(p, base, lane, r);
+}
+__device__ inline void StoreRow8Bf16(__hip_bfloat16* p, int64_t base, int lane, const float r[8]) {
+  StoreRowEplBf16<8>(p, base, lane, r);
+}
+
+// BF16 Q/K/V/Out; EPL=8 → d=256, EPL=16 → d=512. No per-key block sync (decode+prefill).
+template <int EPL>
+__global__ void PagedAttnDecodeOptBf16T(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                        const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                        const int32_t* block_table, const int32_t* seq_lens,
+                                        const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                        int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                        int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                        int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                        float scale, float softcap, bool causal, int window_left,
+                                        int window_right) {
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  const int64_t t = blockIdx.x;
+  const int64_t h = blockIdx.y;
+  const int warp = static_cast<int>(threadIdx.x) >> 5;
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  if (h >= hq || d != d_expect) return;
+
+  int64_t r = -1, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    r = 0;
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+    if (t < q0 || t >= q1) return;
+  } else {
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t >= a && t < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int64_t p = context + (t - q0);
+
+  int64_t jmin = 0;
+  if (window_left >= 0) {
+    jmin = p - window_left;
+    if (jmin < 0) jmin = 0;
+  }
+  int64_t jmax = causal ? p : (seqlen - 1);
+  if (window_right >= 0) {
+    const int64_t jr = p + window_right;
+    if (jr < jmax) jmax = jr;
+  }
+  if (jmax > seqlen - 1) jmax = seqlen - 1;
+
+  const int64_t g = h / (hq / num_kv_heads);
+  const int64_t qoff = (t * hq + h) * d;
+
+  float q_reg[kEpl];
+  LoadRowEplBf16<kEpl>(query, qoff, lane, q_reg);
+
+  float m = -INFINITY, lsum = 0.f;
+  float o_reg[kEpl];
+#pragma unroll
+  for (int i = 0; i < kEpl; ++i) o_reg[i] = 0.f;
+
+  for (int64_t j = jmin + warp; j <= jmax; j += kDecWarps) {
+    const int64_t blk = block_table[r * bt_row + (j / block_size) * bt_col];
+    const int64_t off = j % block_size;
+    float k_reg[kEpl];
+    LoadRowEplBf16<kEpl>(k_cache, blk * kc_blk + off * kc_pg + g * kc_hd, lane, k_reg);
+    float dot = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) dot += q_reg[i] * k_reg[i];
+#pragma unroll
+    for (int o = 16; o > 0; o >>= 1) dot += __shfl_down(dot, o);
+    dot = __shfl(dot, 0);
+
+    const float s = Softcap(dot * scale, softcap);
+    const float m_new = fmaxf(m, s);
+    const float corr = FastExp(m - m_new);
+    const float pw = FastExp(s - m_new);
+    float v_reg[kEpl];
+    LoadRowEplBf16<kEpl>(v_cache, blk * vc_blk + off * vc_pg + g * vc_hd, lane, v_reg);
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_reg[i] = o_reg[i] * corr + pw * v_reg[i];
+    lsum = lsum * corr + pw;
+    m = m_new;
+  }
+
+  extern __shared__ float smem_dec[];
+  float* o_sh = smem_dec;
+  float* m_sh = o_sh + kDecWarps * d;
+  float* l_sh = m_sh + kDecWarps;
+#pragma unroll
+  for (int i = 0; i < kEpl; ++i) o_sh[warp * d + lane * kEpl + i] = o_reg[i];
+  if (lane == 0) {
+    m_sh[warp] = m;
+    l_sh[warp] = lsum;
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+    float gm = -INFINITY;
+#pragma unroll
+    for (int w = 0; w < kDecWarps; ++w) gm = fmaxf(gm, m_sh[w]);
+    float gl = 0.f;
+    float acc[kEpl];
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] = 0.f;
+#pragma unroll
+    for (int w = 0; w < kDecWarps; ++w) {
+      const float sc = FastExp(m_sh[w] - gm);
+      gl += l_sh[w] * sc;
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) acc[i] += sc * o_sh[w * d + lane * kEpl + i];
+    }
+    const float inv = (gl > 0.f) ? (1.f / gl) : 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] *= inv;
+    StoreRowEplBf16<kEpl>(out, qoff, lane, acc);
+  }
+}
+
+// GQA-fused decode: one CTA per KV head; load K/V once, attend QG q-heads.
+// Gemma-4: hq=16, kv=8 → QG=2. EPL=8→d=256, EPL=16→d=512. grid=(total_q, num_kv_heads).
+template <int QG, int EPL = 8, int NWARPS = kDecWarps>
+__global__ void PagedAttnDecodeGqaBf16(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                       const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                       const int32_t* block_table, const int32_t* seq_lens,
+                                       const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                       int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                       int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                       int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                       float scale, float softcap, bool causal, int window_left,
+                                       int window_right) {
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  const int64_t t = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int warp = static_cast<int>(threadIdx.x) >> 5;
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  if (g >= num_kv_heads || d != d_expect) return;
+
+  int64_t r = -1, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    r = 0;
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+    if (t < q0 || t >= q1) return;
+  } else {
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t >= a && t < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int64_t p = context + (t - q0);
+  int64_t jmin = 0;
+  if (window_left >= 0) {
+    jmin = p - window_left;
+    if (jmin < 0) jmin = 0;
+  }
+  int64_t jmax = causal ? p : (seqlen - 1);
+  if (window_right >= 0) {
+    const int64_t jr = p + window_right;
+    if (jr < jmax) jmax = jr;
+  }
+  if (jmax > seqlen - 1) jmax = seqlen - 1;
+
+  const int64_t qg_total = hq / num_kv_heads;
+  // blockIdx.z splits a large GQA group into QG-sized tiles (e.g. global QG=8 → two×4).
+  const int64_t h0 = g * qg_total + static_cast<int64_t>(blockIdx.z) * QG;
+  if (h0 + QG > (g + 1) * qg_total) return;
+  float q_reg[QG][kEpl];
+#pragma unroll
+  for (int hh = 0; hh < QG; ++hh)
+    LoadRowEplBf16<kEpl>(query, (t * hq + (h0 + hh)) * d, lane, q_reg[hh]);
+
+  float m[QG], lsum[QG];
+  float o_reg[QG][kEpl];
+#pragma unroll
+  for (int hh = 0; hh < QG; ++hh) {
+    m[hh] = -INFINITY;
+    lsum[hh] = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = 0.f;
+  }
+
+  for (int64_t j = jmin + warp; j <= jmax; j += NWARPS) {
+    const int64_t blk = block_table[r * bt_row + (j / block_size) * bt_col];
+    const int64_t off = j % block_size;
+    float k_reg[kEpl];
+    LoadRowEplBf16<kEpl>(k_cache, blk * kc_blk + off * kc_pg + g * kc_hd, lane, k_reg);
+
+    float s_h[QG];
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh) {
+      float dot = 0.f;
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) dot += q_reg[hh][i] * k_reg[i];
+#pragma unroll
+      for (int o = 16; o > 0; o >>= 1) dot += __shfl_down(dot, o);
+      s_h[hh] = Softcap(__shfl(dot, 0) * scale, softcap);
+    }
+
+    float v_reg[kEpl];
+    LoadRowEplBf16<kEpl>(v_cache, blk * vc_blk + off * vc_pg + g * vc_hd, lane, v_reg);
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh) {
+      const float m_new = fmaxf(m[hh], s_h[hh]);
+      const float corr = FastExp(m[hh] - m_new);
+      const float pw = FastExp(s_h[hh] - m_new);
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = o_reg[hh][i] * corr + pw * v_reg[i];
+      lsum[hh] = lsum[hh] * corr + pw;
+      m[hh] = m_new;
+    }
+  }
+
+  extern __shared__ float smem_gqa[];
+  float* o_sh = smem_gqa;
+  float* m_sh = o_sh + static_cast<size_t>(NWARPS) * QG * d;
+  float* l_sh = m_sh + static_cast<size_t>(NWARPS) * QG;
+#pragma unroll
+  for (int hh = 0; hh < QG; ++hh) {
+    float* dst = o_sh + (static_cast<size_t>(warp) * QG + hh) * d + lane * kEpl;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) dst[i] = o_reg[hh][i];
+    if (lane == 0) {
+      m_sh[warp * QG + hh] = m[hh];
+      l_sh[warp * QG + hh] = lsum[hh];
+    }
+  }
+  __syncthreads();
+
+  for (int hh = warp; hh < QG; hh += NWARPS) {
+    float gm = -INFINITY;
+#pragma unroll
+    for (int w = 0; w < NWARPS; ++w) gm = fmaxf(gm, m_sh[w * QG + hh]);
+    float gl = 0.f;
+    float acc[kEpl];
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] = 0.f;
+#pragma unroll
+    for (int w = 0; w < NWARPS; ++w) {
+      const float sc = FastExp(m_sh[w * QG + hh] - gm);
+      gl += l_sh[w * QG + hh] * sc;
+      const float* src = o_sh + (static_cast<size_t>(w) * QG + hh) * d + lane * kEpl;
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) acc[i] += sc * src[i];
+    }
+    const float inv = (gl > 0.f) ? (1.f / gl) : 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] *= inv;
+    StoreRowEplBf16<kEpl>(out, (t * hq + (h0 + hh)) * d, lane, acc);
+  }
+}
+
+
+// SGLang-style flash prefill GQA (steal base 2026-08-10):
+//   BLOCK_M queries × BLOCK_N keys, Q+K tiles in smem, online softmax.
+//   HIP default tiles from extend_attention: BLOCK_M=64, BLOCK_N=64.
+// grid=(ceil(total_q/BM), num_kv_heads). One CTA = one Q-tile × one KV head (QG q-heads).
+// SGLang-style tile flash: BM×BN, Q+K in smem, o/m/l in registers (no huge o smem).
+// HIP steal defaults ~64×64; we use BM=16 BN=64 @d=256 and BM=8 BN=64 @d=512 to fit LDS.
+template <int QG, int EPL, int BM, int BN>
+__global__ void PagedAttnPrefillFlashTile(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                          const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                          const int32_t* block_table, const int32_t* seq_lens,
+                                          const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                          int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                          int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                          int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                          float scale, float softcap, bool causal, int window_left,
+                                          int window_right) {
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  // Max rows this CTA tracks = BM * QG; each warp owns a strided subset.
+  constexpr int kRows = BM * QG;
+  const int64_t q_tile = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int warp = tid >> 5;
+  const int lane = tid & 31;
+  const int nwarps = static_cast<int>(blockDim.x) >> 5;
+  if (g >= num_kv_heads || d != d_expect) return;
+
+  const int64_t t_base = q_tile * BM;
+  int64_t r = 0, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+  } else {
+    r = -1;
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t_base >= a && t_base < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+  if (t_base >= q1) return;
+  const int nq = static_cast<int>((q1 - t_base) < BM ? (q1 - t_base) : BM);
+  if (nq <= 0) return;
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int nrows = nq * QG;
+
+  __shared__ int64_t s_jmin_q[BM], s_jmax_q[BM];
+  __shared__ int64_t s_jmin, s_jmax;
+  for (int qq = tid; qq < BM; qq += static_cast<int>(blockDim.x)) {
+    if (qq >= nq) {
+      s_jmin_q[qq] = seqlen;
+      s_jmax_q[qq] = -1;
+      continue;
+    }
+    const int64_t t = t_base + qq;
+    const int64_t pos = context + (t - q0);
+    int64_t jn = 0;
+    if (window_left >= 0) {
+      jn = pos - window_left;
+      if (jn < 0) jn = 0;
+    }
+    int64_t jx = causal ? pos : (seqlen - 1);
+    if (window_right >= 0) {
+      const int64_t jr = pos + window_right;
+      if (jr < jx) jx = jr;
+    }
+    if (jx > seqlen - 1) jx = seqlen - 1;
+    s_jmin_q[qq] = jn;
+    s_jmax_q[qq] = jx;
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int64_t tn = seqlen, tx = -1;
+    for (int qq = 0; qq < nq; ++qq) {
+      if (s_jmin_q[qq] < tn) tn = s_jmin_q[qq];
+      if (s_jmax_q[qq] > tx) tx = s_jmax_q[qq];
+    }
+    s_jmin = tn;
+    s_jmax = tx;
+  }
+  __syncthreads();
+  if (s_jmax < s_jmin) return;
+
+  const int64_t h0 = g * QG;
+  // smem: Q[BM*QG*d] bf16 + KV[BN*d] bf16  (d=256 BM=16 BN=64 → 16KB+32KB)
+  extern __shared__ __hip_bfloat16 dyn_bf[];
+  __hip_bfloat16* q_sm = dyn_bf;
+  __hip_bfloat16* kv_sm = q_sm + static_cast<size_t>(BM) * QG * d;
+  __shared__ int64_t s_blk[BN], s_off[BN];
+  // Scores: QG planes of BM×BN so rocWMMA can store_matrix_sync with ld=BN
+  // (consecutive qq for fixed hh). No per-warp tile_s[8] — that overflowed LDS.
+  __shared__ float s_sc[QG * BM * BN];
+
+  // Load Q tile; zero-pad to full BM so WMMA never OOB on partial last tiles.
+  for (int e = tid; e < BM * QG * static_cast<int>(d); e += static_cast<int>(blockDim.x))
+    q_sm[e] = __hip_bfloat16{};
+  __syncthreads();
+  for (int e = tid; e < nq * QG * static_cast<int>(d); e += static_cast<int>(blockDim.x)) {
+    const int dd = e % static_cast<int>(d);
+    const int tmp = e / static_cast<int>(d);
+    const int hh = tmp % QG;
+    const int qq = tmp / QG;
+    q_sm[(static_cast<size_t>(qq) * QG + hh) * d + dd] =
+        query[((t_base + qq) * hq + (h0 + hh)) * d + dd];
+  }
+  __syncthreads();
+
+  // Per-row online state in registers for rows owned by this warp.
+  // Cap: BM=16 QG=2 → 32 rows, 8 warps → 4 rows/warp.
+  constexpr int kMaxRowsPerWarp = (kRows + 7) / 8;  // assume >=8 warps
+  float m_r[kMaxRowsPerWarp];
+  float l_r[kMaxRowsPerWarp];
+  float o_r[kMaxRowsPerWarp][kEpl];
+  int row_ids[kMaxRowsPerWarp];
+  int n_own = 0;
+  for (int row = warp; row < nrows && n_own < kMaxRowsPerWarp; row += nwarps) {
+    row_ids[n_own] = row;
+    m_r[n_own] = -INFINITY;
+    l_r[n_own] = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_r[n_own][i] = 0.f;
+    ++n_own;
+  }
+
+  for (int64_t j0 = s_jmin; j0 <= s_jmax; j0 += BN) {
+    const int n_k = static_cast<int>((s_jmax - j0 + 1) < BN ? (s_jmax - j0 + 1) : BN);
+    const int bdx = static_cast<int>(blockDim.x);
+    for (int kk = tid; kk < n_k; kk += bdx) {
+      const int64_t j = j0 + kk;
+      s_blk[kk] = block_table[r * bt_row + (j / block_size) * bt_col];
+      s_off[kk] = j % block_size;
+    }
+    __syncthreads();
+    for (int e = tid; e < BN * static_cast<int>(d); e += bdx) kv_sm[e] = __hip_bfloat16{};
+    __syncthreads();
+    for (int e = tid; e < n_k * static_cast<int>(d); e += bdx) {
+      const int kk = e / static_cast<int>(d);
+      const int dd = e - kk * static_cast<int>(d);
+      kv_sm[e] = k_cache[s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd];
+    }
+    __syncthreads();
+
+    // QK: concurrent multi-wave rocWMMA → s_sc[hh][qq][kk] (ld=BN).
+    // Direct store (no tile_s[8]) keeps LDS under 64KB at BM=16 BN=64 d=256.
+    constexpr bool kUseWmma =
+        (BM % 16 == 0) && (BN % 16 == 0) && (d_expect % 16 == 0) && (BM >= 16) && (BN >= 16);
+#if defined(VT_ROCWMMA_OK)
+    if constexpr (kUseWmma) {
+      constexpr int WM = 16, WN = 16, WK = 16;
+      using namespace rocwmma;
+      const int tiles_m = BM / WM;
+      const int tiles_n = BN / WN;
+      const int ntiles_h = tiles_m * tiles_n;
+      const int ntiles = ntiles_h * QG;
+      const int step = (nwarps < 8) ? nwarps : 8;
+      if (warp < 8) {
+        for (int t = warp; t < ntiles; t += step) {
+          const int hh = t / ntiles_h;
+          const int t2 = t - hh * ntiles_h;
+          const int tm = t2 / tiles_n;
+          const int tn = t2 - tm * tiles_n;
+          const int m0 = tm * WM;
+          const int n0 = tn * WN;
+          fragment<matrix_a, WM, WN, WK, bfloat16_t, row_major> a_frag;
+          fragment<matrix_b, WM, WN, WK, bfloat16_t, col_major> b_frag;
+          fragment<accumulator, WM, WN, WK, float> acc;
+          fill_fragment(acc, 0.f);
+          const bfloat16_t* Qbase =
+              reinterpret_cast<const bfloat16_t*>(q_sm + static_cast<size_t>(hh) * d);
+          const long lda = static_cast<long>(QG) * static_cast<long>(d);
+          const bfloat16_t* Kbase =
+              reinterpret_cast<const bfloat16_t*>(kv_sm + static_cast<size_t>(n0) * d);
+          for (int k = 0; k < d_expect; k += WK) {
+            load_matrix_sync(a_frag, Qbase + static_cast<long>(m0) * lda + k, lda);
+            load_matrix_sync(b_frag, Kbase + k, d);
+            mma_sync(acc, a_frag, b_frag, acc);
+          }
+          // Plane hh: rows = qq, cols = kk, leading dim BN
+          float* sc_base = s_sc + static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(m0) * BN + n0;
+          store_matrix_sync(sc_base, acc, BN, mem_row_major);
+        }
+      }
+      __syncthreads();
+      // Mask/softcap applied in online loop (no extra full-matrix pass).
+    } else
+#endif
+    {
+      for (int own = 0; own < n_own; ++own) {
+        const int row = row_ids[own];
+        const int qq = row / QG;
+        const int hh = row - qq * QG;
+#pragma unroll 1
+        for (int kk = 0; kk < BN; ++kk) {
+          float s = -INFINITY;
+          if (kk < n_k) {
+            const int64_t j = j0 + kk;
+            if (j >= s_jmin_q[qq] && j <= s_jmax_q[qq]) {
+              float dot = 0.f;
+#pragma unroll
+              for (int i = 0; i < kEpl; ++i) {
+                const int dd = lane * kEpl + i;
+                if (dd < d) {
+                  dot += __bfloat162float(q_sm[(static_cast<size_t>(qq) * QG + hh) * d + dd]) *
+                         __bfloat162float(kv_sm[static_cast<size_t>(kk) * d + dd]);
+                }
+              }
+#pragma unroll
+              for (int o = 16; o > 0; o >>= 1) dot += __shfl_down(dot, o);
+              s = Softcap(__shfl(dot, 0) * scale, softcap);
+            }
+          }
+          if (lane == 0)
+            s_sc[static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(qq) * BN + kk] = s;
+        }
+      }
+      __syncthreads();
+    }
+
+
+    // V into kv_sm
+    for (int e = tid; e < n_k * static_cast<int>(d); e += static_cast<int>(blockDim.x)) {
+      const int kk = e / static_cast<int>(d);
+      const int dd = e - kk * static_cast<int>(d);
+      kv_sm[e] = v_cache[s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd];
+    }
+    __syncthreads();
+
+    // Tile-softmax + PV (FA2-style): one rowmax, then one exp pass — fewer
+    // exp/renorm than per-key online. WMMA QK scores stay in s_sc.
+    for (int own = 0; own < n_own; ++own) {
+      const int row = row_ids[own];
+      const int qq = row / QG;
+      const int hh = row - qq * QG;
+      float* rp = s_sc + static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(qq) * BN;
+
+      float m_tile = -INFINITY;
+#pragma unroll 1
+      for (int kk = 0; kk < BN; ++kk) {
+        if (kk >= n_k) break;
+        float s;
+        if constexpr (kUseWmma) {
+          const int64_t j = j0 + kk;
+          if (!(j >= s_jmin_q[qq] && j <= s_jmax_q[qq])) {
+            rp[kk] = -INFINITY;
+            continue;
+          }
+          s = Softcap(rp[kk] * scale, softcap);
+        } else {
+          s = rp[kk];
+        }
+        rp[kk] = s;
+        m_tile = fmaxf(m_tile, s);
+      }
+
+      if (!(m_tile > -INFINITY)) continue;
+      const float m_new = fmaxf(m_r[own], m_tile);
+      const float e_old = (m_r[own] > -INFINITY) ? expf(m_r[own] - m_new) : 0.f;
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) o_r[own][i] *= e_old;
+      l_r[own] *= e_old;
+
+      float l_add = 0.f;
+#pragma unroll 1
+      for (int kk = 0; kk < BN; ++kk) {
+        if (kk >= n_k) break;
+        const float s = rp[kk];
+        if (!(s > -INFINITY)) continue;
+        const float p = expf(s - m_new);
+        l_add += p;
+#pragma unroll
+        for (int i = 0; i < kEpl; ++i) {
+          const int dd = lane * kEpl + i;
+          const float vv = (dd < d) ? __bfloat162float(kv_sm[static_cast<size_t>(kk) * d + dd]) : 0.f;
+          o_r[own][i] += p * vv;
+        }
+      }
+      l_r[own] += l_add;
+      m_r[own] = m_new;
+    }
+    __syncthreads();
+  }
+
+  for (int own = 0; own < n_own; ++own) {
+    const int row = row_ids[own];
+    const int qq = row / QG;
+    const int hh = row - qq * QG;
+    const float inv = (l_r[own] > 0.f) ? (1.f / l_r[own]) : 0.f;
+    float acc[kEpl];
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] = o_r[own][i] * inv;
+    StoreRowEplBf16<kEpl>(out, ((t_base + qq) * hq + (h0 + hh)) * d, lane, acc);
+  }
+}
+
+
+// 1-wave/CTA flash prefill with rocWMMA QK (gfx1201-safe).
+// grid=(ceil(total_q/BM), num_kv_heads), block=32.
+// Parallelism = many CTAs; never multi-wave mma_sync (hangs on gfx1201).
+template <int QG, int EPL, int BM, int BN>
+__global__ void PagedAttnPrefillWmmaWave(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                         const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                         const int32_t* block_table, const int32_t* seq_lens,
+                                         const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                         int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                         int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                         int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                         float scale, float softcap, bool causal, int window_left,
+                                         int window_right) {
+#if !defined(VT_ROCWMMA_OK)
+  (void)out; (void)query; (void)k_cache; (void)v_cache; (void)block_table; (void)seq_lens;
+  (void)query_start_loc; (void)num_reqs; (void)hq; (void)num_kv_heads; (void)d; (void)block_size;
+  (void)bt_row; (void)bt_col; (void)kc_blk; (void)kc_pg; (void)kc_hd; (void)vc_blk; (void)vc_pg;
+  (void)vc_hd; (void)scale; (void)softcap; (void)causal; (void)window_left; (void)window_right;
+  return;
+#else
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  constexpr int WM = 16, WN = 16, WK = 16;
+  static_assert(BM % WM == 0 && BN % WN == 0, "WMMA tile alignment");
+  const int64_t q_tile = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  const int tid = lane;  // 1 wave
+  if (g >= num_kv_heads || d != d_expect || threadIdx.x >= 32) return;
+
+  const int64_t t_base = q_tile * BM;
+  int64_t r = 0, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+  } else {
+    r = -1;
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t_base >= a && t_base < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+  if (t_base >= q1) return;
+  const int nq = static_cast<int>((q1 - t_base) < BM ? (q1 - t_base) : BM);
+  if (nq <= 0) return;
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int64_t h0 = g * QG;
+
+  __shared__ int64_t s_jmin_q[BM], s_jmax_q[BM];
+  __shared__ int64_t s_jmin, s_jmax;
+  for (int qq = tid; qq < BM; qq += 32) {
+    if (qq >= nq) {
+      s_jmin_q[qq] = seqlen;
+      s_jmax_q[qq] = -1;
+      continue;
+    }
+    const int64_t pos = context + ((t_base + qq) - q0);
+    int64_t jn = 0;
+    if (window_left >= 0) {
+      jn = pos - window_left;
+      if (jn < 0) jn = 0;
+    }
+    int64_t jx = causal ? pos : (seqlen - 1);
+    if (window_right >= 0) {
+      const int64_t jr = pos + window_right;
+      if (jr < jx) jx = jr;
+    }
+    if (jx > seqlen - 1) jx = seqlen - 1;
+    s_jmin_q[qq] = jn;
+    s_jmax_q[qq] = jx;
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int64_t tn = seqlen, tx = -1;
+    for (int qq = 0; qq < nq; ++qq) {
+      if (s_jmin_q[qq] < tn) tn = s_jmin_q[qq];
+      if (s_jmax_q[qq] > tx) tx = s_jmax_q[qq];
+    }
+    s_jmin = tn;
+    s_jmax = tx;
+  }
+  __syncthreads();
+  if (s_jmax < s_jmin) return;
+
+  // smem: Q[BM*QG*d] + KV[BN*d]
+  extern __shared__ __hip_bfloat16 dyn[];
+  __hip_bfloat16* q_sm = dyn;
+  __hip_bfloat16* kv_sm = dyn + static_cast<size_t>(BM) * QG * d;
+  __shared__ int64_t s_blk[BN], s_off[BN];
+  __shared__ float s_score[BM * QG * BN];
+  __shared__ float tile_s[WM * WN];
+
+  // zero + load Q
+  for (int e = tid; e < BM * QG * static_cast<int>(d); e += 32) q_sm[e] = __hip_bfloat16{};
+  __syncthreads();
+  for (int e = tid; e < nq * QG * static_cast<int>(d); e += 32) {
+    const int dd = e % static_cast<int>(d);
+    const int tmp = e / static_cast<int>(d);
+    const int hh = tmp % QG;
+    const int qq = tmp / QG;
+    q_sm[(static_cast<size_t>(qq) * QG + hh) * d + dd] =
+        query[((t_base + qq) * hq + (h0 + hh)) * d + dd];
+  }
+  __syncthreads();
+
+  // online state in regs: nrows = nq*QG <= BM*QG
+  constexpr int kMaxRows = BM * QG;
+  float m_r[kMaxRows];
+  float l_r[kMaxRows];
+  float o_r[kMaxRows][kEpl];
+  const int nrows = nq * QG;
+  for (int row = 0; row < kMaxRows; ++row) {
+    m_r[row] = -INFINITY;
+    l_r[row] = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_r[row][i] = 0.f;
+  }
+
+  using namespace rocwmma;
+  for (int64_t j0 = s_jmin; j0 <= s_jmax; j0 += BN) {
+    const int n_k = static_cast<int>((s_jmax - j0 + 1) < BN ? (s_jmax - j0 + 1) : BN);
+    // 1-wave CTA: must stride — tid<n_k only covers 32 slots when BN=64 (GPU hang).
+    for (int kk = tid; kk < n_k; kk += 32) {
+      const int64_t j = j0 + kk;
+      s_blk[kk] = block_table[r * bt_row + (j / block_size) * bt_col];
+      s_off[kk] = j % block_size;
+    }
+    __syncthreads();
+    for (int e = tid; e < BN * static_cast<int>(d); e += 32) kv_sm[e] = __hip_bfloat16{};
+    __syncthreads();
+    for (int e = tid; e < n_k * static_cast<int>(d); e += 32) {
+      const int kk = e / static_cast<int>(d);
+      const int dd = e - kk * static_cast<int>(d);
+      kv_sm[e] = k_cache[s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd];
+    }
+    __syncthreads();
+
+    // WMMA QK — single wave, serial 16x16 tiles (safe on gfx1201)
+    for (int hh = 0; hh < QG; ++hh) {
+      for (int m0 = 0; m0 < BM; m0 += WM) {
+        for (int n0 = 0; n0 < BN; n0 += WN) {
+          fragment<matrix_a, WM, WN, WK, bfloat16_t, row_major> a_frag;
+          fragment<matrix_b, WM, WN, WK, bfloat16_t, col_major> b_frag;
+          fragment<accumulator, WM, WN, WK, float> acc;
+          fill_fragment(acc, 0.f);
+          const bfloat16_t* Qbase =
+              reinterpret_cast<const bfloat16_t*>(q_sm + static_cast<size_t>(hh) * d);
+          const long lda = static_cast<long>(QG) * static_cast<long>(d);
+          const bfloat16_t* Kbase =
+              reinterpret_cast<const bfloat16_t*>(kv_sm + static_cast<size_t>(n0) * d);
+          for (int k = 0; k < d_expect; k += WK) {
+            load_matrix_sync(a_frag, Qbase + static_cast<long>(m0) * lda + k, lda);
+            load_matrix_sync(b_frag, Kbase + k, d);
+            mma_sync(acc, a_frag, b_frag, acc);
+          }
+          store_matrix_sync(tile_s, acc, WN, mem_row_major);
+          if (lane == 0) {
+            for (int rm = 0; rm < WM; ++rm) {
+              for (int rn = 0; rn < WN; ++rn) {
+                const int qq = m0 + rm;
+                const int kk = n0 + rn;
+                if (qq >= nq || kk >= n_k) continue;
+                float s = tile_s[rm * WN + rn];
+                const int64_t j = j0 + kk;
+                if (!(j >= s_jmin_q[qq] && j <= s_jmax_q[qq])) s = -INFINITY;
+                else s = Softcap(s * scale, softcap);
+                s_score[(qq * QG + hh) * BN + kk] = s;
+              }
+            }
+          }
+        }
+      }
+    }
+    __syncthreads();
+
+    // V load
+    for (int e = tid; e < n_k * static_cast<int>(d); e += 32) {
+      const int kk = e / static_cast<int>(d);
+      const int dd = e - kk * static_cast<int>(d);
+      kv_sm[e] = v_cache[s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd];
+    }
+    __syncthreads();
+
+    // Online softmax + V; each lane owns d strip via kEpl
+    for (int row = 0; row < nrows; ++row) {
+#pragma unroll 1
+      for (int kk = 0; kk < BN; ++kk) {
+        if (kk >= n_k) break;
+        const float s = s_score[row * BN + kk];
+        if (!(s > -INFINITY)) continue;
+        const float m_new = fmaxf(m_r[row], s);
+        const float e_old = (m_r[row] > -INFINITY) ? expf(m_r[row] - m_new) : 0.f;
+        const float e_s = expf(s - m_new);
+        l_r[row] = l_r[row] * e_old + e_s;
+#pragma unroll
+        for (int i = 0; i < kEpl; ++i) {
+          const int dd = lane * kEpl + i;
+          const float vv = (dd < d) ? __bfloat162float(kv_sm[static_cast<size_t>(kk) * d + dd]) : 0.f;
+          o_r[row][i] = o_r[row][i] * e_old + e_s * vv;
+        }
+        m_r[row] = m_new;
+      }
+    }
+    __syncthreads();
+  }
+
+  for (int row = 0; row < nrows; ++row) {
+    const int qq = row / QG;
+    const int hh = row - qq * QG;
+    const float inv = (l_r[row] > 0.f) ? (1.f / l_r[row]) : 0.f;
+    float acc[kEpl];
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) acc[i] = o_r[row][i] * inv;
+    StoreRowEplBf16<kEpl>(out, ((t_base + qq) * hq + (h0 + hh)) * d, lane, acc);
+  }
+#endif  // VT_ROCWMMA_OK
+}
+
+// Shared-K prefill (scoreless — SGLang direction, gfx1201-safe):
+//   BM queries × 1 warp each, QG heads in registers (DecodeGqa-style).
+//   K/V streamed in BN tiles into smem once per tile; online softmax in regs.
+//   No score matrix, no multi-wave mma. Grid=(ceil(total_q/BM), num_kv_heads[, z]).
+//   blockIdx.z tiles large GQA groups (global qg=8 → z=4 with QG=2).
+template <int QG, int EPL, int BM, int BN>
+__global__ void PagedAttnPrefillSharedK(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                        const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                        const int32_t* block_table, const int32_t* seq_lens,
+                                        const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                        int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                        int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                        int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                        float scale, float softcap, bool causal, int window_left,
+                                        int window_right) {
+  static_assert(BM >= 1 && BM <= 32, "BM warps");
+  static_assert(BN <= 64, "BN smem/regs");
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  const int64_t q_tile = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int warp = tid >> 5;
+  const int lane = tid & 31;
+  const int bdx = static_cast<int>(blockDim.x);
+  if (g >= num_kv_heads || d != d_expect || warp >= BM) return;
+
+  const int64_t t_base = q_tile * BM;
+  int64_t r = 0, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+  } else {
+    r = -1;
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t_base >= a && t_base < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+  if (t_base >= q1) return;
+  const int nq = static_cast<int>((q1 - t_base) < BM ? (q1 - t_base) : BM);
+  if (nq <= 0) return;
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int64_t qg_total = hq / num_kv_heads;
+  const int64_t h0 = g * qg_total + static_cast<int64_t>(blockIdx.z) * QG;
+  if (h0 + QG > (g + 1) * qg_total) return;
+
+  // Per-warp query row
+  const int qq = warp;
+  const bool live = qq < nq;
+  int64_t jmin = seqlen, jmax = -1;
+  float q_reg[QG][kEpl];
+  float m[QG], lsum[QG];
+  float o_reg[QG][kEpl];
+#pragma unroll
+  for (int hh = 0; hh < QG; ++hh) {
+    m[hh] = -INFINITY;
+    lsum[hh] = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = 0.f;
+  }
+  if (live) {
+    const int64_t t = t_base + qq;
+    const int64_t pos = context + (t - q0);
+    jmin = 0;
+    if (window_left >= 0) {
+      jmin = pos - window_left;
+      if (jmin < 0) jmin = 0;
+    }
+    jmax = causal ? pos : (seqlen - 1);
+    if (window_right >= 0) {
+      const int64_t jr = pos + window_right;
+      if (jr < jmax) jmax = jr;
+    }
+    if (jmax > seqlen - 1) jmax = seqlen - 1;
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh)
+      LoadRowEplBf16<kEpl>(query, (t * hq + (h0 + hh)) * d, lane, q_reg[hh]);
+  }
+
+  __shared__ int64_t s_jmin, s_jmax;
+  __shared__ int64_t s_jmin_q[BM], s_jmax_q[BM];
+  if (lane == 0) {
+    s_jmin_q[qq] = live ? jmin : seqlen;
+    s_jmax_q[qq] = live ? jmax : -1;
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int64_t tn = seqlen, tx = -1;
+    for (int i = 0; i < nq; ++i) {
+      if (s_jmin_q[i] < tn) tn = s_jmin_q[i];
+      if (s_jmax_q[i] > tx) tx = s_jmax_q[i];
+    }
+    s_jmin = tn;
+    s_jmax = tx;
+  }
+  __syncthreads();
+  if (s_jmax < s_jmin) return;
+
+  // smem: K[BN*d] + V[BN*d] — fused QK+online V, no score matrix / no SUB sync tax.
+  // d=256 BN=32 → 32KB; d=512 BN=16 → 32KB. (BN=64×2 would be 64KB edge.)
+  extern __shared__ __hip_bfloat16 dyn_kv[];
+  __hip_bfloat16* k_sm = dyn_kv;
+  __hip_bfloat16* v_sm = dyn_kv + static_cast<size_t>(BN) * static_cast<size_t>(d_expect);
+  __shared__ int64_t s_blk[BN], s_off[BN];
+
+  for (int64_t j0 = s_jmin; j0 <= s_jmax; j0 += BN) {
+    const int n_k = static_cast<int>((s_jmax - j0 + 1) < BN ? (s_jmax - j0 + 1) : BN);
+    for (int kk = tid; kk < n_k; kk += bdx) {
+      const int64_t j = j0 + kk;
+      s_blk[kk] = block_table[r * bt_row + (j / block_size) * bt_col];
+      s_off[kk] = j % block_size;
+    }
+    __syncthreads();
+    // Prefetch K and V tiles together (vectorized uint4 = 8 bf16 when d%8==0).
+    if ((static_cast<int>(d) & 7) == 0) {
+      const int d8 = static_cast<int>(d) >> 3;
+      const int nvec = n_k * d8;
+      for (int e = tid; e < nvec; e += bdx) {
+        const int kk = e / d8;
+        const int v = e - kk * d8;
+        const int dd = v << 3;
+        const int64_t bo = s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd;
+        const int64_t vo = s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd;
+        const size_t dst = (static_cast<size_t>(kk) * static_cast<size_t>(d) + dd) >> 3;
+        reinterpret_cast<uint4*>(k_sm)[dst] = *reinterpret_cast<const uint4*>(k_cache + bo);
+        reinterpret_cast<uint4*>(v_sm)[dst] = *reinterpret_cast<const uint4*>(v_cache + vo);
+      }
+    } else {
+      for (int e = tid; e < n_k * static_cast<int>(d); e += bdx) {
+        const int kk = e / static_cast<int>(d);
+        const int dd = e - kk * static_cast<int>(d);
+        const int64_t bo = s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd;
+        const int64_t vo = s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd;
+        k_sm[static_cast<size_t>(kk) * d + dd] = k_cache[bo];
+        v_sm[static_cast<size_t>(kk) * d + dd] = v_cache[vo];
+      }
+    }
+    __syncthreads();
+
+    // Fused QK + online V (scoreless, one pass — no s_h[BN] regs).
+    if (live) {
+#pragma unroll 1
+      for (int kk = 0; kk < n_k; ++kk) {
+        const int64_t j = j0 + kk;
+        if (!(j >= jmin && j <= jmax)) continue;
+        float k_reg[kEpl];
+        LoadRowEplBf16<kEpl>(k_sm, static_cast<int64_t>(kk) * d, lane, k_reg);
+        float v_reg[kEpl];
+        LoadRowEplBf16<kEpl>(v_sm, static_cast<int64_t>(kk) * d, lane, v_reg);
+#pragma unroll
+        for (int hh = 0; hh < QG; ++hh) {
+          float dot = 0.f;
+#pragma unroll
+          for (int i = 0; i < kEpl; ++i) dot += q_reg[hh][i] * k_reg[i];
+#pragma unroll
+          for (int o = 16; o > 0; o >>= 1) dot += __shfl_down(dot, o);
+          const float s = Softcap(__shfl(dot, 0) * scale, softcap);
+          const float m_new = fmaxf(m[hh], s);
+          const float corr = (m[hh] > -INFINITY) ? FastExp(m[hh] - m_new) : 0.f;
+          const float pw = FastExp(s - m_new);
+#pragma unroll
+          for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = o_reg[hh][i] * corr + pw * v_reg[i];
+          lsum[hh] = lsum[hh] * corr + pw;
+          m[hh] = m_new;
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  if (live) {
+    const int64_t t = t_base + qq;
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh) {
+      const float inv = (lsum[hh] > 0.f) ? (1.f / lsum[hh]) : 0.f;
+      float acc[kEpl];
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) acc[i] = o_reg[hh][i] * inv;
+      StoreRowEplBf16<kEpl>(out, (t * hq + (h0 + hh)) * d, lane, acc);
+    }
+  }
+}
+
+// SharedK + rocWMMA QK (score matrix only for one BN tile; online softmax/V in regs).
+// Dyn smem: Q[BM*QG*d] + KV[BN*d]. Static: s_sc[QG*BM*BN].
+// d=256 BM16 BN64 ≈56KB; d=512 BM16 BN16 ≈50KB. Env: VT_ATTN_PREFILL_SHAREDK_WMMA=1.
+// kQGlobal=true: Q from global (lda=hq*d), dyn smem = K+V only — enables d=512 WMMA under 64KB LDS.
+// kQGlobal=false: Q tile in smem (d=256 path). Partial tiles (nq<BM) use scalar QK when kQGlobal.
+template <int QG, int EPL, int BM, int BN, bool kQGlobal>
+__global__ void PagedAttnPrefillSharedKWmma(__hip_bfloat16* out, const __hip_bfloat16* query,
+                                            const __hip_bfloat16* k_cache, const __hip_bfloat16* v_cache,
+                                            const int32_t* block_table, const int32_t* seq_lens,
+                                            const int32_t* query_start_loc, int64_t num_reqs, int64_t hq,
+                                            int64_t num_kv_heads, int64_t d, int64_t block_size,
+                                            int64_t bt_row, int64_t bt_col, int64_t kc_blk, int64_t kc_pg,
+                                            int64_t kc_hd, int64_t vc_blk, int64_t vc_pg, int64_t vc_hd,
+                                            float scale, float softcap, bool causal, int window_left,
+                                            int window_right) {
+#if !defined(VT_ROCWMMA_OK)
+  (void)out;
+  (void)query;
+  (void)k_cache;
+  (void)v_cache;
+  (void)block_table;
+  (void)seq_lens;
+  (void)query_start_loc;
+  (void)num_reqs;
+  (void)hq;
+  (void)num_kv_heads;
+  (void)d;
+  (void)block_size;
+  (void)bt_row;
+  (void)bt_col;
+  (void)kc_blk;
+  (void)kc_pg;
+  (void)kc_hd;
+  (void)vc_blk;
+  (void)vc_pg;
+  (void)vc_hd;
+  (void)scale;
+  (void)softcap;
+  (void)causal;
+  (void)window_left;
+  (void)window_right;
+#else
+  static_assert(BM % 16 == 0 && BN % 16 == 0, "WMMA tile");
+  static_assert(BM >= 16 && BM <= 32 && BN <= 64, "bounds");
+  constexpr int kEpl = EPL;
+  constexpr int d_expect = kEpl * 32;
+  constexpr int WM = 16, WN = 16, WK = 16;
+  const int64_t q_tile = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int warp = tid >> 5;
+  const int lane = tid & 31;
+  const int bdx = static_cast<int>(blockDim.x);
+  const int nwarps = bdx >> 5;
+  if (g >= num_kv_heads || d != d_expect) return;
+
+  const int64_t t_base = q_tile * BM;
+  int64_t r = 0, q0 = 0, q1 = 0;
+  if (num_reqs == 1) {
+    q0 = query_start_loc[0];
+    q1 = query_start_loc[1];
+  } else {
+    r = -1;
+    for (int64_t rr = 0; rr < num_reqs; ++rr) {
+      const int64_t a = query_start_loc[rr], b = query_start_loc[rr + 1];
+      if (t_base >= a && t_base < b) {
+        r = rr;
+        q0 = a;
+        q1 = b;
+        break;
+      }
+    }
+    if (r < 0) return;
+  }
+  if (t_base >= q1) return;
+  const int nq = static_cast<int>((q1 - t_base) < BM ? (q1 - t_base) : BM);
+  if (nq <= 0) return;
+
+  const int64_t query_len = q1 - q0;
+  const int64_t seqlen = seq_lens[r];
+  const int64_t context = seqlen - query_len;
+  const int64_t qg_total = hq / num_kv_heads;
+  const int64_t h0 = g * qg_total + static_cast<int64_t>(blockIdx.z) * QG;
+  if (h0 + QG > (g + 1) * qg_total) return;
+
+  const int qq = warp;  // may be >= BM if block oversized; only BM warps own rows
+  const bool live = (qq < nq) && (qq < BM);
+
+  __shared__ int64_t s_jmin, s_jmax;
+  __shared__ int64_t s_jmin_q[BM], s_jmax_q[BM];
+  if (lane == 0 && qq < BM) {
+    if (live) {
+      const int64_t t = t_base + qq;
+      const int64_t pos = context + (t - q0);
+      int64_t jn = 0;
+      if (window_left >= 0) {
+        jn = pos - window_left;
+        if (jn < 0) jn = 0;
+      }
+      int64_t jx = causal ? pos : (seqlen - 1);
+      if (window_right >= 0) {
+        const int64_t jr = pos + window_right;
+        if (jr < jx) jx = jr;
+      }
+      if (jx > seqlen - 1) jx = seqlen - 1;
+      s_jmin_q[qq] = jn;
+      s_jmax_q[qq] = jx;
+    } else {
+      s_jmin_q[qq] = seqlen;
+      s_jmax_q[qq] = -1;
+    }
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int64_t tn = seqlen, tx = -1;
+    for (int i = 0; i < nq; ++i) {
+      if (s_jmin_q[i] < tn) tn = s_jmin_q[i];
+      if (s_jmax_q[i] > tx) tx = s_jmax_q[i];
+    }
+    s_jmin = tn;
+    s_jmax = tx;
+  }
+  __syncthreads();
+  if (s_jmax < s_jmin) return;
+
+  extern __shared__ __hip_bfloat16 dyn_bf[];
+  __hip_bfloat16* q_sm = nullptr;
+  __hip_bfloat16* k_sm = nullptr;
+  __hip_bfloat16* v_sm = nullptr;
+  if constexpr (kQGlobal) {
+    // Dyn = K+V only (d=512: BN16 → 32KB).
+    k_sm = dyn_bf;
+    v_sm = k_sm + static_cast<size_t>(BN) * static_cast<size_t>(d_expect);
+  } else {
+    q_sm = dyn_bf;
+    k_sm = q_sm + static_cast<size_t>(BM) * QG * static_cast<size_t>(d_expect);
+    v_sm = k_sm + static_cast<size_t>(BN) * static_cast<size_t>(d_expect);
+  }
+  __shared__ int64_t s_blk[BN], s_off[BN];
+  __shared__ float s_sc[QG * BM * BN];
+
+  // Q: smem tile (d=256) or per-warp regs for scalar tail (d=512 global).
+  float q_reg[QG][kEpl];
+  if constexpr (!kQGlobal) {
+    for (int e = tid; e < BM * QG * static_cast<int>(d); e += bdx) q_sm[e] = __hip_bfloat16{};
+    __syncthreads();
+    for (int e = tid; e < nq * QG * static_cast<int>(d); e += bdx) {
+      const int dd = e % static_cast<int>(d);
+      const int tmp = e / static_cast<int>(d);
+      const int hh = tmp % QG;
+      const int qi = tmp / QG;
+      q_sm[(static_cast<size_t>(qi) * QG + hh) * d + dd] =
+          query[((t_base + qi) * hq + (h0 + hh)) * d + dd];
+    }
+    __syncthreads();
+  } else if (live) {
+    const int64_t t = t_base + qq;
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh)
+      LoadRowEplBf16<kEpl>(query, (t * hq + (h0 + hh)) * d, lane, q_reg[hh]);
+  }
+
+  float m[QG], lsum[QG];
+  float o_reg[QG][kEpl];
+#pragma unroll
+  for (int hh = 0; hh < QG; ++hh) {
+    m[hh] = -INFINITY;
+    lsum[hh] = 0.f;
+#pragma unroll
+    for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = 0.f;
+  }
+
+  using namespace rocwmma;
+  // Full BM tiles can WMMA from global Q without OOB; partial last tile uses scalar QK.
+  const bool use_wmma_qk = !kQGlobal || (nq == BM);
+  for (int64_t j0 = s_jmin; j0 <= s_jmax; j0 += BN) {
+    const int n_k = static_cast<int>((s_jmax - j0 + 1) < BN ? (s_jmax - j0 + 1) : BN);
+    for (int kk = tid; kk < n_k; kk += bdx) {
+      const int64_t j = j0 + kk;
+      s_blk[kk] = block_table[r * bt_row + (j / block_size) * bt_col];
+      s_off[kk] = j % block_size;
+    }
+    __syncthreads();
+    // Prefetch K+V together (vectorized when d%8==0).
+    if ((static_cast<int>(d) & 7) == 0) {
+      const int d8 = static_cast<int>(d) >> 3;
+      const int nvec_all = BN * d8;
+      for (int e = tid; e < nvec_all; e += bdx) {
+        reinterpret_cast<uint4*>(k_sm)[static_cast<size_t>(e)] = uint4{0, 0, 0, 0};
+        reinterpret_cast<uint4*>(v_sm)[static_cast<size_t>(e)] = uint4{0, 0, 0, 0};
+      }
+      __syncthreads();
+      const int nvec = n_k * d8;
+      for (int e = tid; e < nvec; e += bdx) {
+        const int kk = e / d8;
+        const int v = e - kk * d8;
+        const int dd = v << 3;
+        const int64_t bo = s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd;
+        const int64_t vo = s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd;
+        const size_t dst = static_cast<size_t>(e);
+        reinterpret_cast<uint4*>(k_sm)[dst] = *reinterpret_cast<const uint4*>(k_cache + bo);
+        reinterpret_cast<uint4*>(v_sm)[dst] = *reinterpret_cast<const uint4*>(v_cache + vo);
+      }
+    } else {
+      for (int e = tid; e < BN * static_cast<int>(d); e += bdx) {
+        k_sm[e] = __hip_bfloat16{};
+        v_sm[e] = __hip_bfloat16{};
+      }
+      __syncthreads();
+      for (int e = tid; e < n_k * static_cast<int>(d); e += bdx) {
+        const int kk = e / static_cast<int>(d);
+        const int dd = e - kk * static_cast<int>(d);
+        k_sm[e] = k_cache[s_blk[kk] * kc_blk + s_off[kk] * kc_pg + g * kc_hd + dd];
+        v_sm[e] = v_cache[s_blk[kk] * vc_blk + s_off[kk] * vc_pg + g * vc_hd + dd];
+      }
+    }
+    __syncthreads();
+
+    if (use_wmma_qk) {
+      // WMMA QK → s_sc[hh][qq][kk]
+      constexpr int tiles_m = BM / WM;
+      constexpr int tiles_n = BN / WN;
+      constexpr int ntiles_h = tiles_m * tiles_n;
+      constexpr int ntiles = ntiles_h * QG;
+      const int step = nwarps;
+      for (int t = warp; t < ntiles; t += step) {
+        const int hh = t / ntiles_h;
+        const int t2 = t - hh * ntiles_h;
+        const int tm = t2 / tiles_n;
+        const int tn = t2 - tm * tiles_n;
+        const int m0 = tm * WM;
+        const int n0 = tn * WN;
+        fragment<matrix_a, WM, WN, WK, bfloat16_t, row_major> a_frag;
+        fragment<matrix_b, WM, WN, WK, bfloat16_t, col_major> b_frag;
+        fragment<accumulator, WM, WN, WK, float> acc;
+        fill_fragment(acc, 0.f);
+        const bfloat16_t* Kbase =
+            reinterpret_cast<const bfloat16_t*>(k_sm + static_cast<size_t>(n0) * d);
+        if constexpr (kQGlobal) {
+          // query layout [t][hq][d]; fixed head h0+hh, row stride = hq*d
+          const bfloat16_t* Qbase = reinterpret_cast<const bfloat16_t*>(
+              query + ((t_base + m0) * hq + (h0 + hh)) * d);
+          const long lda = static_cast<long>(hq) * static_cast<long>(d);
+          for (int k = 0; k < d_expect; k += WK) {
+            load_matrix_sync(a_frag, Qbase + k, lda);
+            load_matrix_sync(b_frag, Kbase + k, d);
+            mma_sync(acc, a_frag, b_frag, acc);
+          }
+        } else {
+          const bfloat16_t* Qbase =
+              reinterpret_cast<const bfloat16_t*>(q_sm + static_cast<size_t>(hh) * d);
+          const long lda = static_cast<long>(QG) * static_cast<long>(d);
+          for (int k = 0; k < d_expect; k += WK) {
+            load_matrix_sync(a_frag, Qbase + static_cast<long>(m0) * lda + k, lda);
+            load_matrix_sync(b_frag, Kbase + k, d);
+            mma_sync(acc, a_frag, b_frag, acc);
+          }
+        }
+        float* sc_base = s_sc + static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(m0) * BN + n0;
+        store_matrix_sync(sc_base, acc, BN, mem_row_major);
+      }
+      __syncthreads();
+    } else if (live) {
+      // Partial tile + global Q: scalar QK into s_sc for this row (no OOB WMMA).
+#pragma unroll 1
+      for (int kk = 0; kk < n_k; ++kk) {
+        float k_reg[kEpl];
+        LoadRowEplBf16<kEpl>(k_sm, static_cast<int64_t>(kk) * d, lane, k_reg);
+#pragma unroll
+        for (int hh = 0; hh < QG; ++hh) {
+          float dot = 0.f;
+#pragma unroll
+          for (int i = 0; i < kEpl; ++i) dot += q_reg[hh][i] * k_reg[i];
+#pragma unroll
+          for (int o = 16; o > 0; o >>= 1) dot += __shfl_down(dot, o);
+          if (lane == 0)
+            s_sc[static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(qq) * BN + kk] =
+                __shfl(dot, 0);
+        }
+      }
+      __syncthreads();
+    } else {
+      __syncthreads();
+    }
+
+    // Online softmax + V from v_sm (no K reload, no V global round-trip).
+    if (live) {
+      const int64_t jmin = s_jmin_q[qq];
+      const int64_t jmax = s_jmax_q[qq];
+#pragma unroll 1
+      for (int kk = 0; kk < n_k; ++kk) {
+        const int64_t j = j0 + kk;
+        float v_reg[kEpl];
+        bool loaded = false;
+#pragma unroll
+        for (int hh = 0; hh < QG; ++hh) {
+          float s = -INFINITY;
+          if (j >= jmin && j <= jmax) {
+            s = Softcap(s_sc[static_cast<size_t>(hh) * BM * BN + static_cast<size_t>(qq) * BN + kk] *
+                            scale,
+                        softcap);
+          }
+          if (!(s > -INFINITY)) continue;
+          if (!loaded) {
+            LoadRowEplBf16<kEpl>(v_sm, static_cast<int64_t>(kk) * d, lane, v_reg);
+            loaded = true;
+          }
+          const float m_new = fmaxf(m[hh], s);
+          const float corr = (m[hh] > -INFINITY) ? FastExp(m[hh] - m_new) : 0.f;
+          const float pw = FastExp(s - m_new);
+#pragma unroll
+          for (int i = 0; i < kEpl; ++i) o_reg[hh][i] = o_reg[hh][i] * corr + pw * v_reg[i];
+          lsum[hh] = lsum[hh] * corr + pw;
+          m[hh] = m_new;
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  if (live) {
+    const int64_t t = t_base + qq;
+#pragma unroll
+    for (int hh = 0; hh < QG; ++hh) {
+      const float inv = (lsum[hh] > 0.f) ? (1.f / lsum[hh]) : 0.f;
+      float acc[kEpl];
+#pragma unroll
+      for (int i = 0; i < kEpl; ++i) acc[i] = o_reg[hh][i] * inv;
+      StoreRowEplBf16<kEpl>(out, (t * hq + (h0 + hh)) * d, lane, acc);
+    }
+  }
+#endif  // VT_ROCWMMA_OK
+}
+
 
 }  // namespace
 
@@ -243,6 +1669,248 @@ void PagedAttentionKernelRocm(Queue& q, Tensor& out, const Tensor& query, const 
   const int64_t bt_row = block_table.stride[0], bt_col = block_table.stride[1];
   const int64_t kc_blk = k_cache.stride[0], kc_pg = k_cache.stride[1], kc_hd = k_cache.stride[2];
   const int64_t vc_blk = v_cache.stride[0], vc_pg = v_cache.stride[1], vc_hd = v_cache.stride[2];
+
+  static const bool decode_opt = [] {
+    const char* e = std::getenv("VT_ATTN_DECODE_OPT");
+    if (e && e[0] == '0') return false;
+    return true;
+  }();
+  static const bool decode_gqa = [] {
+    const char* e = std::getenv("VT_ATTN_DECODE_GQA");
+    if (e && e[0] == '0') return false;
+    return true;  // default ON when decode_opt
+  }();
+
+  const bool bf16_decode_opt =
+      decode_opt && (d == 256 || d == 512) && query.dtype == DType::kBF16 &&
+      k_cache.dtype == DType::kBF16 && v_cache.dtype == DType::kBF16 && out.dtype == DType::kBF16 &&
+      kc_hd % 8 == 0;
+
+  if (bf16_decode_opt) {
+    const int64_t qg = hq / num_kv_heads;
+    // GQA fuse: sliding QG=2. Global QG=8: tile as DecodeGqa QG=2 × z=4
+    // (proven kernel; halves K/V reloads vs DecodeOpt's 8×). QG=4/8 CTAs lost A/B.
+    if (decode_gqa && ((qg == 2 && (d == 256 || d == 512)) || (qg == 8 && d == 512))) {
+      // Prefill SharedK (scoreless). Default ON for long single-req prefill (lab win
+      // ~1.09× @11k vs DecodeGqa-z4). Set VT_ATTN_PREFILL_FLASH_SHAREDK=0 to disable.
+      // SHAREDK_WMMA=1: rocWMMA QK + online V (lab; keep only if beats scalar SharedK).
+      static const bool prefill_sharedk = [] {
+        const char* e = std::getenv("VT_ATTN_PREFILL_FLASH_SHAREDK");
+        if (!e) return true;  // default ON
+        return e[0] != '0';
+      }();
+      static const bool sharedk_wmma = [] {
+        // Default ON: d=256 Q-smem WMMA; d=512 global-Q WMMA (K+V only LDS).
+        // =0 forces scalar SharedK for A/B.
+        const char* e = std::getenv("VT_ATTN_PREFILL_SHAREDK_WMMA");
+        if (!e) return true;
+        return e[0] != '0';
+      }();
+      if (prefill_sharedk && total_q >= 64 && num_reqs == 1) {
+        auto smem_kv = [&](int bn) -> size_t {
+          // K[bn*d] + V[bn*d] fused scoreless
+          return sizeof(__hip_bfloat16) * static_cast<size_t>(2 * bn) * static_cast<size_t>(d);
+        };
+        auto smem_qkv = [&](int bm, int bn) -> size_t {
+          // Q[bm*QG*d] + K[bn*d] + V[bn*d]  (QG=2 packed as bm*2*d)
+          return sizeof(__hip_bfloat16) *
+                 (static_cast<size_t>(bm) * 2 * static_cast<size_t>(d) +
+                  static_cast<size_t>(2 * bn) * static_cast<size_t>(d));
+        };
+        const unsigned z_groups = (qg == 8 && d == 512) ? 4u : 1u;
+        // Host must not launch WMMA stubs on non-gfx1200/1201 fatbin slices
+        // (kernel body is #else empty there → silent garbage out).
+#if defined(VT_ROCWMMA_OK)
+        if (sharedk_wmma) {
+          if (d == 256) {
+            // Q16K+K16K+V16K=48KB dyn + s_sc~4KB
+            constexpr int BM = 16, BN = 32;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads), z_groups);
+            dim3 block(static_cast<unsigned>(BM * 32));
+            PagedAttnPrefillSharedKWmma<2, 8, BM, BN, false>
+                <<<grid, block, smem_qkv(BM, BN), st>>>(
+                    out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(),
+                    k_cache.Ptr<__hip_bfloat16>(), v_cache.Ptr<__hip_bfloat16>(),
+                    block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                    query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size,
+                    bt_row, bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale,
+                    args.logits_soft_cap, args.causal, window_left, window_right);
+            Check(hipGetLastError(), "paged_attention prefill_sharedk_wmma d256 launch");
+            return;
+          } else if (d == 512) {
+            // Global Q; dyn K+V only BN16 → 32KB. Partial last tile scalar QK.
+            constexpr int BM = 16, BN = 16;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads), z_groups);
+            dim3 block(static_cast<unsigned>(BM * 32));
+            PagedAttnPrefillSharedKWmma<2, 16, BM, BN, true>
+                <<<grid, block, smem_kv(BN), st>>>(
+                    out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(),
+                    k_cache.Ptr<__hip_bfloat16>(), v_cache.Ptr<__hip_bfloat16>(),
+                    block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                    query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size,
+                    bt_row, bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale,
+                    args.logits_soft_cap, args.causal, window_left, window_right);
+            Check(hipGetLastError(), "paged_attention prefill_sharedk_wmma d512 launch");
+            return;
+          }
+        }
+#endif  // VT_ROCWMMA_OK
+        if (d == 256) {
+          constexpr int BM = 32, BN = 32;  // K+V 32KB; BM32 ~+2% vs BM16 @11k
+          const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+          dim3 grid(tiles, static_cast<unsigned>(num_kv_heads), z_groups);
+          dim3 block(static_cast<unsigned>(BM * 32));
+          PagedAttnPrefillSharedK<2, 8, BM, BN><<<grid, block, smem_kv(BN), st>>>(
+              out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+              v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+              query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+              bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+              args.causal, window_left, window_right);
+        } else if (d == 512) {
+          constexpr int BM = 16, BN = 16;  // K+V dual 32KB; was BN32 K-only overwrite
+          const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+          dim3 grid(tiles, static_cast<unsigned>(num_kv_heads), z_groups);
+          dim3 block(static_cast<unsigned>(BM * 32));
+          PagedAttnPrefillSharedK<2, 16, BM, BN><<<grid, block, smem_kv(BN), st>>>(
+              out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+              v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+              query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+              bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+              args.causal, window_left, window_right);
+        } else {
+          goto flash_fallback;
+        }
+        Check(hipGetLastError(), "paged_attention prefill_sharedk launch");
+        return;
+      }
+      // Prefill flash (opt-in). Default OFF — DecodeGqa remains prod.
+      // FLASH=1 → PrefillFlashTile + concurrent multi-wave WMMA QK (lab 2026-08-10).
+      // FLASH_WMMA=1 → 1-wave/CTA WMMA only.
+      // Flash tiles are QG=2-shaped — sliding only (quality fail on global 2026-08-10).
+      static const bool prefill_flash = [] {
+        const char* e = std::getenv("VT_ATTN_PREFILL_FLASH");
+        return e && e[0] == '1';
+      }();
+      if (prefill_flash && qg == 2 && total_q >= 64 && num_reqs == 1) {
+        static const bool flash_wmma1 = [] {
+          const char* e = std::getenv("VT_ATTN_PREFILL_FLASH_WMMA");
+          return e && e[0] == '1';
+        }();
+        auto smem_qk = [&](int bm, int bn) -> size_t {
+          return sizeof(__hip_bfloat16) *
+                 (static_cast<size_t>(bm) * 2 * static_cast<size_t>(d) +
+                  static_cast<size_t>(bn) * static_cast<size_t>(d));
+        };
+        if (flash_wmma1) {
+          dim3 block(32);
+          if (d == 256) {
+            constexpr int BM = 16, BN = 64;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads));
+            PagedAttnPrefillWmmaWave<2, 8, BM, BN><<<grid, block, smem_qk(BM, BN), st>>>(
+                out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+                v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+                bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+                args.causal, window_left, window_right);
+          } else if (d == 512) {
+            constexpr int BM = 16, BN = 32;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads));
+            PagedAttnPrefillWmmaWave<2, 16, BM, BN><<<grid, block, smem_qk(BM, BN), st>>>(
+                out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+                v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+                bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+                args.causal, window_left, window_right);
+          } else {
+            goto flash_fallback;
+          }
+          Check(hipGetLastError(), "paged_attention prefill_wmma_wave launch");
+          return;
+        }
+        // Default FLASH=1: concurrent WMMA direct-to-s_sc; BM=32 packs more Q/CTA
+        {
+          dim3 block(256);
+          if (d == 256) {
+            constexpr int BM = 32, BN = 32;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads));
+            PagedAttnPrefillFlashTile<2, 8, BM, BN><<<grid, block, smem_qk(BM, BN), st>>>(
+                out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+                v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+                bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+                args.causal, window_left, window_right);
+          } else if (d == 512) {
+            constexpr int BM = 16, BN = 32;
+            const unsigned tiles = static_cast<unsigned>((total_q + BM - 1) / BM);
+            dim3 grid(tiles, static_cast<unsigned>(num_kv_heads));
+            PagedAttnPrefillFlashTile<2, 16, BM, BN><<<grid, block, smem_qk(BM, BN), st>>>(
+                out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+                v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+                query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+                bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+                args.causal, window_left, window_right);
+          } else {
+            goto flash_fallback;
+          }
+          Check(hipGetLastError(), "paged_attention prefill_flash_wmma_mw launch");
+          return;
+        }
+      }
+      flash_fallback:
+      // DecodeGqa QG=2: sliding z=1; global qg=8 → z=4 head tiles (same kernel/regs).
+      const int nwarps = kDecWarps;
+      const size_t smem =
+          sizeof(float) *
+          (static_cast<size_t>(nwarps) * 2 * static_cast<size_t>(d) +
+           2 * static_cast<size_t>(nwarps) * 2);
+      const unsigned z_groups = (qg == 8 && d == 512) ? 4u : 1u;
+      dim3 grid(static_cast<unsigned>(total_q), static_cast<unsigned>(num_kv_heads), z_groups);
+      dim3 block(static_cast<unsigned>(nwarps * 32));
+      if (d == 256) {
+        PagedAttnDecodeGqaBf16<2, 8, 8><<<grid, block, smem, st>>>(
+            out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+            v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+            query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+            bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+            args.causal, window_left, window_right);
+      } else {
+        PagedAttnDecodeGqaBf16<2, 16, 8><<<grid, block, smem, st>>>(
+            out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+            v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+            query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row,
+            bt_col, kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap,
+            args.causal, window_left, window_right);
+      }
+      Check(hipGetLastError(), "paged_attention decode_gqa launch");
+      return;
+    }
+    const size_t smem =
+        sizeof(float) * (static_cast<size_t>(kDecWarps) * static_cast<size_t>(d) +
+                         2 * static_cast<size_t>(kDecWarps));
+    dim3 grid(static_cast<unsigned>(total_q), static_cast<unsigned>(hq));
+    if (d == 256) {
+      PagedAttnDecodeOptBf16T<8><<<grid, kDecWarps * 32, smem, st>>>(
+          out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+          v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+          query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row, bt_col,
+          kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap, args.causal,
+          window_left, window_right);
+    } else {
+      PagedAttnDecodeOptBf16T<16><<<grid, kDecWarps * 32, smem, st>>>(
+          out.Ptr<__hip_bfloat16>(), query.Ptr<__hip_bfloat16>(), k_cache.Ptr<__hip_bfloat16>(),
+          v_cache.Ptr<__hip_bfloat16>(), block_table.Ptr<int32_t>(), seq_lens.Ptr<int32_t>(),
+          query_start_loc.Ptr<int32_t>(), num_reqs, hq, num_kv_heads, d, block_size, bt_row, bt_col,
+          kc_blk, kc_pg, kc_hd, vc_blk, vc_pg, vc_hd, args.scale, args.logits_soft_cap, args.causal,
+          window_left, window_right);
+    }
+    Check(hipGetLastError(), "paged_attention decode_opt launch");
+    return;
+  }
 
   // threads: reduce over head_dim; need power-of-2 <= 256 and <= d*something
   unsigned threads = 64;

--- a/src/vt/rocm/rocm_rmsnorm.hip
+++ b/src/vt/rocm/rocm_rmsnorm.hip
@@ -30,6 +30,7 @@
 #include <hip/hip_runtime.h>
 
 #include "vt/ops.h"
+#include "vt/rocm/rocm_device_bind.h"
 
 namespace vt::rocm {
 namespace {
@@ -161,8 +162,11 @@ __global__ void RmsNormPlusAddKernel(T* out, const T* x, const T* w, const T* ad
 
 // The registered RmsNormFn (include/vt/ops.h:810). Signature is the shared vt
 // one, unchanged — that is the whole contract a backend has to meet.
-void RmsNormKernelRocm(Queue& q, Tensor& out, const Tensor& x, const Tensor& w,
+void RmsNormKernelRocm(Queue& q,
+  // bind
+ Tensor& out, const Tensor& x, const Tensor& w,
                        const RmsNormArgs& args, Tensor* residual) {
+  EnsureQueueDevice(q);
   VT_CHECK(w.dtype == x.dtype, "rocm rmsnorm: weight dtype must match x");
   hipStream_t s = static_cast<hipStream_t>(q.handle);
   switch (x.dtype) {
@@ -178,8 +182,11 @@ void RmsNormKernelRocm(Queue& q, Tensor& out, const Tensor& x, const Tensor& w,
 }
 
 // out = rmsnorm(x, w) + addend
-void RmsNormPlusAddRocm(Queue& q, Tensor& out, const Tensor& x, const Tensor& w,
+void RmsNormPlusAddRocm(Queue& q,
+  // bind
+ Tensor& out, const Tensor& x, const Tensor& w,
                         const Tensor& addend, const RmsNormArgs& args) {
+  EnsureQueueDevice(q);
   VT_CHECK(w.dtype == x.dtype && out.dtype == x.dtype && addend.dtype == x.dtype,
            "rocm rmsnorm+add: dtype match");
   VT_CHECK(x.rank >= 2 && out.shape[0] == x.shape[0] && out.shape[1] == x.shape[1] &&
@@ -270,9 +277,12 @@ __global__ void DualRmsNormPlusResKernel(T* out, const T* x1, const T* w1, const
   }
 }
 
-void DualRmsNormPlusResRocm(Queue& q, Tensor& out, const Tensor& x1, const Tensor& w1,
+void DualRmsNormPlusResRocm(Queue& q,
+  // bind
+ Tensor& out, const Tensor& x1, const Tensor& w1,
                             const Tensor& x2, const Tensor& w2, const Tensor& w3,
                             const Tensor& residual, const RmsNormArgs& args) {
+  EnsureQueueDevice(q);
   VT_CHECK(out.dtype == x1.dtype && x1.dtype == x2.dtype && x1.dtype == residual.dtype,
            "dual rms dtype");
   const int64_t t = x1.shape[0], h = x1.shape[1];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1155,6 +1155,7 @@ vllm_cpp_add_test(test_ops_paged_attn vt/test_ops_paged_attn.cpp)
 # switch, memcmp over every dtype the switch handled (spec §3, issue #391).
 vllm_cpp_add_test(test_ops_paged_attn_dtype vt/test_ops_paged_attn_dtype.cpp)
 vllm_cpp_add_test(test_ops_sample vt/test_ops_sample.cpp)
+vllm_cpp_add_test(test_gemma4_rocm_fp8_seams vt/test_gemma4_rocm_fp8_seams.cpp)
 vllm_cpp_add_test(test_ops_penalties vt/test_ops_penalties.cpp)
 
 vllm_cpp_add_test(test_npy parity/test_npy.cpp)

--- a/tests/vt/test_gemma4_rocm_fp8_seams.cpp
+++ b/tests/vt/test_gemma4_rocm_fp8_seams.cpp
@@ -1,0 +1,78 @@
+// CPU seam gate for #317 Gemma4 ROCm FP8 MoE stack.
+// Does NOT require a ROCm device: proves portable fused_ops declarations link
+// and the documented VT_GEMMA4_ / VT_ATTN_ env knobs parse inertly on CPU.
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "vt/fused_ops.h"
+
+namespace {
+
+struct EnvRestorer {
+  const char* key;
+  bool had = false;
+  std::string prev;
+  explicit EnvRestorer(const char* k) : key(k) {
+    if (const char* v = std::getenv(k)) {
+      had = true;
+      prev = v;
+    }
+  }
+  ~EnvRestorer() {
+    if (had) ::setenv(key, prev.c_str(), 1);
+    else ::unsetenv(key);
+  }
+};
+
+int EnvInt(const char* key, int def) {
+  const char* e = std::getenv(key);
+  if (e == nullptr || e[0] == '\0') return def;
+  char* end = nullptr;
+  long v = std::strtol(e, &end, 10);
+  if (end == e) return def;
+  return static_cast<int>(v);
+}
+
+}  // namespace
+
+TEST_CASE("gemma4 rocm fp8 seams: fused_ops ExpertGeGLU symbols link on CPU") {
+  // Taking addresses forces the linker to resolve the portable wrappers.
+  // Bodies may no-op or refuse without ROCm — that is fine for this gate.
+  auto* p0 = &vt::ExpertGeGLUFp8TopKM1;
+  auto* p1 = &vt::ExpertGeGLUFp8TopKIndexed;
+  auto* p2 = &vt::MatmulBTFp8Channel;
+  auto* p3 = &vt::DequantFp8ChannelBf16;
+  auto* p4 = &vt::PrewarmExpertGeGLUFp8TopK;
+  CHECK(p0 != nullptr);
+  CHECK(p1 != nullptr);
+  CHECK(p2 != nullptr);
+  CHECK(p3 != nullptr);
+  CHECK(p4 != nullptr);
+}
+
+TEST_CASE("gemma4 rocm fp8 seams: recipe env knobs parse inert defaults") {
+  // Defaults match docs/ENVIRONMENT.md / lab recipe when unset.
+  {
+    EnvRestorer a("VT_GEMMA4_FP8_HW_CVT");
+    EnvRestorer b("VT_ATTN_DECODE_KV_SPLITS");
+    EnvRestorer c("VT_ATTN_DECODE_SLIDE_SPLITS");
+    EnvRestorer d("VT_ATTN_DECODE_SPLIT_WARPS");
+    ::unsetenv("VT_GEMMA4_FP8_HW_CVT");
+    ::unsetenv("VT_ATTN_DECODE_KV_SPLITS");
+    ::unsetenv("VT_ATTN_DECODE_SLIDE_SPLITS");
+    ::unsetenv("VT_ATTN_DECODE_SPLIT_WARPS");
+    // Unset → code defaults are env-read at runtime inside HIP; here we only
+    // document the *recipe* integers the lab pins (not process-wide defaults).
+    CHECK(EnvInt("VT_GEMMA4_FP8_HW_CVT", 1) == 1);
+    CHECK(EnvInt("VT_ATTN_DECODE_KV_SPLITS", 16) == 16);
+    CHECK(EnvInt("VT_ATTN_DECODE_SLIDE_SPLITS", 8) == 8);
+    CHECK(EnvInt("VT_ATTN_DECODE_SPLIT_WARPS", 12) == 12);
+  }
+  {
+    EnvRestorer a("VT_GEMMA4_FP8_HW_CVT");
+    ::setenv("VT_GEMMA4_FP8_HW_CVT", "0", 1);
+    CHECK(EnvInt("VT_GEMMA4_FP8_HW_CVT", 1) == 0);
+  }
+}


### PR DESCRIPTION
## Summary

**ROCm / Gemma4 half** of the #228 split. **#228 is closed** — land this instead.

| Related | Role |
|---------|------|
| **#234** | ROCm V1 sampler + parallel RandomSample |
| **#227** | KV fail-fast |
| **#316** | SSE keepalives (timed wait) — not here |
| **#228** | Original megapr — **closed**, superseded |

## In

Dual-GPU FP8 resident MoE, peer mix, SharedK-WMMA prefill, decode KV-split, fused_ops seam, ENVIRONMENT `VT_GEMMA4_*` / `VT_ATTN_*`.

## Out

SSE/serving (#316), `rocm_sample` (#234), `support_static_graph_mode` flip.

## Review fixes in this tip

- HIPBLAS_V2 restored
- No platform graph-mode flip
- Host `#if VT_ROCWMMA_OK` around SharedK-WMMA launches

## Honest follow-ups

HIP guards in `models/gemma4.cpp`, MoE policy guards, peer weight_id/hscale, tests/spec. Large diff (~5k prod lines) — may need another slice or maintainer path like #154 if review asks.

Lab: dual R9700 gfx1201 / `start-gemma4-fp8-8010.sh`.

## Land order

1. **#234** → 2. **#227** → 3. **#316** → 4. **This PR (#317)**
