### PR TITLE
fix(server): gemma4 bare call: tool extract for OpenAI chat

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -516,7 +516,7 @@ a stop token early.
 | `--enable-radix-attention` / `--disable-radix-attention` | model default | SGLang-named alias for the prefix-cache toggle |
 | `--enable-jump-forward` | off | Jump-forward decoding for structured output (token-unique subset) |
 | `--enable-force-include-usage` | off | Force the usage block in responses |
-| `--tool-call-parser <name>` | `hermes` | Tool-call dialect (40 names over 36 families). `auto` detects from the chat template, `none` disables |
+| `--tool-call-parser <name>` | `hermes` | Tool-call dialect (40 names over 36 families). `auto` detects from the chat template, `none` disables. For `gemma4`, OpenAI chat uses the text-seam parser (wrapped `<\|tool_call>` **or** bare `call:NAME{ARGS}`) so free-form / detokenized tool bodies still become `tool_calls` |
 | `--reasoning-parser <name>` | `none` | Reasoning parser (`think_auto`, `deepseek_r1`, `deepseek_v3`, `holo2`, `mistral`, `minimax_m2`, `minimax_m2_append_think`, `step3`, `olmo3`). `auto` detects, `none` disables |
 | `--kv-transfer-config '<json>'` | (unset) | External KV connector, same JSON as vLLM's flag. See [docs/KV-OFFLOAD.md](KV-OFFLOAD.md) |
 | `--speculative-config '<json>'` | (unset) | Speculative decoding (`mtp`, `dflash`, `ngram`), same JSON as vLLM's flag. `dspark` speculates on the Qwen3.6 gate models (native + Speculators drafts), token-identically to speculative-off, but is not gated on speed (currently ~2% behind at c1). A GGUF target, or a target with no aux multi-tap, is refused by name (`SPEC-DSPARK`). See [docs/SPECULATIVE-DECODING.md](SPECULATIVE-DECODING.md) |

--- a/src/vllm/entrypoints/openai/serving_chat.cpp
+++ b/src/vllm/entrypoints/openai/serving_chat.cpp
@@ -529,6 +529,14 @@ class ChatSseStream final : public SseStream {
 std::unique_ptr<ToolParser> OpenAIServingChat::MakeToolParser(
     const ChatCompletionRequest& request) const {
   if (tool_parser_name_.empty() || !ToolsEnabled(request)) return nullptr;
+  // Lab/Hermes: free-form Gemma4 often emits bare `call:NAME{ARGS}` (or
+  // detokenized <|tool_call>… text) without the engine's special-token IDs.
+  // Prefer the text-seam gemma4 tool parser so both shapes extract to tool_calls.
+  // Engine-backed gemma4 remains available for other entrypoints via
+  // get_parser_engine("gemma4").
+  if (tool_parser_name_ == "gemma4") {
+    return get_tool_parser("gemma4");
+  }
   // An engine-backed name is served by MakeParserEngine, not the legacy seam.
   if (vllm::parser::get_parser_engine(tool_parser_name_) != nullptr) {
     return nullptr;
@@ -539,6 +547,9 @@ std::unique_ptr<ToolParser> OpenAIServingChat::MakeToolParser(
 std::unique_ptr<vllm::parser::engine::ParserEngine>
 OpenAIServingChat::MakeParserEngine(const ChatCompletionRequest& request) const {
   if (tool_parser_name_.empty() || !ToolsEnabled(request)) return nullptr;
+  if (tool_parser_name_ == "gemma4") {
+    return nullptr;  // OpenAI chat uses text-seam MakeToolParser above.
+  }
   // parser_manager get_parser_engine returns nullptr for a name that is not an
   // engine-backed format, so the legacy MakeToolParser seam handles those. This
   // is the name-selected dispatch swap: engine-backed (qwen3/seed_oss/kimi_k2)

--- a/src/vllm/entrypoints/openai/tool_parsers/gemma4.cpp
+++ b/src/vllm/entrypoints/openai/tool_parsers/gemma4.cpp
@@ -553,16 +553,97 @@ nlohmann::ordered_json Gemma4ToolParser::ParseArray(const std::string& arr_str,
   return ParseGemmaArray(arr_str, partial);
 }
 
+// Bare `call:NAME{ARGS}` fallback — some decodes drop <|tool_call>/<tool_call|>
+// specials (text-only seam / free-form with structural tags off) but still emit
+// the call: body Hermes needs. Brace depth ignores content inside <|\"|> strings.
+void ScanBareCalls(const std::string& text, std::string& content_out,
+                   std::vector<GemmaCall>& calls_out) {
+  content_out.clear();
+  calls_out.clear();
+  std::size_t pos = 0;
+  const std::size_t n = text.size();
+  while (pos < n) {
+    const std::size_t s = text.find(kCall, pos);
+    if (s == std::string::npos) {
+      content_out += text.substr(pos);
+      break;
+    }
+    // Avoid matching inside identifiers ("callback:", paths, etc.).
+    if (s > 0) {
+      const char prev = text[s - 1];
+      if (std::isalnum(static_cast<unsigned char>(prev)) || prev == '_' ||
+          prev == '/') {
+        content_out += text.substr(pos, s + kCall.size() - pos);
+        pos = s + kCall.size();
+        continue;
+      }
+    }
+    content_out += text.substr(pos, s - pos);
+    const std::size_t name_start = s + kCall.size();
+    const std::size_t brace = text.find('{', name_start);
+    if (brace == std::string::npos) {
+      content_out += text.substr(s);
+      break;
+    }
+    GemmaCall call;
+    call.name = Strip(text.substr(name_start, brace - name_start));
+    call.has_name = !call.name.empty();
+    std::size_t i = brace + 1;
+    int depth = 1;
+    bool in_str = false;
+    while (i < n && depth > 0) {
+      if (!in_str && DelimAt(text, i)) {
+        in_str = true;
+        i += kDelimLen;
+        continue;
+      }
+      if (in_str) {
+        if (DelimAt(text, i)) {
+          in_str = false;
+          i += kDelimLen;
+          continue;
+        }
+        ++i;
+        continue;
+      }
+      if (text[i] == '{') {
+        ++depth;
+      } else if (text[i] == '}') {
+        --depth;
+        if (depth == 0) {
+          call.args_text = text.substr(brace + 1, i - (brace + 1));
+          call.complete = true;
+          ++i;
+          break;
+        }
+      }
+      ++i;
+    }
+    if (!call.complete) {
+      call.args_text = text.substr(brace + 1);
+      call.complete = false;
+      pos = n;
+    } else {
+      pos = i;
+    }
+    if (call.has_name) calls_out.push_back(std::move(call));
+  }
+}
+
 ExtractedToolCallInformation Gemma4ToolParser::extract_tool_calls(
     const std::string& model_output, const ChatCompletionRequest& request) {
-  // No start marker -> plain content (unmodified).
-  if (model_output.find(kStart) == std::string::npos) {
-    return ExtractedToolCallInformation{false, {}, model_output};
-  }
   try {
     std::string content;
     std::vector<GemmaCall> calls;
-    ScanBlocks(model_output, content, calls);
+    const bool has_wrapped = model_output.find(kStart) != std::string::npos;
+    if (has_wrapped) {
+      ScanBlocks(model_output, content, calls);
+    } else if (model_output.find(kCall) != std::string::npos) {
+      // Lab/Hermes free-form path: bare call:NAME{ARGS} without specials.
+      ScanBareCalls(model_output, content, calls);
+    } else {
+      return ExtractedToolCallInformation{false, {}, model_output};
+    }
 
     std::vector<ToolCall> tool_calls;
     for (const GemmaCall& c : calls) {
@@ -580,9 +661,14 @@ ExtractedToolCallInformation Gemma4ToolParser::extract_tool_calls(
       return ExtractedToolCallInformation{false, {}, model_output};
     }
 
-    // Content = text before the first <|tool_call>, stripped; None when empty.
+    // Content = text before the first tool marker, stripped; None when empty.
     std::optional<std::string> content_opt;
-    const std::size_t first = model_output.find(kStart);
+    std::size_t first = std::string::npos;
+    if (has_wrapped) {
+      first = model_output.find(kStart);
+    } else {
+      first = model_output.find(kCall);
+    }
     if (first != std::string::npos && first > 0) {
       const std::string c = Strip(model_output.substr(0, first));
       if (!c.empty()) content_opt = c;
@@ -604,7 +690,20 @@ std::optional<DeltaMessage> Gemma4ToolParser::extract_tool_calls_streaming(
   try {
     std::string content;
     std::vector<GemmaCall> calls;
-    ScanBlocks(current_text, content, calls);
+    if (current_text.find(kStart) != std::string::npos) {
+      ScanBlocks(current_text, content, calls);
+    } else if (current_text.find(kCall) != std::string::npos) {
+      ScanBareCalls(current_text, content, calls);
+    } else {
+      // Still stream plain content before any call marker appears.
+      if (current_text.size() > streamed_content_len_) {
+        DeltaMessage msg;
+        msg.content = current_text.substr(streamed_content_len_);
+        streamed_content_len_ = current_text.size();
+        return msg;
+      }
+      return std::nullopt;
+    }
 
     DeltaMessage msg;
     std::vector<DeltaToolCall> deltas;

--- a/src/vllm/entrypoints/openai/tool_parsers/gemma4.cpp
+++ b/src/vllm/entrypoints/openai/tool_parsers/gemma4.cpp
@@ -477,6 +477,26 @@ std::string FixArgTypes(const std::string& args_json, const std::string& func_na
   return args_json;
 }
 
+
+// Strip trailing partial prefixes of tool markers so stream chunks never leak
+// half a `<|tool_call>` or bare `call:` into content (maint-bot split-tag case).
+void StripTrailingToolMarkerPrefixes(std::string& content_out) {
+  for (std::size_t k = kStart.size() - 1; k >= 1; --k) {
+    if (EndsWith(content_out, kStart.substr(0, k))) {
+      content_out.erase(content_out.size() - k);
+      break;
+    }
+    if (k == 1) break;
+  }
+  for (std::size_t k = kCall.size() - 1; k >= 1; --k) {
+    if (EndsWith(content_out, kCall.substr(0, k))) {
+      content_out.erase(content_out.size() - k);
+      break;
+    }
+    if (k == 1) break;
+  }
+}
+
 // ── Wire-format block scan ────────────────────────────────────────────────────
 // One <|tool_call>call:NAME{ARGS}<tool_call|> block recovered from the text.
 struct GemmaCall {
@@ -529,33 +549,14 @@ void ScanBlocks(const std::string& text, std::string& content_out,
     calls_out.push_back(std::move(call));
   }
 
-  // Buffer a trailing partial <|tool_call> start-tag prefix out of content so a
-  // split start tag never leaks (mirrors the engine never emitting a partial
-  // special token as text).
-  for (std::size_t k = kStart.size() - 1; k >= 1; --k) {
-    if (EndsWith(content_out, kStart.substr(0, k))) {
-      content_out.erase(content_out.size() - k);
-      break;
-    }
-    if (k == 1) break;
-  }
+  // Buffer trailing partial tool-marker prefixes out of content.
+  StripTrailingToolMarkerPrefixes(content_out);
 }
 
-}  // namespace
-
-nlohmann::ordered_json Gemma4ToolParser::ParseArgs(const std::string& args_str,
-                                                   bool partial) {
-  return ParseGemmaArgs(args_str, partial);
-}
-
-nlohmann::ordered_json Gemma4ToolParser::ParseArray(const std::string& arr_str,
-                                                    bool partial) {
-  return ParseGemmaArray(arr_str, partial);
-}
 
 // Bare `call:NAME{ARGS}` fallback — some decodes drop <|tool_call>/<tool_call|>
 // specials (text-only seam / free-form with structural tags off) but still emit
-// the call: body Hermes needs. Brace depth ignores content inside <|\"|> strings.
+// the call: body Hermes needs. Brace depth ignores content inside <|"|> strings.
 void ScanBareCalls(const std::string& text, std::string& content_out,
                    std::vector<GemmaCall>& calls_out) {
   content_out.clear();
@@ -582,7 +583,7 @@ void ScanBareCalls(const std::string& text, std::string& content_out,
     const std::size_t name_start = s + kCall.size();
     const std::size_t brace = text.find('{', name_start);
     if (brace == std::string::npos) {
-      content_out += text.substr(s);
+      // Incomplete bare call (no '{' yet) — buffer; do not leak as content.
       break;
     }
     GemmaCall call;
@@ -628,6 +629,20 @@ void ScanBareCalls(const std::string& text, std::string& content_out,
     }
     if (call.has_name) calls_out.push_back(std::move(call));
   }
+  StripTrailingToolMarkerPrefixes(content_out);
+}
+
+
+}  // namespace
+
+nlohmann::ordered_json Gemma4ToolParser::ParseArgs(const std::string& args_str,
+                                                   bool partial) {
+  return ParseGemmaArgs(args_str, partial);
+}
+
+nlohmann::ordered_json Gemma4ToolParser::ParseArray(const std::string& arr_str,
+                                                    bool partial) {
+  return ParseGemmaArray(arr_str, partial);
 }
 
 ExtractedToolCallInformation Gemma4ToolParser::extract_tool_calls(
@@ -690,19 +705,16 @@ std::optional<DeltaMessage> Gemma4ToolParser::extract_tool_calls_streaming(
   try {
     std::string content;
     std::vector<GemmaCall> calls;
+    // Unified content path: never emit a trailing partial `<|tool_call>` or
+    // bare `call:` prefix (split-across-chunks). Full markers dispatch to the
+    // wrapped / bare scanners; otherwise treat text as content with buffering.
     if (current_text.find(kStart) != std::string::npos) {
       ScanBlocks(current_text, content, calls);
     } else if (current_text.find(kCall) != std::string::npos) {
       ScanBareCalls(current_text, content, calls);
     } else {
-      // Still stream plain content before any call marker appears.
-      if (current_text.size() > streamed_content_len_) {
-        DeltaMessage msg;
-        msg.content = current_text.substr(streamed_content_len_);
-        streamed_content_len_ = current_text.size();
-        return msg;
-      }
-      return std::nullopt;
+      content = current_text;
+      StripTrailingToolMarkerPrefixes(content);
     }
 
     DeltaMessage msg;

--- a/tests/vllm/entrypoints/openai/tool_parsers/test_gemma4.cpp
+++ b/tests/vllm/entrypoints/openai/tool_parsers/test_gemma4.cpp
@@ -624,3 +624,133 @@ TEST_CASE("gemma4 stream: start tag split across chunks buffers cleanly") {
   CHECK(CollectName(r) == "get_weather");
   CHECK(Parsed(CollectArgs(r)) == nlohmann::json{{"location", "London"}});
 }
+
+// ── Maint-bot regressions (#328): bare + stream contracts ─────────────────────
+// Covers: wrapped, bare, prose containing `call:`, nested braces/string delims,
+// incomplete calls, and markers split across streaming chunks.
+
+TEST_CASE("gemma4 bare nonstream: complete call") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = p.extract_tool_calls(
+      "call:get_weather{location:<|\"|>London<|\"|>}", req);
+  CHECK(r.tools_called);
+  REQUIRE(r.tool_calls.size() == 1);
+  CHECK(r.tool_calls[0].function.name == "get_weather");
+  CHECK(Parsed(r.tool_calls[0].function.arguments) ==
+        nlohmann::json{{"location", "London"}});
+  CHECK_FALSE(r.content.has_value());
+}
+
+TEST_CASE("gemma4 bare nonstream: prose prefix kept as content") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = p.extract_tool_calls(
+      "Sure — call:get_weather{location:<|\"|>Paris<|\"|>}", req);
+  CHECK(r.tools_called);
+  REQUIRE(r.tool_calls.size() == 1);
+  CHECK(r.tool_calls[0].function.name == "get_weather");
+  REQUIRE(r.content.has_value());
+  CHECK(*r.content == "Sure —");
+}
+
+TEST_CASE("gemma4 bare nonstream: ordinary prose with call: substring not a tool") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  // Identifier boundary: "callback:" must not become a tool call.
+  const std::string prose = "Use the callback: handler, not a tool.";
+  auto r = p.extract_tool_calls(prose, req);
+  CHECK_FALSE(r.tools_called);
+  REQUIRE(r.content.has_value());
+  CHECK(*r.content == prose);
+}
+
+TEST_CASE("gemma4 bare nonstream: nested braces and string delimiters") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  // Nested object + delimiter-wrapped string that itself contains braces.
+  auto r = p.extract_tool_calls(
+      "call:search{input:{all:true,note:<|\"|>a{b}c<|\"|>}}", req);
+  CHECK(r.tools_called);
+  REQUIRE(r.tool_calls.size() == 1);
+  CHECK(r.tool_calls[0].function.name == "search");
+  auto args = Parsed(r.tool_calls[0].function.arguments);
+  CHECK(args["input"]["all"] == true);
+  CHECK(args["input"]["note"] == "a{b}c");
+}
+
+TEST_CASE("gemma4 bare nonstream: incomplete call stays plain content") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  // No '{' yet — not a finished bare call; return unmodified.
+  auto r = p.extract_tool_calls("call:get_weather", req);
+  CHECK_FALSE(r.tools_called);
+  REQUIRE(r.content.has_value());
+  CHECK(*r.content == "call:get_weather");
+}
+
+TEST_CASE("gemma4 bare nonstream: wrapped still preferred over bare") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = p.extract_tool_calls(
+      "<|tool_call>call:get_weather{location:<|\"|>London<|\"|>}<tool_call|>",
+      req);
+  CHECK(r.tools_called);
+  CHECK(r.tool_calls[0].function.name == "get_weather");
+}
+
+TEST_CASE("gemma4 stream bare: complete single call") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = Stream(p,
+                  {"call:get_weather{", "location:<|\"|>London<|\"|>", "}"},
+                  req);
+  CHECK(CollectContent(r).empty());
+  CHECK(CollectName(r) == "get_weather");
+  CHECK(Parsed(CollectArgs(r)) == nlohmann::json{{"location", "London"}});
+}
+
+TEST_CASE("gemma4 stream bare: call: prefix split across chunks buffers") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = Stream(p,
+                  {"ca", "ll:", "get_weather{", "location:<|\"|>Berlin<|\"|>", "}"},
+                  req);
+  // Partial "ca"/"ll:" must not leak as content before the bare call resolves.
+  CHECK(CollectContent(r).empty());
+  CHECK(CollectName(r) == "get_weather");
+  CHECK(Parsed(CollectArgs(r)) == nlohmann::json{{"location", "Berlin"}});
+}
+
+TEST_CASE("gemma4 stream bare: prose then bare call") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = Stream(p,
+                  {"Let me check. ", "call:get_weather{",
+                   "location:<|\"|>Oslo<|\"|>", "}"},
+                  req);
+  CHECK(CollectContent(r).find("Let me check.") != std::string::npos);
+  CHECK(CollectName(r) == "get_weather");
+  CHECK(Parsed(CollectArgs(r)) == nlohmann::json{{"location", "Oslo"}});
+}
+
+TEST_CASE("gemma4 stream bare: incomplete call: does not leak as content mid-stream") {
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  // Only a partial bare marker — buffer, no tool, no leaked "call".
+  auto r = Stream(p, {"call"}, req);
+  CHECK(CollectContent(r).empty());
+  CHECK(CollectName(r).empty());
+}
+
+TEST_CASE("gemma4 stream: start tag split across chunks buffers cleanly (bare path safe)") {
+  // Duplicate emphasis of the CI-failing case after the no-marker branch change.
+  Gemma4ToolParser p;
+  ChatCompletionRequest req = MakeRequest();
+  auto r = Stream(p, {"<", "|tool", "_call>", "call:get_weather{",
+                      "location:<|\"|>London<|\"|>}", "<tool_call|>"},
+                  req);
+  CHECK(CollectContent(r).empty());
+  CHECK(CollectName(r) == "get_weather");
+  CHECK(Parsed(CollectArgs(r)) == nlohmann::json{{"location", "London"}});
+}


### PR DESCRIPTION
## Summary
Gemma-4 free-form tool use (no structural tags / specials stripped at detokenize) often emits bare `call:NAME{ARGS}` instead of wrapped `<|tool_call>…` bodies. The engine-backed gemma4 parser needs special-token IDs; OpenAI `/v1/chat/completions` then returned plain `content` and clients (e.g. Hermes) never executed tools.

## Changes
- Text-seam `Gemma4ToolParser`: extract bare `call:NAME{ARGS}` (stream + non-stream), still supports wrapped blocks
- OpenAI chat: for `--tool-call-parser gemma4`, prefer text-seam `MakeToolParser` over engine path so detokenized/free-form bodies become real `tool_calls`
- USAGE: document the gemma4 dual surface

## Test plan
- [x] Lab: non-stream + stream `tools=[{terminal}]` → `finish_reason=tool_calls`, args `{"command":"date"}`
- [ ] CI gates
- [ ] Regression: wrapped `<|tool_call>call:…` still extracts

## Notes
Small serve/parser fix; independent of ROCm #317. Does not change structural-tag defaults.

FOLLOWING_AGENTS_PROTOCOL