### PR TITLE
spec(BACKEND-ROCM): port the vt::Backend graph-capture seam to hipGraph (#332)

### DIFF
--- a/.agents/roadmap_v1.md
+++ b/.agents/roadmap_v1.md
@@ -42,6 +42,7 @@ issue is not yet placed. Keyed record: update in place, never append.
 | [#132](https://github.com/mudler/vllm.cpp/issues/132) | `BACKEND-ROCM` | ROCm `-O0` RmsNorm CLR HostcallListener teardown deadlock | bug |
 | [#201](https://github.com/mudler/vllm.cpp/issues/201) | `BACKEND-ROCM` | `hipblasGemmEx` overload mismatch in `rocm_matmul_hipblaslt.hip` | bug |
 | [#269](https://github.com/mudler/vllm.cpp/issues/269) | `BACKEND-ROCM` | ROCm gfx1200 (RX 9060 XT): Qwen3-0.6B produces wrong greedy output despite all-native execution — embedding gather cleared | bug |
+| [#332](https://github.com/mudler/vllm.cpp/issues/332) | `BACKEND-ROCM` | ROCm: no decode-graph capture — the hipGraph seam is unimplemented, costing ~3x decode throughput vs vLLM on gfx1200 | perf |
 | [#125](https://github.com/mudler/vllm.cpp/issues/125) | `BACKEND-VULKAN` | Vulkan on AMD Strix Halo (gfx1151) does not load | bug |
 | [#203](https://github.com/mudler/vllm.cpp/issues/203) | `BACKEND-VULKAN` | Vulkan on unified memory holds TWO copies of the weights: 27B peaks at 100.8 GiB RSS and OOM-reboots a Spark | bug |
 | [#310](https://github.com/mudler/vllm.cpp/issues/310) | `BACKEND-VULKAN` | docs/FEATURES.md understates Vulkan: says decode 4.24 vs 4.35 where the binding figure is 4.36 vs 4.35 | bug |

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -2,17 +2,14 @@
 
 **Row:** `BACKEND-ROCM` (backend-matrix, `ACTIVE`).
 **Claim:** `CLAIM-ROCM-DECODE-GRAPH` (unclaimed at time of writing).
-**Issue:** **PENDING — file before implementation starts.** Per AGENTS.md "no
-work without an open GitHub issue"; the number then lands here, in the
-[roadmap intake table](../roadmap_v1.md), and in the PR body, and the three must
-agree. Draft text: §9 W0.
-**Base:** `6e4244f0` on `docs/rocm-gfx1200-m2-spec`, so this **stacks on
-[PR #273](https://github.com/mudler/vllm.cpp/pull/273)**, where
-[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) lands;
-`check-agent-record` fails with a dangling link if based on `main`. #273 merges
-first. The source tree is `f323907e` (`upstream/main`, 2026-08-10) — #273 is
-docs-only, so every `file:line` below holds against either. Re-anchor at
-implementation time; `check_links` validates ranges.
+**Issue:** [#332](https://github.com/mudler/vllm.cpp/issues/332), also carried in
+the [roadmap intake table](../roadmap_v1.md) and owed in the PR body — the three
+must agree.
+**Base:** current `upstream/main`. The gfx1200 correctness record this spec
+links, [rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md), is
+already ON `main` — it landed with #273's commits, so there is nothing left to
+stack on and no dangling link. Every `file:line` below was re-verified against
+this tree. Re-anchor at implementation time; `check_links` validates ranges.
 **Board:** AMD Radeon RX 9060 XT (`gfx1200`, Navi 44, RDNA4, discrete), ROCm
 7.2.3, hipClang/Clang 22.0.0 — the only board with hardware access here. Records
 say gfx1200 and must not imply the four #41 boards
@@ -293,21 +290,8 @@ the W1 approach-(b) delta does today.
 
 ## 9. Work breakdown
 
-- **W0 — file the issue, commit this spec.** No code. *Gate: issue open, number
-  agreeing in three places.* Draft:
-  > **Title:** ROCm: no decode-graph capture — hipGraph seam unimplemented,
-  > costing up to ~3x decode throughput vs vLLM on gfx1200
-  > **Body:** `vt::Backend`'s graph-capture virtuals are CUDA-only;
-  > `SupportsGraphCapture()` is false on ROCm and `support_static_graph_mode()`
-  > inherits false, so every decode step pays full host launch cost. Measured on
-  > RX 9060 XT (gfx1200, ROCm 7.2.3) vs a real vLLM-ROCm oracle at pin
-  > `555967922` in production config, batch 8, 128in/128out: Qwen3-0.6B 184.69
-  > vs 552.65 tok/s (2.99x), Qwen3-1.7B 150.50 vs 286.42 (1.90x), Qwen3-4B 98.49
-  > vs 143.36 (1.46x). The gap shrinks monotonically as per-step compute grows
-  > while launch count stays fixed — the signature of launch overhead, not
-  > kernel quality. vLLM captures 51 piecewise + 35 full hipGraphs on this same
-  > board, so hipGraph capture demonstrably works here.
-  > Spec: `.agents/specs/rocm-decode-graph.md`.
+- **W0 — DONE.** [#332](https://github.com/mudler/vllm.cpp/issues/332) filed and
+  carried in the intake table and this header; this spec committed. No code.
 - **W1 — backend seam + micro-test.** §5 port map, §6 test, RED-first. Verify D1
   with a capture around a GEMM. *Gate: 1, 2, 7.*
 - **W2 — flip `support_static_graph_mode()`, run a real model.** Qwen3-0.6B end

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -67,7 +67,7 @@ compute rather than a measurement of it, and no trace has been taken on either
 side. D4 carries this.
 
 **Structural reason, independent of the numbers.** `vt::Backend`'s capture
-virtuals (`include/vt/backend.h:181-195`) are documented as a multi-backend seam
+virtuals (`include/vt/backend.h:188-202`) are documented as a multi-backend seam
 ("CUDA Graphs / Metal ICB / Vulkan CB"), but CUDA is its only implementation:
 Metal (`metal_backend.mm:13`), Vulkan (`vulkan_backend.cpp:16`) and ROCm all
 carry the same `stays FALSE` note. A one-implementation abstraction is unproven.
@@ -85,14 +85,14 @@ side (~8.0 GB weights + ~3 GB captured graphs against 15.92 GiB). Oracle =
 cell on a board that also drives a display: indicative, and **not** the
 2-3x-reproduced-idle standard gate 5 requires. `Qwen/Qwen3-8B` does not fit
 (~16.4 GB bf16 against 15.92 GiB), and no quantized path is available — ROCm
-registers 23 ops to CUDA's 84, none of them quantized, and a discrete board has
+registers 44 ops to CUDA's 84, none of them quantized, and a discrete board has
 no reference tier, so an unregistered op throws.
 
 ## 2. Scope
 
 **In scope.**
 1. `src/vt/rocm/rocm_backend.hip` — the six capture virtuals against hipGraph,
-   mirroring `cuda_backend.cu:194-286`, replacing the `stays FALSE` note at
+   mirroring `cuda_backend.cu:198-290`, replacing the `stays FALSE` note at
    `:22-26`.
 2. `src/vllm/platforms/rocm.cpp` — add the `support_static_graph_mode()`
    override (`rocm.cpp:67` is today a comment explaining the inherited false,
@@ -104,7 +104,7 @@ no reference tier, so an unregistered op throws.
 **Out of scope.**
 - **New decode-graph model siblings.** Only models that already have one
   benefit; writing more is separate work with its own correctness gate.
-- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:230-262`) — CUDA-profiler
+- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:234-266`) — CUDA-profiler
   instrumentation, not load-bearing. A `rocprofiler` equivalent is later work;
   the first cut omits it and says so in the code.
 - **Any model-level edit.** Every decode-graph class already gates generically
@@ -114,7 +114,7 @@ no reference tier, so an unregistered op throws.
 - **Metal / Vulkan capture.** Different APIs, different specs.
 - **The M3 attention-backend NAME registration** (`rocm.cpp:105` returns `{}`)
   and the stale `rocm.cpp:91` comment claiming `kPagedAttention` is unregistered
-  for `kROCM` — it is registered (`rocm_ops.hip:92`) and ran `vt-native` on this
+  for `kROCM` — it is registered (`rocm_ops.hip:148`) and ran `vt-native` on this
   board. Both real, both separate; a bug found in passing gets its own issue.
 
 ## 3. Upstream chain
@@ -132,12 +132,12 @@ Observed on this board 2026-08-10 — 51 piecewise + 35 full captures, ~6 s, in 
 not inferred.
 
 Internal anchors:
-- `include/vt/backend.h:181-195` — the six virtuals and the multi-backend comment.
+- `include/vt/backend.h:188-202` — the six virtuals and the multi-backend comment.
 - `src/vt/backend.cpp:29-34` — base impls: five `VT_CHECK(false, ...)` throws,
   `DestroyGraph` a no-op. An unimplemented backend fails loudly; the model-level
   `enabled` gate keeps it off the path.
-- `src/vt/cuda/cuda_backend.cu:178-286` — the implementation to mirror. Its
-  capture-contract comment (`:183-193`) is the real specification of what a
+- `src/vt/cuda/cuda_backend.cu:182-290` — the implementation to mirror. Its
+  capture-contract comment (`:187-197`) is the real specification of what a
   caller must honour.
 - `src/vllm/platforms/interface.h:185-189`, `cuda.cpp:58-59`, `rocm.cpp:67`.
 - `src/vllm/model_executor/models/qwen3.cpp:489-560` — the consumer:
@@ -161,13 +161,13 @@ here.
 
 | CUDA (`cuda_backend.cu`) | ROCm (`rocm_backend.hip`) |
 |---|---|
-| `:194` `SupportsGraphCapture()` | same |
-| `:200-203` `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
-| `:204-212` `EndCapture` — end → destroy prior `exec_` → instantiate → destroy graph | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
-| `:214-216` `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
-| `:221-227` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape; returns `hipGraphExec_t` as `void*` |
-| `:229-266` `ReplayGraph(q, graph)` | same, minus `VT_BENCH_PROFILE_CONTROL` (§2) |
-| `:284-286` `DestroyGraph` | `hipGraphExecDestroy` |
+| `:198` `SupportsGraphCapture()` | same |
+| `:204-207` `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
+| `:208-216` `EndCapture` — end → destroy prior `exec_` → instantiate → destroy graph | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
+| `:218-220` `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
+| `:225-231` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape; returns `hipGraphExec_t` as `void*` |
+| `:233-270` `ReplayGraph(q, graph)` | same, minus `VT_BENCH_PROFILE_CONTROL` (§2) |
+| `:288-290` `DestroyGraph` | `hipGraphExecDestroy` |
 | `platforms/cuda.cpp:58-59` `support_static_graph_mode()` | new override in `platforms/rocm.cpp` |
 
 Every name is a long-stable HIP runtime API with the same signature and
@@ -252,7 +252,7 @@ mutations that must turn it red, in a scratch copy, restored byte-for-byte:
 fails.** `rocm_matmul_hipblaslt.hip:243-255` allocates the hipBLASLt workspace
 lazily in the GEMM path, growing on demand (`if (need > cap) { hipFree;
 hipMalloc; }`). Allocation inside a capture region is illegal and invalidates
-it. CUDA's contract comment (`cuda_backend.cu:186-190`) names exactly this and
+it. CUDA's contract comment (`cuda_backend.cu:190-194`) names exactly this and
 notes cuBLASLt's workspace is a one-time per-context alloc there. *Mitigation:*
 the decode-graph pre-warm runs the same shapes at the same padded size before
 capture, which should grow `cap` to its high-water mark. *If it does not:*

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -1,0 +1,330 @@
+# ROCm decode-graph capture — port the `vt::Backend` capture seam to hipGraph
+
+**Row:** `BACKEND-ROCM` (backend-matrix, `ACTIVE`).
+**Claim:** `CLAIM-ROCM-DECODE-GRAPH` (unclaimed at time of writing).
+**Issue:** **PENDING — must be filed before implementation starts.** Per
+AGENTS.md "no work without an open GitHub issue"; the number then lands in the
+[roadmap intake table](../roadmap_v1.md), in this spec's header, and in the PR
+body, and those three must agree. Draft issue text: §9.
+**Base:** `6e4244f0` on `docs/rocm-gfx1200-m2-spec` — i.e. **this work stacks on
+[PR #273](https://github.com/mudler/vllm.cpp/pull/273)**, which is where
+[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) lands. That
+dependency is real, not incidental: §1's measurements and gate 3's near-tie
+context both come from that investigation, and `check-agent-record` fails with a
+dangling link if this spec is based on `main` instead. #273 merges first. The
+underlying source tree is `f323907e` (`upstream/main`, 2026-08-10) — #273 is
+docs-only and touches nothing under `src/`, `include/` or `tests/`, so every
+`file:line` below is equally valid against either. Re-anchor at implementation
+time anyway (anchor drift is a standing hazard, and `check_links` validates
+ranges).
+**Board:** AMD Radeon RX 9060 XT (`gfx1200`, Navi 44, RDNA4, discrete), ROCm
+7.2.3, hipClang/Clang 22.0.0. This is the ONLY board with hardware access here.
+Findings must say gfx1200 and not imply the four #41 boards
+(gfx1151/gfx1103/gfx1100/gfx1201) are covered.
+
+---
+
+## 1. Why this, and what it is worth
+
+Measured on gfx1200, 2026-08-10, 128in/128out, our engine vs a real vLLM-ROCm
+oracle at this project's own pin (`555967922`), oracle in production config
+(**not** `--enforce-eager`):
+
+| Model | Ours (batch 8) | Oracle (batch 8) | Ratio |
+|---|---|---|---|
+| Gemma-3-1B-it | 146.43 tok/s | 438.09 tok/s | 2.99x |
+| Qwen3-0.6B | 184.69 tok/s | 552.65 tok/s | 2.99x |
+
+Two structurally different models (GeGLU/dual-rope/sandwich-norm vs
+SiLU/standard-attention), different sizes, different absolute speeds on both
+sides — and the SAME ratio to three significant figures. That is the signature
+of a backend-wide, architecture-independent overhead, not a per-kernel quality
+gap: a slow GeGLU kernel would move Gemma's ratio and not Qwen's.
+
+The oracle's run captured 51 piecewise + 35 full hipGraphs before its timed
+section. Ours captured none, because `SupportsGraphCapture()` is `false` on
+ROCm — so every decode step pays full host-side launch cost. **The hypothesis
+this spec tests is that graph capture is the dominant term in that 2.99x.** It
+is a hypothesis, not a conclusion: no `rocprof` trace has been taken on either
+side, and §8/D4 keeps that gap open rather than assuming.
+
+**Second, structural reason.** `vt::Backend`'s capture virtuals
+(`include/vt/backend.h:181-195`) are documented as a multi-backend seam
+("CUDA Graphs / Metal ICB / Vulkan CB"), but **CUDA is the only implementation
+that exists**. Metal (`metal_backend.mm:13`), Vulkan (`vulkan_backend.cpp:16`)
+and ROCm (`rocm_backend.hip:22`) all carry an explicit `SupportsGraphCapture()
+stays FALSE` comment. A one-implementation abstraction is an unproven
+abstraction. ROCm is the cheapest possible second implementation — hipGraph is
+a near-exact mirror of the CUDA graph API, where `MTLIndirectCommandBuffer` and
+a pre-recorded `VkCommandBuffer` are genuinely different models — so this is
+also the cheapest available evidence that the seam generalizes at all.
+
+**What it does NOT do, stated up front.** It does not speed up Gemma-3.
+`grep -rl DecodeGraph include/ src/` returns Qwen3 (dense + MoE), DeepSeek-V2/V4,
+Voxtral and Laguna — **there is no `Gemma3DecodeGraph` on any backend, CUDA
+included**. Gemma gains exactly nothing from this change until someone writes
+that sibling (sweep-gemma.md's W7, unclaimed). The measurable vehicle here is
+Qwen3-0.6B.
+
+## 2. Scope
+
+**In scope.**
+1. `src/vt/rocm/rocm_backend.hip` — implement the six capture virtuals against
+   hipGraph, mirroring `src/vt/cuda/cuda_backend.cu:194-286` virtual for
+   virtual, and delete the `stays FALSE` scope note at `rocm_backend.hip:22-26`
+   (replacing it with what is now true).
+2. `src/vllm/platforms/rocm.cpp` — add a `support_static_graph_mode()` override
+   returning `true` (today the class does not override it and inherits
+   `false` from `interface.h:189`; `rocm.cpp:67` is a comment explaining that
+   inheritance, not an override). Replace that comment.
+3. `tests/vt/test_rocm_backend.cpp` — a capture/replay case, RED-first (§6).
+4. Records: this spec, the roadmap intake row, `backend-matrix.md`'s
+   `BACKEND-ROCM` row, and `docs/ROCM.md` §5's M3 text.
+
+**Out of scope, each with a reason.**
+- **`Gemma3DecodeGraph`** — does not exist on any backend; a new model-level
+  decode-graph sibling is its own change with its own correctness gate. Writing
+  it here would bundle two independently-reviewable things (§1).
+- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:230-262`, `cudaProfilerStart/
+  Stop` arming around a targeted replay) — CUDA-profiler-specific
+  instrumentation, not load-bearing for correctness. A `rocprofiler` equivalent
+  is a later, separate change. The first cut omits it and says so in the code.
+- **Any model-level edit.** Every decode-graph class already gates on
+  `platforms::GetPlatform(...).support_static_graph_mode() &&
+  b.SupportsGraphCapture()` with no `is_cuda()` anywhere (verified:
+  `qwen3.cpp:494-498`, `qwen3_moe.cpp:385`, `deepseek_v2.cpp:896`,
+  `voxtral.cpp:438`, `qwen3_5.cpp:7846,8167`). Flipping the two flags is
+  sufficient; a model edit would mean the seam had failed.
+- **Metal / Vulkan capture.** Different APIs, different specs.
+- **The M3 attention-backend NAME registration** (`rocm.cpp:105`
+  `get_attn_backend_priority` returns `{}`) and the stale
+  `rocm.cpp:91` comment claiming `kPagedAttention` is not registered for
+  `kROCM` — it IS (`rocm_ops.hip:92`), and it ran `selected=vt-native` on this
+  board. Both are real, both are separate; per AGENTS.md a bug found while
+  doing something else gets its own issue, not a silent fix.
+
+## 3. Upstream chain
+
+**No upstream vLLM analog, and that is recorded rather than papered over.**
+Graph capture in vLLM is torch's (`CompilationConfig.cudagraph_mode`,
+`CUDAGraphMode.FULL_AND_PIECEWISE`); there is no `csrc/` file to port. Our
+`vt::Backend` capture seam is an ADDITIVE abstraction, in the same class as the
+ROCm `hipMallocManaged` decision (`rocm-unified-memory-b.md` §"Upstream
+grounding") — it goes in the porting inventory as additive, with this spec as
+its record.
+
+What IS mirrored is upstream's *behaviour*: vLLM on ROCm captures hipGraphs by
+default in production config, which is precisely the configuration our gate
+measures against. Observed directly on this board 2026-08-10 (51 piecewise + 35
+full captures, ~6 s, in the `vllm bench` log) — so "hipGraph capture works on
+gfx1200/ROCm 7.2.3" is measured, not inferred.
+
+Internal anchors (base `f323907e`):
+- `include/vt/backend.h:181-195` — the six virtuals + the multi-backend comment.
+- `src/vt/backend.cpp:29-34` — base impls: five `VT_CHECK(false, ...)` throws,
+  `DestroyGraph` a no-op. So an unimplemented backend fails loudly, and the
+  model-level `enabled` gate is what keeps it off the path.
+- `src/vt/cuda/cuda_backend.cu:178-286` — the implementation to mirror,
+  including its capture contract comment (`:183-193`), which is the real
+  specification of what a caller must honour.
+- `src/vllm/platforms/interface.h:185-189`, `src/vllm/platforms/cuda.cpp:58-59`,
+  `src/vllm/platforms/rocm.cpp:67`.
+- `src/vllm/model_executor/models/qwen3.cpp:489-560` — `Qwen3DenseDecodeGraph::
+  Impl`, the consumer: per-padded-size `SizeSlot`s with fixed-address persistent
+  host/device buffers, `Refresh()` in place, invalidate-and-recapture on a
+  block-table column change.
+
+## 4. Our baseline
+
+**REUSED as-is** (this is most of the change's value — nothing here is written):
+- The whole `vt::Backend` virtual interface. No signature changes.
+- Every decode-graph model class and its capture contract handling — padded
+  size slots, pre-warm, persistent buffers, column-change invalidation.
+- `test_cuda_backend.cpp:102-153` as the test shape to mirror.
+- The `tests/CMakeLists.txt` pattern that COMPILES `test_rocm_backend.cpp`
+  everywhere as a bit-rot guard but LINKS it only under `VLLM_CPP_HIP`.
+
+**NEW, and why it cannot be reused:** the `hip*` graph calls themselves.
+Mechanically a near-copy, but new code that has never been compiled here.
+
+## 5. Port map
+
+| CUDA (`cuda_backend.cu`, base `f323907e`) | ROCm (`rocm_backend.hip`) |
+|---|---|
+| `:194` `SupportsGraphCapture() { return true; }` | same |
+| `:200-203` `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
+| `:204-212` `EndCapture` — `cudaStreamEndCapture` → destroy prior `exec_` → `cudaGraphInstantiate` → `cudaGraphDestroy` | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
+| `:214-216` `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
+| `:221-227` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape, `hip*`; returns `hipGraphExec_t` as `void*` |
+| `:229-266` `ReplayGraph(q, graph)` | same, **minus** the `VT_BENCH_PROFILE_CONTROL` block (§2) |
+| `:284-286` `DestroyGraph` — `cudaGraphExecDestroy` | `hipGraphExecDestroy` |
+| `platforms/cuda.cpp:58-59` `support_static_graph_mode() { return true; }` | new override in `platforms/rocm.cpp`, same |
+
+Every name above is a documented, long-stable HIP runtime API with the same
+signature and semantics as its CUDA counterpart — which is the same property
+that lets upstream compile `csrc/` for both through hipify.
+
+## 6. Tests — RED first, and the RED must be the right red
+
+Nothing to port (additive abstraction). One new case in
+`tests/vt/test_rocm_backend.cpp`, mirroring `test_cuda_backend.cpp:102-153`,
+and **deliberately HIP-header-free** like the rest of that file (every
+assertion through public `vt::` seams; if a test needed a HIP header, the seam
+would be leaking):
+
+1. `SupportsGraphCapture()` is true.
+2. Allocate `src`/`dst` ONCE (fixed pointers — the capture contract). Load `src`
+   with pattern A pre-capture.
+3. `BeginCapture` → one d2d `Copy(dst, src)` → `EndCapture`.
+4. `Replay` → `dst` reads back pattern A. *Proves the graph ran at all.*
+5. **Mutate `src` in place (same address) to pattern B, `Replay` again → `dst`
+   must read back B.** *This is the load-bearing assertion.* It proves replay
+   RE-EXECUTES the captured copy over the persistent buffer rather than
+   replaying a snapshot — which is exactly the mechanism by which a decode
+   graph picks up each new token's inputs, and exactly the failure
+   `rocm_backend.hip:23-25` warns about ("a graph that captures a wrong stream
+   is a silent correctness bug").
+6. Handle variant: `EndCaptureGraph` → `ReplayGraph` → `DestroyGraph`, same
+   A-then-B assertion, since that is the path the decode graphs actually take
+   (`Replay`/`EndCapture` are the single-graph legacy pair).
+
+**RED-first discipline.** The reviewer must see this fail for the intended
+reason before it passes. Two mutations that MUST turn it red, run in a scratch
+copy and restored byte-for-byte:
+- Make `ReplayGraph` a no-op → step 4 fails (graph never ran).
+- Make `EndCaptureGraph` snapshot `src` into a temporary and replay from that
+  instead of the captured pointer → step 4 passes, **step 5 fails**. If step 5
+  does not fail under this mutation, the test is not testing the thing it
+  exists for.
+
+## 7. Gates
+
+1. **Build.** Clean `-Werror`, 0 warnings, HIP build on gfx1200. Non-HIP CPU
+   build still object-compiles the test file (bit-rot guard) and full `ctest`
+   stays green.
+2. **`ctest -R 'rocm|cross_device'`** — the existing 3 binaries plus the new
+   case. Baseline today on this board is 3/3 pass.
+3. **Correctness, non-negotiable, and this is the one that can actually bite.**
+   Re-run BOTH real-oracle batteries from
+   [rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) with capture
+   ON:
+   - **Gemma-3-1B-it** 6-prompt battery — unaffected *by construction* (no
+     `Gemma3DecodeGraph` exists, so no capture happens), but re-run anyway;
+     "assume unaffected" is not this project's standard.
+   - **Qwen3-0.6B** — this one HAS a decode-graph sibling, so capture ON changes
+     its execution path. Its `'The capital of france is'` prompt is a *known,
+     measured, version-sensitive near-tie* where our CPU and ROCm backends
+     already disagree and two real vLLM builds already disagree with each other.
+     A captured graph could plausibly move it again. **Required outcome is an
+     honest report, not a specific token**: re-run the same real-oracle
+     comparison that resolved it before and state what it does. A flip that the
+     oracle also produces is not a regression; a silent unreported flip is.
+4. **`VT_DECODE_GRAPH_STATS=1`** (already printed by the decode-graph `Impl`
+   destructors) must show a non-zero replay count — proving capture engaged
+   rather than silently falling through to eager, which would make gate 5's
+   numbers meaningless.
+5. **Performance, as a MEASUREMENT not a claim.** Re-run the §1 comparison on
+   Qwen3-0.6B, same-binary A/B (capture ON vs `VLLM_CPP_CUDAGRAPH=0`), both
+   arms on an idle box, reproduced 2-3x per AGENTS.md. Record the ratio
+   whatever it is. If the gap does not close materially, **that is a finding to
+   record, not a failure to bury** — it would refute §1's hypothesis and
+   redirect to the profiling in D4. Gemma-3 numbers must NOT be quoted as
+   improved (§1).
+6. **`GetReferenceTierHits()` == 0** in any perf measurement (discrete board;
+   should be structurally impossible, assert anyway).
+7. **Records green:** `scripts/agent-preflight.sh --staged`,
+   `check-agent-record.py`, `check-doc-checkpoint.py`, `check-public-doc-tables.py`,
+   `check-device-leakage.py` (this change adds no device predicate to the
+   shared layer — the ratchet must not move).
+
+## 8. Risks and decisions
+
+**D1 — `LtWorkspace` can `hipMalloc` mid-capture, and that is the single most
+likely way this fails.** `src/vt/rocm/rocm_matmul_hipblaslt.hip:243-255`
+allocates the hipBLASLt workspace lazily, in the GEMM call path, growing it on
+demand (`if (need > cap) { hipFree; hipMalloc; }`). Allocation inside a capture
+region is illegal and invalidates the capture. CUDA's contract comment
+(`cuda_backend.cu:186-190`) names exactly this ("NO cudaMalloc/cudaFree inside
+the region — the scratch pool must be pre-warmed so every allocation is a pool
+hit"), and notes cuBLASLt's workspace is a one-time per-context alloc there.
+*Mitigation:* the decode-graph pre-warm step already runs the same shapes at the
+same padded size before capture, which should grow `cap` to its high-water mark
+first. *Failure mode if it does not:* `hipStreamEndCapture` fails loudly — a
+thrown error, not silent corruption — which is the acceptable direction. **W1
+verifies this explicitly rather than trusting it**, because a shape that only
+appears at capture time would be a latent, board-specific trap.
+
+**D2 — the Qwen3-0.6B near-tie may move.** Covered by gate 3. Called out
+separately because it is the one outcome that could *look* like a regression
+while being nothing of the kind, and the temptation to quietly re-baseline a
+golden is exactly what this project's "never weaken a checker" rule exists to
+stop.
+
+**D3 — gfx12 is new silicon and its kernels are still maturing upstream.**
+vllm-project/vllm#45916 ("Triton split-KV paged decode fallback for gfx12") is
+open, and the oracle's own log on this board printed *"Cannot use ROCm custom
+paged attention kernel, falling back to Triton implementation."* The oracle
+captured graphs successfully anyway — but it captured graphs around *its*
+attention path, not ours. Our native `rocm_paged_attn.hip` inside a capture
+region is the genuinely unproven combination. *Mitigation:* W2 captures a real
+Qwen3 decode step, not just the W1 micro-test; `hipStreamCaptureModeThreadLocal`
+turns any illegal op into a loud capture failure.
+
+**D4 — "graph capture is the 2.99x" is a hypothesis, and the spec must not
+launder it into a conclusion.** No `rocprof`/`nsys`-equivalent trace has been
+taken on either side; the evidence is (a) the ratio is identical across two
+unrelated architectures, (b) the oracle demonstrably captures graphs and we
+demonstrably do not. That is strong, and it is not a profile. Per AGENTS.md
+("never declare a ceiling"; trace both sides with the same tool before a
+throughput claim), if gate 5 closes the gap the win is real but the
+*attribution* still wants a same-tool trace before it is written up as the
+explanation. If gate 5 does NOT close it, D4 becomes the next work item and the
+hypothesis is recorded as refuted.
+
+**D5 — one board, one arch.** gfx1200 only. hipGraph is not arch-specific and
+the four #41 boards are all likelier-supported RDNA3/CDNA parts, but none of
+them has run this. Every record says gfx1200, and the other boards stay
+`PENDING-community` exactly as the W1 approach-(b) delta does today.
+
+## 9. Work breakdown
+
+- **W0 — file the issue, commit this spec.** No code. *Gate: issue open, number
+  agreeing in three places.* Draft issue text:
+  > **Title:** ROCm: no decode-graph capture — hipGraph seam unimplemented,
+  > costing ~3x decode throughput vs vLLM on gfx1200
+  > **Body:** `vt::Backend`'s graph-capture virtuals are implemented only for
+  > CUDA; `SupportsGraphCapture()` is false on ROCm and
+  > `support_static_graph_mode()` inherits false, so every decode step pays full
+  > host launch cost. Measured on RX 9060 XT (gfx1200, ROCm 7.2.3) against a
+  > real vLLM-ROCm oracle at pin `555967922` in production config: ours 146.43
+  > vs 438.09 tok/s (Gemma-3-1B-it) and 184.69 vs 552.65 tok/s (Qwen3-0.6B) —
+  > the same 2.99x on two unrelated architectures, which points at a
+  > backend-wide launch-overhead term rather than kernel quality. vLLM captures
+  > 51 piecewise + 35 full hipGraphs on this same board, so hipGraph capture
+  > demonstrably works here. Spec: `.agents/specs/rocm-decode-graph.md`.
+- **W1 — the backend seam + micro-test.** §5 port map, §6 test, RED-first.
+  Explicitly verify D1 (workspace pre-warm) with a capture around a GEMM.
+  *Gate: 1, 2, 7.*
+- **W2 — flip `support_static_graph_mode()` and run a real model.** Qwen3-0.6B
+  end to end with capture engaged. *Gate: 3, 4 — the correctness gates. Nothing
+  proceeds past a red here.*
+- **W3 — measure.** Gate 5 + 6, same-binary A/B, idle box, 2-3x reproduced.
+  Record the result whatever it is.
+- **W4 — records.** This spec's `## Outcome` (what was measured, what was
+  rejected, why the default is what it is), `backend-matrix.md`,
+  `docs/ROCM.md` §5 M3, `docs/BENCHMARKS.md` if gate 5 yields an accepted
+  measurement, `NOW.md` if the row's lifecycle state moves.
+
+## 10. Stop conditions
+
+Return `NEEDS_DECISION` rather than improvising if:
+- Gate 3 shows a Qwen3-0.6B token change that the real oracle does **not**
+  reproduce — that is a genuine correctness signal, not a near-tie, and it stops
+  the work.
+- D1 turns out to need a real allocator change (a pre-warm hook, a workspace
+  cap) — that widens scope from "port a seam" into shared-allocator surgery and
+  wants its own decision.
+- Gate 5 shows no material improvement — W3 stops and D4 (profiling) becomes the
+  next spec rather than iterating blind on this one.
+
+Return `NEEDS_CONTEXT` if the issue in W0 cannot be filed (no work without one).

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -8,8 +8,15 @@ must agree.
 **Base:** current `upstream/main`. The gfx1200 correctness record this spec
 links, [rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md), is
 already ON `main` — it landed with #273's commits, so there is nothing left to
-stack on and no dangling link. Every `file:line` below was re-verified against
-this tree. Re-anchor at implementation time; `check_links` validates ranges.
+stack on and no dangling link.
+**Anchors are SYMBOLS, not line numbers, and that is deliberate.** `main` runs
+75-207 commits/day (measured over 2026-08-07..11), so a `file:line` anchor is
+wrong within days: an earlier draft of this spec drifted +4 lines in
+`cuda_backend.cu`, +7 in `backend.h`, and `rocm_ops.hip`'s `kPagedAttention`
+registration moved 92 -> 148, all inside one day. Every anchor below is instead
+a function signature, a `RegisterOp` call, a test-case title or a distinctive
+comment — things `grep -rn` still finds after a thousand commits. Keep it that
+way when editing.
 **Board:** AMD Radeon RX 9060 XT (`gfx1200`, Navi 44, RDNA4, discrete), ROCm
 7.2.3, hipClang/Clang 22.0.0 — the only board with hardware access here. Records
 say gfx1200 and must not imply the four #41 boards
@@ -20,10 +27,10 @@ say gfx1200 and must not imply the four #41 boards
 ## 1. Why this, and what it is worth
 
 `vt::Backend`'s graph-capture virtuals are implemented only for CUDA.
-`SupportsGraphCapture()` is false on ROCm (`rocm_backend.hip:22-26` says so
+`SupportsGraphCapture()` is false on ROCm (the `SupportsGraphCapture() stays FALSE` scope note in `rocm_backend.hip` says so
 explicitly) and `RocmPlatform` does not override `support_static_graph_mode()`,
-inheriting false from `interface.h:189`. Decode-graph classes gate on both
-(`qwen3.cpp:494-498`), so every ROCm decode step pays full host launch cost
+inheriting false from `Platform::support_static_graph_mode()` in `interface.h`. Decode-graph classes gate on both
+(the `enabled =` gate in `Qwen3DenseDecodeGraph::Impl`), so every ROCm decode step pays full host launch cost
 while vLLM on the same board replays captured hipGraphs.
 
 Measured on gfx1200, 2026-08-10, 128in/128out batch 8, ours
@@ -67,10 +74,10 @@ compute rather than a measurement of it, and no trace has been taken on either
 side. D4 carries this.
 
 **Structural reason, independent of the numbers.** `vt::Backend`'s capture
-virtuals (`include/vt/backend.h:188-202`) are documented as a multi-backend seam
+virtuals (`vt::Backend`'s capture virtuals (`SupportsGraphCapture` through `DestroyGraph`, `include/vt/backend.h`)) are documented as a multi-backend seam
 ("CUDA Graphs / Metal ICB / Vulkan CB"), but CUDA is its only implementation:
-Metal (`metal_backend.mm:13`), Vulkan (`vulkan_backend.cpp:16`) and ROCm all
-carry the same `stays FALSE` note. A one-implementation abstraction is unproven.
+Metal (`metal_backend.mm`), Vulkan (`vulkan_backend.cpp`) and ROCm all carry the
+same `SupportsGraphCapture() stays FALSE` note. A one-implementation abstraction is unproven.
 hipGraph is the cheapest available second, since `MTLIndirectCommandBuffer` and
 a pre-recorded `VkCommandBuffer` are genuinely different models.
 
@@ -92,11 +99,10 @@ no reference tier, so an unregistered op throws.
 
 **In scope.**
 1. `src/vt/rocm/rocm_backend.hip` — the six capture virtuals against hipGraph,
-   mirroring `cuda_backend.cu:198-290`, replacing the `stays FALSE` note at
-   `:22-26`.
+   mirroring `cuda_backend.cu`'s capture block, replacing that `stays FALSE` note.
 2. `src/vllm/platforms/rocm.cpp` — add the `support_static_graph_mode()`
-   override (`rocm.cpp:67` is today a comment explaining the inherited false,
-   not an override).
+   override (`rocm.cpp` today only *comments* on the
+   inherited false; there is no override).
 3. `tests/vt/test_rocm_backend.cpp` — a RED-first capture/replay case (§6).
 4. Records: this spec, the roadmap intake row, `backend-matrix.md`, and
    `docs/ROCM.md` §5's M3 text.
@@ -104,17 +110,18 @@ no reference tier, so an unregistered op throws.
 **Out of scope.**
 - **New decode-graph model siblings.** Only models that already have one
   benefit; writing more is separate work with its own correctness gate.
-- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:234-266`) — CUDA-profiler
+- **`VT_BENCH_PROFILE_CONTROL`** (the `#ifdef VT_BENCH_PROFILE_CONTROL` block inside `ReplayGraph`) — CUDA-profiler
   instrumentation, not load-bearing. A `rocprofiler` equivalent is later work;
   the first cut omits it and says so in the code.
 - **Any model-level edit.** Every decode-graph class already gates generically
-  with no `is_cuda()` anywhere (`qwen3.cpp:494-498`, `qwen3_moe.cpp:385`,
-  `deepseek_v2.cpp:896`, `voxtral.cpp:438`, `qwen3_5.cpp:7846,8167`). Flipping
+  with no `is_cuda()` anywhere (the identical `enabled =` gate in `qwen3.cpp`, `qwen3_moe.cpp`,
+  `deepseek_v2.cpp`, `voxtral.cpp` and `qwen3_5.cpp` — `grep -rn
+  support_static_graph_mode src/vllm/model_executor/models/`). Flipping
   the two flags suffices; needing a model edit would mean the seam had failed.
 - **Metal / Vulkan capture.** Different APIs, different specs.
-- **The M3 attention-backend NAME registration** (`rocm.cpp:105` returns `{}`)
-  and the stale `rocm.cpp:91` comment claiming `kPagedAttention` is unregistered
-  for `kROCM` — it is registered (`rocm_ops.hip:148`) and ran `vt-native` on this
+- **The M3 attention-backend NAME registration** (`get_attn_backend_priority` returns `{}`)
+  and the stale `rocm.cpp` comment claiming `kPagedAttention` is unregistered
+  for `kROCM` — it is registered (`RegisterOp(OpId::kPagedAttention, DeviceType::kROCM, ...)` in `rocm_ops.hip`) and ran `vt-native` on this
   board. Both real, both separate; a bug found in passing gets its own issue.
 
 ## 3. Upstream chain
@@ -132,15 +139,17 @@ Observed on this board 2026-08-10 — 51 piecewise + 35 full captures, ~6 s, in 
 not inferred.
 
 Internal anchors:
-- `include/vt/backend.h:188-202` — the six virtuals and the multi-backend comment.
-- `src/vt/backend.cpp:29-34` — base impls: five `VT_CHECK(false, ...)` throws,
+- `vt::Backend`'s capture virtuals (`SupportsGraphCapture` through `DestroyGraph`, `include/vt/backend.h`) — the six virtuals and the multi-backend comment.
+- `Backend::BeginCapture` .. `Backend::DestroyGraph` in `src/vt/backend.cpp` — base impls: five `VT_CHECK(false, ...)` throws,
   `DestroyGraph` a no-op. An unimplemented backend fails loudly; the model-level
   `enabled` gate keeps it off the path.
-- `src/vt/cuda/cuda_backend.cu:182-290` — the implementation to mirror. Its
-  capture-contract comment (`:187-197`) is the real specification of what a
+- the `--- CUDA-graph capture/replay` block in `src/vt/cuda/cuda_backend.cu` — the implementation to mirror. Its
+  capture-contract comment above `BeginCapture` is the real specification of what a
   caller must honour.
-- `src/vllm/platforms/interface.h:185-189`, `cuda.cpp:58-59`, `rocm.cpp:67`.
-- `src/vllm/model_executor/models/qwen3.cpp:489-560` — the consumer:
+- `Platform::support_static_graph_mode()` — declared in
+  `src/vllm/platforms/interface.h`, overridden true in `cuda.cpp`, and left to
+  the inherited false in `rocm.cpp` (with a comment saying why).
+- `Qwen3DenseDecodeGraph::Impl` (`src/vllm/model_executor/models/qwen3.cpp`) — the consumer:
   per-padded-size `SizeSlot`s with fixed-address persistent buffers, `Refresh()`
   in place, invalidate-and-recapture on a block-table column change.
 
@@ -149,7 +158,8 @@ Internal anchors:
 **Reused as-is** — most of the change's value is that none of this is written:
 the whole `vt::Backend` interface (no signature changes); every decode-graph
 class and its capture-contract handling (padded slots, pre-warm, persistent
-buffers, column-change invalidation); `test_cuda_backend.cpp:102-153` as the test
+buffers, column-change invalidation); the `CUDA backend: graph capture/replay
+re-executes captured ops` case in `test_cuda_backend.cpp` as the test
 shape; the `tests/CMakeLists.txt` pattern that compiles
 `test_rocm_backend.cpp` everywhere as a bit-rot guard but links it only under
 `VLLM_CPP_HIP`.
@@ -161,14 +171,14 @@ here.
 
 | CUDA (`cuda_backend.cu`) | ROCm (`rocm_backend.hip`) |
 |---|---|
-| `:198` `SupportsGraphCapture()` | same |
-| `:204-207` `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
-| `:208-216` `EndCapture` — end → destroy prior `exec_` → instantiate → destroy graph | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
-| `:218-220` `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
-| `:225-231` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape; returns `hipGraphExec_t` as `void*` |
-| `:233-270` `ReplayGraph(q, graph)` | same, minus `VT_BENCH_PROFILE_CONTROL` (§2) |
-| `:288-290` `DestroyGraph` | `hipGraphExecDestroy` |
-| `platforms/cuda.cpp:58-59` `support_static_graph_mode()` | new override in `platforms/rocm.cpp` |
+| `SupportsGraphCapture()` | same |
+| `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
+| `EndCapture` — end → destroy prior `exec_` → instantiate → destroy graph | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
+| `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
+| `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape; returns `hipGraphExec_t` as `void*` |
+| `ReplayGraph(q, graph)` | same, minus `VT_BENCH_PROFILE_CONTROL` (§2) |
+| `DestroyGraph` | `hipGraphExecDestroy` |
+| `platforms/cuda.cpp` `support_static_graph_mode()` | new override in `platforms/rocm.cpp` |
 
 Every name is a long-stable HIP runtime API with the same signature and
 semantics as its CUDA counterpart — the property that lets upstream compile
@@ -176,8 +186,9 @@ semantics as its CUDA counterpart — the property that lets upstream compile
 
 ## 6. Tests — RED first, and the right red
 
-Nothing to port. One new case in `tests/vt/test_rocm_backend.cpp`, mirroring
-`test_cuda_backend.cpp:102-153`, HIP-header-free like the rest of that file
+Nothing to port. One new case in `tests/vt/test_rocm_backend.cpp`, mirroring the
+`CUDA backend: graph capture/replay re-executes captured ops` case in
+`test_cuda_backend.cpp`, HIP-header-free like the rest of that file
 (every assertion through public `vt::` seams; needing a HIP header would mean the
 seam leaks):
 
@@ -189,7 +200,7 @@ seam leaks):
 5. **Mutate `src` in place (same address) to B, `Replay` → `dst` must read B.**
    The load-bearing assertion: replay re-executes the captured copy over the
    persistent buffer rather than replaying a snapshot, which is how a decode
-   graph picks up each new token's inputs, and the failure `rocm_backend.hip:23-25`
+   graph picks up each new token's inputs, and the failure `rocm_backend.hip`'s `stays FALSE` note
    warns about.
 6. Handle variant: `EndCaptureGraph` → `ReplayGraph` → `DestroyGraph`, same
    A-then-B assertion — that is the path decode graphs actually take.
@@ -249,10 +260,10 @@ mutations that must turn it red, in a scratch copy, restored byte-for-byte:
 ## 8. Risks and decisions
 
 **D1 — `LtWorkspace` can `hipMalloc` mid-capture; the most likely way this
-fails.** `rocm_matmul_hipblaslt.hip:243-255` allocates the hipBLASLt workspace
+fails.** `LtWorkspace()` in `rocm_matmul_hipblaslt.hip` allocates the hipBLASLt workspace
 lazily in the GEMM path, growing on demand (`if (need > cap) { hipFree;
 hipMalloc; }`). Allocation inside a capture region is illegal and invalidates
-it. CUDA's contract comment (`cuda_backend.cu:190-194`) names exactly this and
+it. CUDA's contract comment (`cuda_backend.cu`, the "NO cudaMalloc/cudaFree inside the region" bullet) names exactly this and
 notes cuBLASLt's workspace is a one-time per-context alloc there. *Mitigation:*
 the decode-graph pre-warm runs the same shapes at the same padded size before
 capture, which should grow `cap` to its high-water mark. *If it does not:*

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -2,400 +2,334 @@
 
 **Row:** `BACKEND-ROCM` (backend-matrix, `ACTIVE`).
 **Claim:** `CLAIM-ROCM-DECODE-GRAPH` (unclaimed at time of writing).
-**Issue:** **PENDING — must be filed before implementation starts.** Per
-AGENTS.md "no work without an open GitHub issue"; the number then lands in the
-[roadmap intake table](../roadmap_v1.md), in this spec's header, and in the PR
-body, and those three must agree. Draft issue text: §9.
-**Base:** `6e4244f0` on `docs/rocm-gfx1200-m2-spec` — i.e. **this work stacks on
-[PR #273](https://github.com/mudler/vllm.cpp/pull/273)**, which is where
-[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) lands. That
-dependency is real, not incidental: §1's measurements and gate 3's near-tie
-context both come from that investigation, and `check-agent-record` fails with a
-dangling link if this spec is based on `main` instead. #273 merges first. The
-underlying source tree is `f323907e` (`upstream/main`, 2026-08-10) — #273 is
-docs-only and touches nothing under `src/`, `include/` or `tests/`, so every
-`file:line` below is equally valid against either. Re-anchor at implementation
-time anyway (anchor drift is a standing hazard, and `check_links` validates
-ranges).
+**Issue:** **PENDING — file before implementation starts.** Per AGENTS.md "no
+work without an open GitHub issue"; the number then lands here, in the
+[roadmap intake table](../roadmap_v1.md), and in the PR body, and the three must
+agree. Draft text: §9 W0.
+**Base:** `6e4244f0` on `docs/rocm-gfx1200-m2-spec`, so this **stacks on
+[PR #273](https://github.com/mudler/vllm.cpp/pull/273)**, where
+[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) lands;
+`check-agent-record` fails with a dangling link if based on `main`. #273 merges
+first. The source tree is `f323907e` (`upstream/main`, 2026-08-10) — #273 is
+docs-only, so every `file:line` below holds against either. Re-anchor at
+implementation time; `check_links` validates ranges.
 **Board:** AMD Radeon RX 9060 XT (`gfx1200`, Navi 44, RDNA4, discrete), ROCm
-7.2.3, hipClang/Clang 22.0.0. This is the ONLY board with hardware access here.
-Findings must say gfx1200 and not imply the four #41 boards
+7.2.3, hipClang/Clang 22.0.0 — the only board with hardware access here. Records
+say gfx1200 and must not imply the four #41 boards
 (gfx1151/gfx1103/gfx1100/gfx1201) are covered.
 
 ---
 
 ## 1. Why this, and what it is worth
 
-Measured on gfx1200, 2026-08-10, 128in/128out, our engine vs a real vLLM-ROCm
-oracle at this project's own pin (`555967922`), oracle in production config
-(**not** `--enforce-eager`):
+`vt::Backend`'s graph-capture virtuals are implemented only for CUDA.
+`SupportsGraphCapture()` is false on ROCm (`rocm_backend.hip:22-26` says so
+explicitly) and `RocmPlatform` does not override `support_static_graph_mode()`,
+inheriting false from `interface.h:189`. Decode-graph classes gate on both
+(`qwen3.cpp:494-498`), so every ROCm decode step pays full host launch cost
+while vLLM on the same board replays captured hipGraphs.
 
-| Model | Layers | hidden x inter | Ours (batch 8) | Oracle (batch 8) | Ratio |
+Measured on gfx1200, 2026-08-10, 128in/128out batch 8, ours
+(`examples/vllm-bench` on `build-hip`) vs a real vLLM-ROCm oracle at this
+project's pin `555967922` in production config (**not** `--enforce-eager`):
+
+| Model | Layers | hidden x inter | Ours | Oracle | Ratio |
 |---|---|---|---|---|---|
 | Qwen3-0.6B | 28 | 1024 x 3072 | 184.69 tok/s | 552.65 tok/s | 2.99x |
-| Qwen3-1.7B | 28 | 2048 x 6144 | 150.50 tok/s | 286.42 tok/s | **1.90x** |
-| Gemma-3-1B-it | 26 | 1152 x 6912 | 146.43 tok/s | 438.09 tok/s | 2.99x |
+| Qwen3-1.7B | 28 | 2048 x 6144 | 150.50 tok/s | 286.42 tok/s | 1.90x |
+| Qwen3-4B | 36 | 2560 x 9728 | 98.49 tok/s | 143.36 tok/s | 1.46x |
 
-Single-stream agrees: ours TPOT 13.55 -> 24.09 ms across the two Qwen3 sizes,
-oracle 5.21 -> 12.34 ms/token, ratio 2.60x -> 1.95x.
+Single-stream agrees: our TPOT 13.55 -> 24.09 -> 42.31 ms, oracle 5.21 ->
+12.34 -> 27.13 ms/token, ratio 2.60x -> 1.95x -> 1.56x.
 
-**The premise was tested by a controlled experiment BEFORE committing to
-implementation, and it survived.** Qwen3-0.6B vs Qwen3-1.7B is a clean control:
-**identical layer count (28)**, so an identical number of kernel launches per
-decode step, with roughly **4x the compute per step** (2x hidden, 2x
-intermediate). Launch overhead is fixed per step; compute is not. The gap fell
-**2.99x -> 1.90x**. A gap dominated by kernel quality would not move under that
-change; a gap dominated by fixed per-step overhead must. That is the cheapest
-available test of this spec's premise, and it is why the spec proceeds.
+**The premise was tested by a scaling experiment before any code, and it
+survived.** Launch overhead is fixed per decode step; compute is not. A
+launch-dominated gap must shrink as compute per step grows; a
+kernel-quality-dominated one must not. Across a 7.9x span of per-step compute
+the gap falls monotonically **2.99x -> 1.90x -> 1.46x**.
 
-**It also BOUNDS the expected win, which matters more than the direction.**
-Fitting `ratio = alpha * (1 + L/C)` to the two Qwen3 points (alpha = the
-size-independent efficiency advantage, L = fixed per-step overhead, C = compute
-per step):
+The 0.6B/1.7B pair is the cleanest control: identical layer count (28), so an
+identical launch count per step, with ~4x the compute. Qwen3-4B's 36 layers look
+like a confound but are not — launches and compute both scale with layers, so
+the layer count cancels and `L/C` depends only on per-layer width
+(`1 / (hidden x intermediate)`). All three sit on one curve.
 
-- **alpha ~= 1.54x** — persistent, does NOT shrink with size. Kernel quality,
-  torch.compile/inductor fusion, the Triton attention path.
-- **launch-overhead term ~= 1.45x at 0.6B, ~= 0.36x at 1.7B.**
+**It also bounds the win.** Fitting `ratio = alpha + beta / (hidden x inter)`
+across the three points gives **alpha ~= 1.36x** (size-independent: kernel
+quality, inductor fusion, the Triton attention path) and **beta ~= 1.65** in
+units where 0.6B's `hidden x inter` = 1 — an overhead contribution of ~1.65x at
+0.6B, ~0.41x at 1.7B, ~0.21x at 4B. So roughly half the 0.6B gap is fixed
+overhead, and the expected outcome is all three sizes converging on **~1.36x**:
+a real win, and **not parity**. A ~1.4x residual would remain.
 
-So roughly half the 0.6B gap is launch overhead, and the realistic outcome of
-this work is **0.6B 2.99x -> ~1.54x and 1.7B 1.90x -> ~1.54x**. That is a real,
-worthwhile win, and it is **not parity**: a ~1.5x residual from non-launch
-causes would remain, and this spec must not be written up as closing the gap.
-Gate 5 is calibrated against that number, not against parity.
+Treat the fit as provisional. An earlier two-point version gave `alpha ~= 1.54x`;
+Qwen3-4B then measured 1.46x, below that asymptote, which a curve cannot do, so
+the third point forced the refit. The form is approximate — predicted vs measured
+is 3.01/2.99, 1.77/1.90, 1.57/1.46 — `hidden x inter` is a proxy for per-step
+compute rather than a measurement of it, and no trace has been taken on either
+side. D4 carries this.
 
-Two data points fitted with a one-line model is indicative, not rigorous: "4x
-compute" is an approximation (attention and MLP scale differently, and KV heads
-are identical at 8 in both), alpha is *assumed* size-independent, and no trace
-has been taken on either side. D4 carries that.
+**Structural reason, independent of the numbers.** `vt::Backend`'s capture
+virtuals (`include/vt/backend.h:181-195`) are documented as a multi-backend seam
+("CUDA Graphs / Metal ICB / Vulkan CB"), but CUDA is its only implementation:
+Metal (`metal_backend.mm:13`), Vulkan (`vulkan_backend.cpp:16`) and ROCm all
+carry the same `stays FALSE` note. A one-implementation abstraction is unproven.
+hipGraph is the cheapest available second, since `MTLIndirectCommandBuffer` and
+a pre-recorded `VkCommandBuffer` are genuinely different models.
 
-The oracle's runs captured 51 piecewise + 35 full hipGraphs before their timed
-sections. Ours captured none, because `SupportsGraphCapture()` is `false` on
-ROCm, so every decode step pays full host-side launch cost.
-
-*Measurement provenance.* Checkpoints are stock upstream, SHA-256-verified
-against their HF blob hashes on download: `Qwen/Qwen3-0.6B`,
-`Qwen/Qwen3-1.7B` (shards `169ad53e...30ed5` / `912becff...deff9`),
-`unsloth/gemma-3-1b-it` (`3d4ef8d7...8516b6`, ungated mirror of the gated
-`google/gemma-3-1b-it`). Ours = `examples/vllm-bench` on `build-hip`; oracle =
-`vllm bench throughput` / `vllm bench latency` in the
-`vllm-rocm-oracle:555967922-gfx1200` container (§8/D3, and the build recipe in
-[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md)). Single run
-per cell on a board that also drives a display — indicative, and NOT the
-2-3x-reproduced-idle standard gate 5 requires of the real measurement.
-`Qwen/Qwen3-8B` was considered and does not fit: ~16.4 GB of bf16 weights
-against 15.92 GiB of VRAM, before any KV cache.
-
-**Second, structural reason.** `vt::Backend`'s capture virtuals
-(`include/vt/backend.h:181-195`) are documented as a multi-backend seam
-("CUDA Graphs / Metal ICB / Vulkan CB"), but **CUDA is the only implementation
-that exists**. Metal (`metal_backend.mm:13`), Vulkan (`vulkan_backend.cpp:16`)
-and ROCm (`rocm_backend.hip:22`) all carry an explicit `SupportsGraphCapture()
-stays FALSE` comment. A one-implementation abstraction is an unproven
-abstraction. ROCm is the cheapest possible second implementation — hipGraph is
-a near-exact mirror of the CUDA graph API, where `MTLIndirectCommandBuffer` and
-a pre-recorded `VkCommandBuffer` are genuinely different models — so this is
-also the cheapest available evidence that the seam generalizes at all.
-
-**What it does NOT do, stated up front.** It does not speed up Gemma-3.
-`grep -rl DecodeGraph include/ src/` returns Qwen3 (dense + MoE), DeepSeek-V2/V4,
-Voxtral and Laguna — **there is no `Gemma3DecodeGraph` on any backend, CUDA
-included**. Gemma gains exactly nothing from this change until someone writes
-that sibling (sweep-gemma.md's W7, unclaimed). The measurable vehicle here is
-Qwen3-0.6B.
+*Provenance.* Stock upstream checkpoints, SHA-256-verified against HF blob
+hashes: `Qwen/Qwen3-0.6B`, `Qwen/Qwen3-1.7B` (`169ad53e...30ed5` /
+`912becff...deff9`), `Qwen/Qwen3-4B` (`328a91d3...51223` / `6cd087b3...21ca5` /
+`e4bf4369...f4ca1`). 4B needs `--gpu-memory-utilization 0.85` on the oracle
+side (~8.0 GB weights + ~3 GB captured graphs against 15.92 GiB). Oracle =
+`vllm bench throughput` / `latency` in the
+`vllm-rocm-oracle:555967922-gfx1200` container (recipe in
+[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md)). Single run per
+cell on a board that also drives a display: indicative, and **not** the
+2-3x-reproduced-idle standard gate 5 requires. `Qwen/Qwen3-8B` does not fit
+(~16.4 GB bf16 against 15.92 GiB), and no quantized path is available — ROCm
+registers 23 ops to CUDA's 84, none of them quantized, and a discrete board has
+no reference tier, so an unregistered op throws.
 
 ## 2. Scope
 
 **In scope.**
-1. `src/vt/rocm/rocm_backend.hip` — implement the six capture virtuals against
-   hipGraph, mirroring `src/vt/cuda/cuda_backend.cu:194-286` virtual for
-   virtual, and delete the `stays FALSE` scope note at `rocm_backend.hip:22-26`
-   (replacing it with what is now true).
-2. `src/vllm/platforms/rocm.cpp` — add a `support_static_graph_mode()` override
-   returning `true` (today the class does not override it and inherits
-   `false` from `interface.h:189`; `rocm.cpp:67` is a comment explaining that
-   inheritance, not an override). Replace that comment.
-3. `tests/vt/test_rocm_backend.cpp` — a capture/replay case, RED-first (§6).
-4. Records: this spec, the roadmap intake row, `backend-matrix.md`'s
-   `BACKEND-ROCM` row, and `docs/ROCM.md` §5's M3 text.
+1. `src/vt/rocm/rocm_backend.hip` — the six capture virtuals against hipGraph,
+   mirroring `cuda_backend.cu:194-286`, replacing the `stays FALSE` note at
+   `:22-26`.
+2. `src/vllm/platforms/rocm.cpp` — add the `support_static_graph_mode()`
+   override (`rocm.cpp:67` is today a comment explaining the inherited false,
+   not an override).
+3. `tests/vt/test_rocm_backend.cpp` — a RED-first capture/replay case (§6).
+4. Records: this spec, the roadmap intake row, `backend-matrix.md`, and
+   `docs/ROCM.md` §5's M3 text.
 
-**Out of scope, each with a reason.**
-- **`Gemma3DecodeGraph`** — does not exist on any backend; a new model-level
-  decode-graph sibling is its own change with its own correctness gate. Writing
-  it here would bundle two independently-reviewable things (§1).
-- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:230-262`, `cudaProfilerStart/
-  Stop` arming around a targeted replay) — CUDA-profiler-specific
-  instrumentation, not load-bearing for correctness. A `rocprofiler` equivalent
-  is a later, separate change. The first cut omits it and says so in the code.
-- **Any model-level edit.** Every decode-graph class already gates on
-  `platforms::GetPlatform(...).support_static_graph_mode() &&
-  b.SupportsGraphCapture()` with no `is_cuda()` anywhere (verified:
-  `qwen3.cpp:494-498`, `qwen3_moe.cpp:385`, `deepseek_v2.cpp:896`,
-  `voxtral.cpp:438`, `qwen3_5.cpp:7846,8167`). Flipping the two flags is
-  sufficient; a model edit would mean the seam had failed.
+**Out of scope.**
+- **New decode-graph model siblings.** Only models that already have one
+  benefit; writing more is separate work with its own correctness gate.
+- **`VT_BENCH_PROFILE_CONTROL`** (`cuda_backend.cu:230-262`) — CUDA-profiler
+  instrumentation, not load-bearing. A `rocprofiler` equivalent is later work;
+  the first cut omits it and says so in the code.
+- **Any model-level edit.** Every decode-graph class already gates generically
+  with no `is_cuda()` anywhere (`qwen3.cpp:494-498`, `qwen3_moe.cpp:385`,
+  `deepseek_v2.cpp:896`, `voxtral.cpp:438`, `qwen3_5.cpp:7846,8167`). Flipping
+  the two flags suffices; needing a model edit would mean the seam had failed.
 - **Metal / Vulkan capture.** Different APIs, different specs.
-- **The M3 attention-backend NAME registration** (`rocm.cpp:105`
-  `get_attn_backend_priority` returns `{}`) and the stale
-  `rocm.cpp:91` comment claiming `kPagedAttention` is not registered for
-  `kROCM` — it IS (`rocm_ops.hip:92`), and it ran `selected=vt-native` on this
-  board. Both are real, both are separate; per AGENTS.md a bug found while
-  doing something else gets its own issue, not a silent fix.
+- **The M3 attention-backend NAME registration** (`rocm.cpp:105` returns `{}`)
+  and the stale `rocm.cpp:91` comment claiming `kPagedAttention` is unregistered
+  for `kROCM` — it is registered (`rocm_ops.hip:92`) and ran `vt-native` on this
+  board. Both real, both separate; a bug found in passing gets its own issue.
 
 ## 3. Upstream chain
 
-**No upstream vLLM analog, and that is recorded rather than papered over.**
-Graph capture in vLLM is torch's (`CompilationConfig.cudagraph_mode`,
-`CUDAGraphMode.FULL_AND_PIECEWISE`); there is no `csrc/` file to port. Our
-`vt::Backend` capture seam is an ADDITIVE abstraction, in the same class as the
-ROCm `hipMallocManaged` decision (`rocm-unified-memory-b.md` §"Upstream
-grounding") — it goes in the porting inventory as additive, with this spec as
-its record.
+**No upstream analog.** Graph capture in vLLM is torch's
+(`CompilationConfig.cudagraph_mode`); there is no `csrc/` file to port. The
+`vt::Backend` capture seam is an additive abstraction, same class as the ROCm
+`hipMallocManaged` decision (`rocm-unified-memory-b.md`), and goes in the porting
+inventory as additive with this spec as its record.
 
-What IS mirrored is upstream's *behaviour*: vLLM on ROCm captures hipGraphs by
-default in production config, which is precisely the configuration our gate
-measures against. Observed directly on this board 2026-08-10 (51 piecewise + 35
-full captures, ~6 s, in the `vllm bench` log) — so "hipGraph capture works on
-gfx1200/ROCm 7.2.3" is measured, not inferred.
+What is mirrored is upstream's *behaviour*: vLLM on ROCm captures hipGraphs by
+default in production config, the configuration our gate measures against.
+Observed on this board 2026-08-10 — 51 piecewise + 35 full captures, ~6 s, in the
+`vllm bench` log — so "hipGraph capture works on gfx1200/ROCm 7.2.3" is measured,
+not inferred.
 
-Internal anchors (base `f323907e`):
-- `include/vt/backend.h:181-195` — the six virtuals + the multi-backend comment.
+Internal anchors:
+- `include/vt/backend.h:181-195` — the six virtuals and the multi-backend comment.
 - `src/vt/backend.cpp:29-34` — base impls: five `VT_CHECK(false, ...)` throws,
-  `DestroyGraph` a no-op. So an unimplemented backend fails loudly, and the
-  model-level `enabled` gate is what keeps it off the path.
-- `src/vt/cuda/cuda_backend.cu:178-286` — the implementation to mirror,
-  including its capture contract comment (`:183-193`), which is the real
-  specification of what a caller must honour.
-- `src/vllm/platforms/interface.h:185-189`, `src/vllm/platforms/cuda.cpp:58-59`,
-  `src/vllm/platforms/rocm.cpp:67`.
-- `src/vllm/model_executor/models/qwen3.cpp:489-560` — `Qwen3DenseDecodeGraph::
-  Impl`, the consumer: per-padded-size `SizeSlot`s with fixed-address persistent
-  host/device buffers, `Refresh()` in place, invalidate-and-recapture on a
-  block-table column change.
+  `DestroyGraph` a no-op. An unimplemented backend fails loudly; the model-level
+  `enabled` gate keeps it off the path.
+- `src/vt/cuda/cuda_backend.cu:178-286` — the implementation to mirror. Its
+  capture-contract comment (`:183-193`) is the real specification of what a
+  caller must honour.
+- `src/vllm/platforms/interface.h:185-189`, `cuda.cpp:58-59`, `rocm.cpp:67`.
+- `src/vllm/model_executor/models/qwen3.cpp:489-560` — the consumer:
+  per-padded-size `SizeSlot`s with fixed-address persistent buffers, `Refresh()`
+  in place, invalidate-and-recapture on a block-table column change.
 
 ## 4. Our baseline
 
-**REUSED as-is** (this is most of the change's value — nothing here is written):
-- The whole `vt::Backend` virtual interface. No signature changes.
-- Every decode-graph model class and its capture contract handling — padded
-  size slots, pre-warm, persistent buffers, column-change invalidation.
-- `test_cuda_backend.cpp:102-153` as the test shape to mirror.
-- The `tests/CMakeLists.txt` pattern that COMPILES `test_rocm_backend.cpp`
-  everywhere as a bit-rot guard but LINKS it only under `VLLM_CPP_HIP`.
+**Reused as-is** — most of the change's value is that none of this is written:
+the whole `vt::Backend` interface (no signature changes); every decode-graph
+class and its capture-contract handling (padded slots, pre-warm, persistent
+buffers, column-change invalidation); `test_cuda_backend.cpp:102-153` as the test
+shape; the `tests/CMakeLists.txt` pattern that compiles
+`test_rocm_backend.cpp` everywhere as a bit-rot guard but links it only under
+`VLLM_CPP_HIP`.
 
-**NEW, and why it cannot be reused:** the `hip*` graph calls themselves.
-Mechanically a near-copy, but new code that has never been compiled here.
+**New:** the `hip*` graph calls. Mechanically a near-copy, but never compiled
+here.
 
 ## 5. Port map
 
-| CUDA (`cuda_backend.cu`, base `f323907e`) | ROCm (`rocm_backend.hip`) |
+| CUDA (`cuda_backend.cu`) | ROCm (`rocm_backend.hip`) |
 |---|---|
-| `:194` `SupportsGraphCapture() { return true; }` | same |
+| `:194` `SupportsGraphCapture()` | same |
 | `:200-203` `BeginCapture` — `cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal)` | `hipStreamBeginCapture(s, hipStreamCaptureModeThreadLocal)` |
-| `:204-212` `EndCapture` — `cudaStreamEndCapture` → destroy prior `exec_` → `cudaGraphInstantiate` → `cudaGraphDestroy` | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
+| `:204-212` `EndCapture` — end → destroy prior `exec_` → instantiate → destroy graph | `hipStreamEndCapture` / `hipGraphExecDestroy` / `hipGraphInstantiate` / `hipGraphDestroy` |
 | `:214-216` `Replay` — `cudaGraphLaunch(exec_, s)` | `hipGraphLaunch` |
-| `:221-227` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape, `hip*`; returns `hipGraphExec_t` as `void*` |
-| `:229-266` `ReplayGraph(q, graph)` | same, **minus** the `VT_BENCH_PROFILE_CONTROL` block (§2) |
-| `:284-286` `DestroyGraph` — `cudaGraphExecDestroy` | `hipGraphExecDestroy` |
-| `platforms/cuda.cpp:58-59` `support_static_graph_mode() { return true; }` | new override in `platforms/rocm.cpp`, same |
+| `:221-227` `EndCaptureGraph` — opaque-handle variant for the multi-size slot map | same shape; returns `hipGraphExec_t` as `void*` |
+| `:229-266` `ReplayGraph(q, graph)` | same, minus `VT_BENCH_PROFILE_CONTROL` (§2) |
+| `:284-286` `DestroyGraph` | `hipGraphExecDestroy` |
+| `platforms/cuda.cpp:58-59` `support_static_graph_mode()` | new override in `platforms/rocm.cpp` |
 
-Every name above is a documented, long-stable HIP runtime API with the same
-signature and semantics as its CUDA counterpart — which is the same property
-that lets upstream compile `csrc/` for both through hipify.
+Every name is a long-stable HIP runtime API with the same signature and
+semantics as its CUDA counterpart — the property that lets upstream compile
+`csrc/` for both through hipify.
 
-## 6. Tests — RED first, and the RED must be the right red
+## 6. Tests — RED first, and the right red
 
-Nothing to port (additive abstraction). One new case in
-`tests/vt/test_rocm_backend.cpp`, mirroring `test_cuda_backend.cpp:102-153`,
-and **deliberately HIP-header-free** like the rest of that file (every
-assertion through public `vt::` seams; if a test needed a HIP header, the seam
-would be leaking):
+Nothing to port. One new case in `tests/vt/test_rocm_backend.cpp`, mirroring
+`test_cuda_backend.cpp:102-153`, HIP-header-free like the rest of that file
+(every assertion through public `vt::` seams; needing a HIP header would mean the
+seam leaks):
 
 1. `SupportsGraphCapture()` is true.
-2. Allocate `src`/`dst` ONCE (fixed pointers — the capture contract). Load `src`
-   with pattern A pre-capture.
+2. Allocate `src`/`dst` once — fixed pointers, per the capture contract. Load
+   `src` with pattern A before capture.
 3. `BeginCapture` → one d2d `Copy(dst, src)` → `EndCapture`.
-4. `Replay` → `dst` reads back pattern A. *Proves the graph ran at all.*
-5. **Mutate `src` in place (same address) to pattern B, `Replay` again → `dst`
-   must read back B.** *This is the load-bearing assertion.* It proves replay
-   RE-EXECUTES the captured copy over the persistent buffer rather than
-   replaying a snapshot — which is exactly the mechanism by which a decode
-   graph picks up each new token's inputs, and exactly the failure
-   `rocm_backend.hip:23-25` warns about ("a graph that captures a wrong stream
-   is a silent correctness bug").
+4. `Replay` → `dst` reads back A. Proves the graph ran.
+5. **Mutate `src` in place (same address) to B, `Replay` → `dst` must read B.**
+   The load-bearing assertion: replay re-executes the captured copy over the
+   persistent buffer rather than replaying a snapshot, which is how a decode
+   graph picks up each new token's inputs, and the failure `rocm_backend.hip:23-25`
+   warns about.
 6. Handle variant: `EndCaptureGraph` → `ReplayGraph` → `DestroyGraph`, same
-   A-then-B assertion, since that is the path the decode graphs actually take
-   (`Replay`/`EndCapture` are the single-graph legacy pair).
+   A-then-B assertion — that is the path decode graphs actually take.
 
-**RED-first discipline.** The reviewer must see this fail for the intended
-reason before it passes. Two mutations that MUST turn it red, run in a scratch
-copy and restored byte-for-byte:
-- Make `ReplayGraph` a no-op → step 4 fails (graph never ran).
-- Make `EndCaptureGraph` snapshot `src` into a temporary and replay from that
-  instead of the captured pointer → step 4 passes, **step 5 fails**. If step 5
-  does not fail under this mutation, the test is not testing the thing it
-  exists for.
+**RED-first.** The reviewer sees it fail for the intended reason first. Two
+mutations that must turn it red, in a scratch copy, restored byte-for-byte:
+- `ReplayGraph` a no-op → step 4 fails.
+- `EndCaptureGraph` snapshots `src` into a temporary and replays from that →
+  step 4 passes, **step 5 fails**. If step 5 survives this, the test is not
+  testing the thing it exists for.
 
 ## 7. Gates
 
 1. **Build.** Clean `-Werror`, 0 warnings, HIP build on gfx1200. Non-HIP CPU
-   build still object-compiles the test file (bit-rot guard) and full `ctest`
-   stays green.
+   build still object-compiles the test file and full `ctest` stays green.
 2. **`ctest -R 'rocm|cross_device'`** — the existing 3 binaries plus the new
-   case. Baseline today on this board is 3/3 pass.
-3. **Correctness, non-negotiable, and this is the one that can actually bite.**
-   Re-run BOTH real-oracle batteries from
+   case. Baseline on this board is 3/3.
+3. **Correctness — the gate that can actually bite.** Re-run the Qwen3-0.6B
+   real-oracle battery from
    [rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md) with capture
-   ON:
-   - **Gemma-3-1B-it** 6-prompt battery — unaffected *by construction* (no
-     `Gemma3DecodeGraph` exists, so no capture happens), but re-run anyway;
-     "assume unaffected" is not this project's standard.
-   - **Qwen3-0.6B** — this one HAS a decode-graph sibling, so capture ON changes
-     its execution path. Its `'The capital of france is'` prompt is a *known,
-     measured, version-sensitive near-tie* where our CPU and ROCm backends
-     already disagree and two real vLLM builds already disagree with each other.
-     A captured graph could plausibly move it again. **Required outcome is an
-     honest report, not a specific token**: re-run the same real-oracle
-     comparison that resolved it before and state what it does. A flip that the
-     oracle also produces is not a regression; a silent unreported flip is.
-4. **`VT_DECODE_GRAPH_STATS=1`** (already printed by the decode-graph `Impl`
-   destructors) must show a non-zero replay count — proving capture engaged
-   rather than silently falling through to eager, which would make gate 5's
-   numbers meaningless.
-5. **Performance, as a MEASUREMENT against a PRE-REGISTERED prediction.** Re-run
-   the §1 comparison on **both** Qwen3-0.6B and Qwen3-1.7B, same-binary A/B
-   (capture ON vs `VLLM_CPP_CUDAGRAPH=0`), both arms on an idle box, reproduced
-   2-3x per AGENTS.md. The prediction from §1's fit, written down before the
-   work so it cannot be retrofitted:
+   ON. Qwen3 has a decode-graph sibling, so capture changes its execution path,
+   and its `'The capital of france is'` prompt is a known, measured,
+   version-sensitive near-tie: our CPU and ROCm backends already disagree, and
+   two real vLLM builds disagree with each other. A captured graph could move it
+   again. **Required outcome is an honest report, not a specific token** — re-run
+   the same real-oracle comparison that resolved it before and state what it
+   does. A flip the oracle also produces is not a regression; a silent one is.
+4. **`VT_DECODE_GRAPH_STATS=1`** must show a non-zero replay count, proving
+   capture engaged rather than falling through to eager — otherwise gate 5's
+   numbers are meaningless.
+5. **Performance, measured against a pre-registered prediction.** Re-run §1 on
+   all three sizes, same-binary A/B (capture ON vs `VLLM_CPP_CUDAGRAPH=0`), idle
+   box, reproduced 2-3x per AGENTS.md. Written down before the work so it cannot
+   be retrofitted:
 
    | Model | Today | Predicted with capture |
    |---|---|---|
-   | Qwen3-0.6B | 2.99x | ~1.54x |
-   | Qwen3-1.7B | 1.90x | ~1.54x |
+   | Qwen3-0.6B | 2.99x | ~1.36x |
+   | Qwen3-1.7B | 1.90x | ~1.36x |
+   | Qwen3-4B | 1.46x | ~1.36x |
 
-   The load-bearing shape is that **both sizes should converge on the same
-   ratio**, since the size-dependent term is what capture removes. Convergence
-   is stronger evidence than either number alone. Record what actually happens.
-   A result materially worse than predicted is a finding to record, not a
-   failure to bury; it would mean the fixed-overhead term is smaller than the
-   fit implies and redirect to D4's profiling. **Do NOT quote Gemma-3 as
-   improved** — it has no decode-graph sibling and cannot be (§1, D6). **Do NOT
-   describe any outcome as reaching parity**; ~1.54x is the predicted floor for
+   The load-bearing shape is **convergence**: capture removes the size-dependent
+   term, so all three should land together. That is stronger evidence than any
+   single number. 4B has the least room to move and is the weakest individual
+   signal but the best convergence check. A result materially short of the
+   prediction is a finding to record, not one to bury — it would mean the
+   fixed-overhead term is smaller than the fit implies, and redirect to D4.
+   **Do not describe any outcome as parity**; ~1.36x is the predicted floor for
    this change alone.
-6. **`GetReferenceTierHits()` == 0** in any perf measurement (discrete board;
-   should be structurally impossible, assert anyway).
-7. **Records green:** `scripts/agent-preflight.sh --staged`,
-   `check-agent-record.py`, `check-doc-checkpoint.py`, `check-public-doc-tables.py`,
-   `check-device-leakage.py` (this change adds no device predicate to the
-   shared layer — the ratchet must not move).
+6. **`GetReferenceTierHits()` == 0** in any perf measurement — structurally
+   impossible on a discrete board, assert anyway.
+7. **Records green:** `agent-preflight.sh --staged`, `check-agent-record.py`,
+   `check-doc-checkpoint.py`, `check-public-doc-tables.py`,
+   `check-device-leakage.py` (this adds no shared-layer device predicate; the
+   ratchet must not move).
 
 ## 8. Risks and decisions
 
-**D1 — `LtWorkspace` can `hipMalloc` mid-capture, and that is the single most
-likely way this fails.** `src/vt/rocm/rocm_matmul_hipblaslt.hip:243-255`
-allocates the hipBLASLt workspace lazily, in the GEMM call path, growing it on
-demand (`if (need > cap) { hipFree; hipMalloc; }`). Allocation inside a capture
-region is illegal and invalidates the capture. CUDA's contract comment
-(`cuda_backend.cu:186-190`) names exactly this ("NO cudaMalloc/cudaFree inside
-the region — the scratch pool must be pre-warmed so every allocation is a pool
-hit"), and notes cuBLASLt's workspace is a one-time per-context alloc there.
-*Mitigation:* the decode-graph pre-warm step already runs the same shapes at the
-same padded size before capture, which should grow `cap` to its high-water mark
-first. *Failure mode if it does not:* `hipStreamEndCapture` fails loudly — a
-thrown error, not silent corruption — which is the acceptable direction. **W1
-verifies this explicitly rather than trusting it**, because a shape that only
-appears at capture time would be a latent, board-specific trap.
+**D1 — `LtWorkspace` can `hipMalloc` mid-capture; the most likely way this
+fails.** `rocm_matmul_hipblaslt.hip:243-255` allocates the hipBLASLt workspace
+lazily in the GEMM path, growing on demand (`if (need > cap) { hipFree;
+hipMalloc; }`). Allocation inside a capture region is illegal and invalidates
+it. CUDA's contract comment (`cuda_backend.cu:186-190`) names exactly this and
+notes cuBLASLt's workspace is a one-time per-context alloc there. *Mitigation:*
+the decode-graph pre-warm runs the same shapes at the same padded size before
+capture, which should grow `cap` to its high-water mark. *If it does not:*
+`hipStreamEndCapture` fails loudly rather than corrupting — the acceptable
+direction. **W1 verifies this rather than trusting it**; a shape appearing only
+at capture time would be a latent, board-specific trap.
 
-**D2 — the Qwen3-0.6B near-tie may move.** Covered by gate 3. Called out
-separately because it is the one outcome that could *look* like a regression
-while being nothing of the kind, and the temptation to quietly re-baseline a
-golden is exactly what this project's "never weaken a checker" rule exists to
-stop.
+**D2 — the Qwen3-0.6B near-tie may move.** Covered by gate 3. Separate because
+it is the one outcome that could look like a regression while being nothing of
+the kind, and quietly re-baselining a golden is what "never weaken a checker"
+exists to stop.
 
-**D3 — gfx12 is new silicon and its kernels are still maturing upstream.**
-vllm-project/vllm#45916 ("Triton split-KV paged decode fallback for gfx12") is
-open, and the oracle's own log on this board printed *"Cannot use ROCm custom
-paged attention kernel, falling back to Triton implementation."* The oracle
-captured graphs successfully anyway — but it captured graphs around *its*
-attention path, not ours. Our native `rocm_paged_attn.hip` inside a capture
-region is the genuinely unproven combination. *Mitigation:* W2 captures a real
-Qwen3 decode step, not just the W1 micro-test; `hipStreamCaptureModeThreadLocal`
-turns any illegal op into a loud capture failure.
+**D3 — gfx12 is new silicon, its kernels still maturing upstream.**
+vllm-project/vllm#45916 is open, and the oracle's log on this board printed
+"Cannot use ROCm custom paged attention kernel, falling back to Triton". It
+captured graphs anyway — but around *its* attention path, not ours. Our native
+`rocm_paged_attn.hip` inside a capture region is the unproven combination.
+*Mitigation:* W2 captures a real Qwen3 decode step, not just the W1 micro-test;
+`hipStreamCaptureModeThreadLocal` turns any illegal op into a loud failure.
 
-**D4 — the launch-overhead attribution is now EVIDENCED but still not PROFILED,
-and the spec must not launder the one into the other.** The §1 scaling
-experiment is real evidence: a controlled 4x compute increase at constant layer
-count moved the gap 2.99x -> 1.90x, which a kernel-quality-dominated gap would
-not do. What is still missing is a same-tool trace (`rocprof` on both sides) that
-*isolates* launch overhead from the other things graph capture changes. Until
-that exists, "graph capture recovers ~1.45x" is a calibrated prediction, not a
-measured attribution. Per AGENTS.md (trace both sides with the same tool before
-a throughput claim; never declare a ceiling), the write-up in W4 says
-"consistent with" and not "because of" unless the trace has been run. The
-residual alpha ~= 1.54x is explicitly NOT claimed to be a floor — it is the next
-thing to attack, and naming it is what keeps the gap open.
+**D4 — the attribution is evidenced, not profiled.** §1's scaling result is real
+evidence: a monotonic fall across a 7.9x compute span, with the 0.6B/1.7B pair
+isolating it at constant layer count. But the alpha estimate has already moved
+once under new data (1.54x -> 1.36x), a standing warning against treating the
+fit as settled, and no same-tool trace (`rocprof` both sides) exists to isolate
+launch overhead from everything else capture changes. Until one does, "capture
+recovers ~1.6x at 0.6B" is a calibrated prediction, not a measured attribution:
+W4 says "consistent with", not "because of". The residual alpha ~= 1.36x is not
+claimed as a floor — it is the next thing to attack.
 
 **D5 — one board, one arch.** gfx1200 only. hipGraph is not arch-specific and
-the four #41 boards are all likelier-supported RDNA3/CDNA parts, but none of
-them has run this. Every record says gfx1200, and the other boards stay
-`PENDING-community` exactly as the W1 approach-(b) delta does today.
-
-**D6 — Gemma-3-1B does not sit on the Qwen3 scaling curve, and that is an open
-question this spec does not answer.** An earlier reading of the matching 2.99x
-on Gemma-3-1B and Qwen3-0.6B claimed it proved architecture-independence. The
-1.7B point refutes that reasoning: Gemma-3-1B has ~2.5x the MLP compute of
-Qwen3-0.6B (1152x6912 vs 1024x3072), so on the fitted curve it should land near
-**2.1x**, and it measures **2.99x**. So there IS an architecture-dependent
-component, and Gemma is relatively slower on our side than its compute alone
-explains — plausibly its unusual attention shape (head_dim 256, 4 query heads,
-1 KV head) or the GeGLU/dual-rope path, neither investigated. The original
-matching ratio was substantially coincidence. This does not block the work
-(Gemma has no decode-graph sibling and is unaffected either way, §1), but it is
-a real, recorded, unexplained residual and it must not be quietly dropped
-because it is inconvenient. It wants its own investigation after W3.
+the four #41 boards are likelier-supported RDNA3/CDNA parts, but none has run
+this. Records say gfx1200; the other boards stay `PENDING-community` exactly as
+the W1 approach-(b) delta does today.
 
 ## 9. Work breakdown
 
 - **W0 — file the issue, commit this spec.** No code. *Gate: issue open, number
-  agreeing in three places.* Draft issue text:
+  agreeing in three places.* Draft:
   > **Title:** ROCm: no decode-graph capture — hipGraph seam unimplemented,
-  > costing ~3x decode throughput vs vLLM on gfx1200
-  > **Body:** `vt::Backend`'s graph-capture virtuals are implemented only for
-  > CUDA; `SupportsGraphCapture()` is false on ROCm and
-  > `support_static_graph_mode()` inherits false, so every decode step pays full
-  > host launch cost. Measured on RX 9060 XT (gfx1200, ROCm 7.2.3) against a
-  > real vLLM-ROCm oracle at pin `555967922` in production config: ours 146.43
-  > vs 438.09 tok/s (Gemma-3-1B-it) and 184.69 vs 552.65 tok/s (Qwen3-0.6B) —
-  > the same 2.99x on two unrelated architectures, which points at a
-  > backend-wide launch-overhead term rather than kernel quality. vLLM captures
-  > 51 piecewise + 35 full hipGraphs on this same board, so hipGraph capture
-  > demonstrably works here. Spec: `.agents/specs/rocm-decode-graph.md`.
-- **W1 — the backend seam + micro-test.** §5 port map, §6 test, RED-first.
-  Explicitly verify D1 (workspace pre-warm) with a capture around a GEMM.
-  *Gate: 1, 2, 7.*
-- **W2 — flip `support_static_graph_mode()` and run a real model.** Qwen3-0.6B
-  end to end with capture engaged. *Gate: 3, 4 — the correctness gates. Nothing
-  proceeds past a red here.*
-- **W3 — measure against the pre-registered prediction.** Gate 5 + 6, on BOTH
-  Qwen3-0.6B and Qwen3-1.7B, same-binary A/B, idle box, 2-3x reproduced. The
-  convergence of the two ratios is the load-bearing result, not either number.
-  Record what happens, including a miss.
-- **W4 — records.** This spec's `## Outcome` (what was measured, what was
-  rejected, why the default is what it is), `backend-matrix.md`,
+  > costing up to ~3x decode throughput vs vLLM on gfx1200
+  > **Body:** `vt::Backend`'s graph-capture virtuals are CUDA-only;
+  > `SupportsGraphCapture()` is false on ROCm and `support_static_graph_mode()`
+  > inherits false, so every decode step pays full host launch cost. Measured on
+  > RX 9060 XT (gfx1200, ROCm 7.2.3) vs a real vLLM-ROCm oracle at pin
+  > `555967922` in production config, batch 8, 128in/128out: Qwen3-0.6B 184.69
+  > vs 552.65 tok/s (2.99x), Qwen3-1.7B 150.50 vs 286.42 (1.90x), Qwen3-4B 98.49
+  > vs 143.36 (1.46x). The gap shrinks monotonically as per-step compute grows
+  > while launch count stays fixed — the signature of launch overhead, not
+  > kernel quality. vLLM captures 51 piecewise + 35 full hipGraphs on this same
+  > board, so hipGraph capture demonstrably works here.
+  > Spec: `.agents/specs/rocm-decode-graph.md`.
+- **W1 — backend seam + micro-test.** §5 port map, §6 test, RED-first. Verify D1
+  with a capture around a GEMM. *Gate: 1, 2, 7.*
+- **W2 — flip `support_static_graph_mode()`, run a real model.** Qwen3-0.6B end
+  to end with capture engaged. *Gate: 3, 4. Nothing proceeds past a red.*
+- **W3 — measure against the prediction.** Gate 5 + 6, all three sizes,
+  same-binary A/B, idle box, 2-3x reproduced. Convergence is the result, not any
+  single ratio. Record a miss as readily as a hit.
+- **W4 — records.** This spec's `## Outcome`, `backend-matrix.md`,
   `docs/ROCM.md` §5 M3, `docs/BENCHMARKS.md` if gate 5 yields an accepted
   measurement, `NOW.md` if the row's lifecycle state moves.
 
 ## 10. Stop conditions
 
 Return `NEEDS_DECISION` rather than improvising if:
-- Gate 3 shows a Qwen3-0.6B token change that the real oracle does **not**
-  reproduce — that is a genuine correctness signal, not a near-tie, and it stops
-  the work.
-- D1 turns out to need a real allocator change (a pre-warm hook, a workspace
-  cap) — that widens scope from "port a seam" into shared-allocator surgery and
-  wants its own decision.
-- Gate 5 lands materially short of the §1 prediction — concretely, if
-  Qwen3-0.6B does not fall below ~2.2x (i.e. under half the predicted 1.45x
-  recovery) — W3 stops and D4's profiling becomes the next spec rather than
-  iterating blind on this one. The threshold is stated here, in advance, so it
-  is a stop condition and not a judgement call made after seeing the number.
+- Gate 3 shows a Qwen3-0.6B token change the real oracle does **not** reproduce
+  — a genuine correctness signal, not a near-tie, and it stops the work.
+- D1 needs a real allocator change (pre-warm hook, workspace cap) — that widens
+  scope from porting a seam into shared-allocator surgery.
+- Gate 5 lands materially short: concretely, if Qwen3-0.6B does not fall below
+  **~2.2x** (under half the predicted ~1.63x recovery), W3 stops and D4's
+  profiling becomes the next spec rather than iterating blind here. The
+  threshold is fixed in advance so it is a stop condition, not a judgement call
+  made after seeing the number.
 
-Return `NEEDS_CONTEXT` if the issue in W0 cannot be filed (no work without one).
+Return `NEEDS_CONTEXT` if the W0 issue cannot be filed (no work without one).

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -27,11 +27,12 @@ say gfx1200 and must not imply the four #41 boards
 ## 1. Why this, and what it is worth
 
 `vt::Backend`'s graph-capture virtuals are implemented only for CUDA.
-`SupportsGraphCapture()` is false on ROCm (the `SupportsGraphCapture() stays FALSE` scope note in `rocm_backend.hip` says so
-explicitly) and `RocmPlatform` does not override `support_static_graph_mode()`,
-inheriting false from `Platform::support_static_graph_mode()` in `interface.h`. Decode-graph classes gate on both
-(the `enabled =` gate in `Qwen3DenseDecodeGraph::Impl`), so every ROCm decode step pays full host launch cost
-while vLLM on the same board replays captured hipGraphs.
+`SupportsGraphCapture()` is false on ROCm — the `stays FALSE` scope note in
+`rocm_backend.hip` says so explicitly — and `RocmPlatform` does not override
+`support_static_graph_mode()`, inheriting false from `interface.h`.
+Decode-graph classes gate on both (the `enabled =` gate in
+`Qwen3DenseDecodeGraph::Impl`), so every ROCm decode step pays full host launch
+cost while vLLM on the same board replays captured hipGraphs.
 
 Measured on gfx1200, 2026-08-10, 128in/128out batch 8, ours
 (`examples/vllm-bench` on `build-hip`) vs a real vLLM-ROCm oracle at this
@@ -73,13 +74,14 @@ is 3.01/2.99, 1.77/1.90, 1.57/1.46 — `hidden x inter` is a proxy for per-step
 compute rather than a measurement of it, and no trace has been taken on either
 side. D4 carries this.
 
-**Structural reason, independent of the numbers.** `vt::Backend`'s capture
-virtuals (`vt::Backend`'s capture virtuals (`SupportsGraphCapture` through `DestroyGraph`, `include/vt/backend.h`)) are documented as a multi-backend seam
-("CUDA Graphs / Metal ICB / Vulkan CB"), but CUDA is its only implementation:
-Metal (`metal_backend.mm`), Vulkan (`vulkan_backend.cpp`) and ROCm all carry the
-same `SupportsGraphCapture() stays FALSE` note. A one-implementation abstraction is unproven.
-hipGraph is the cheapest available second, since `MTLIndirectCommandBuffer` and
-a pre-recorded `VkCommandBuffer` are genuinely different models.
+**Structural reason, independent of the numbers.** The capture virtuals
+(`SupportsGraphCapture` through `DestroyGraph`, `include/vt/backend.h`) are
+documented as a multi-backend seam ("CUDA Graphs / Metal ICB / Vulkan CB"), but
+CUDA is the only implementation: Metal (`metal_backend.mm`), Vulkan
+(`vulkan_backend.cpp`) and ROCm all carry the same `stays FALSE` note. A
+one-implementation abstraction is unproven. hipGraph is the cheapest available
+second, since `MTLIndirectCommandBuffer` and a pre-recorded `VkCommandBuffer`
+are genuinely different models.
 
 *Provenance.* Stock upstream checkpoints, SHA-256-verified against HF blob
 hashes: `Qwen/Qwen3-0.6B`, `Qwen/Qwen3-1.7B` (`169ad53e...30ed5` /
@@ -99,7 +101,8 @@ no reference tier, so an unregistered op throws.
 
 **In scope.**
 1. `src/vt/rocm/rocm_backend.hip` — the six capture virtuals against hipGraph,
-   mirroring `cuda_backend.cu`'s capture block, replacing that `stays FALSE` note.
+   mirroring `cuda_backend.cu`'s capture block, replacing the `stays FALSE`
+   note.
 2. `src/vllm/platforms/rocm.cpp` — add the `support_static_graph_mode()`
    override (`rocm.cpp` today only *comments* on the
    inherited false; there is no override).
@@ -110,19 +113,21 @@ no reference tier, so an unregistered op throws.
 **Out of scope.**
 - **New decode-graph model siblings.** Only models that already have one
   benefit; writing more is separate work with its own correctness gate.
-- **`VT_BENCH_PROFILE_CONTROL`** (the `#ifdef VT_BENCH_PROFILE_CONTROL` block inside `ReplayGraph`) — CUDA-profiler
-  instrumentation, not load-bearing. A `rocprofiler` equivalent is later work;
-  the first cut omits it and says so in the code.
+- **`VT_BENCH_PROFILE_CONTROL`** (the `#ifdef` block inside `ReplayGraph`) —
+  CUDA-profiler instrumentation, not load-bearing. A `rocprofiler` equivalent is
+  later work; the first cut omits it and says so in the code.
 - **Any model-level edit.** Every decode-graph class already gates generically
-  with no `is_cuda()` anywhere (the identical `enabled =` gate in `qwen3.cpp`, `qwen3_moe.cpp`,
-  `deepseek_v2.cpp`, `voxtral.cpp` and `qwen3_5.cpp` — `grep -rn
-  support_static_graph_mode src/vllm/model_executor/models/`). Flipping
-  the two flags suffices; needing a model edit would mean the seam had failed.
+  with no `is_cuda()` anywhere — the identical `enabled =` gate across
+  `qwen3.cpp`, `qwen3_moe.cpp`, `deepseek_v2.cpp`, `voxtral.cpp` and
+  `qwen3_5.cpp` (`grep -rn support_static_graph_mode
+  src/vllm/model_executor/models/`). Flipping the two flags suffices; needing a
+  model edit would mean the seam had failed.
 - **Metal / Vulkan capture.** Different APIs, different specs.
-- **The M3 attention-backend NAME registration** (`get_attn_backend_priority` returns `{}`)
-  and the stale `rocm.cpp` comment claiming `kPagedAttention` is unregistered
-  for `kROCM` — it is registered (`RegisterOp(OpId::kPagedAttention, DeviceType::kROCM, ...)` in `rocm_ops.hip`) and ran `vt-native` on this
-  board. Both real, both separate; a bug found in passing gets its own issue.
+- **The M3 attention-backend NAME registration** (`get_attn_backend_priority`
+  returns `{}`) and the stale `rocm.cpp` comment claiming `kPagedAttention` is
+  unregistered for `kROCM` — it is registered (`RegisterOp(OpId::kPagedAttention,
+  DeviceType::kROCM, ...)` in `rocm_ops.hip`) and ran `vt-native` on this board.
+  Both real, both separate; a bug found in passing gets its own issue.
 
 ## 3. Upstream chain
 
@@ -139,19 +144,22 @@ Observed on this board 2026-08-10 — 51 piecewise + 35 full captures, ~6 s, in 
 not inferred.
 
 Internal anchors:
-- `vt::Backend`'s capture virtuals (`SupportsGraphCapture` through `DestroyGraph`, `include/vt/backend.h`) — the six virtuals and the multi-backend comment.
-- `Backend::BeginCapture` .. `Backend::DestroyGraph` in `src/vt/backend.cpp` — base impls: five `VT_CHECK(false, ...)` throws,
-  `DestroyGraph` a no-op. An unimplemented backend fails loudly; the model-level
-  `enabled` gate keeps it off the path.
-- the `--- CUDA-graph capture/replay` block in `src/vt/cuda/cuda_backend.cu` — the implementation to mirror. Its
-  capture-contract comment above `BeginCapture` is the real specification of what a
-  caller must honour.
+- `SupportsGraphCapture` through `DestroyGraph` (`include/vt/backend.h`) — the
+  six virtuals and the multi-backend comment.
+- `Backend::BeginCapture` .. `Backend::DestroyGraph` (`src/vt/backend.cpp`) —
+  base impls: five `VT_CHECK(false, ...)` throws, `DestroyGraph` a no-op. An
+  unimplemented backend fails loudly; the model-level `enabled` gate keeps it
+  off the path.
+- the `--- CUDA-graph capture/replay` block (`src/vt/cuda/cuda_backend.cu`) —
+  the implementation to mirror. Its capture-contract comment above
+  `BeginCapture` is the real specification of what a caller must honour.
 - `Platform::support_static_graph_mode()` — declared in
   `src/vllm/platforms/interface.h`, overridden true in `cuda.cpp`, and left to
   the inherited false in `rocm.cpp` (with a comment saying why).
-- `Qwen3DenseDecodeGraph::Impl` (`src/vllm/model_executor/models/qwen3.cpp`) — the consumer:
-  per-padded-size `SizeSlot`s with fixed-address persistent buffers, `Refresh()`
-  in place, invalidate-and-recapture on a block-table column change.
+- `Qwen3DenseDecodeGraph::Impl` (`src/vllm/model_executor/models/qwen3.cpp`) —
+  the consumer: per-padded-size `SizeSlot`s with fixed-address persistent
+  buffers, `Refresh()` in place, invalidate-and-recapture on a block-table
+  column change.
 
 ## 4. Our baseline
 
@@ -200,8 +208,8 @@ seam leaks):
 5. **Mutate `src` in place (same address) to B, `Replay` → `dst` must read B.**
    The load-bearing assertion: replay re-executes the captured copy over the
    persistent buffer rather than replaying a snapshot, which is how a decode
-   graph picks up each new token's inputs, and the failure `rocm_backend.hip`'s `stays FALSE` note
-   warns about.
+   graph picks up each new token's inputs, and the failure `rocm_backend.hip`'s
+   `stays FALSE` note warns about.
 6. Handle variant: `EndCaptureGraph` → `ReplayGraph` → `DestroyGraph`, same
    A-then-B assertion — that is the path decode graphs actually take.
 
@@ -260,11 +268,12 @@ mutations that must turn it red, in a scratch copy, restored byte-for-byte:
 ## 8. Risks and decisions
 
 **D1 — `LtWorkspace` can `hipMalloc` mid-capture; the most likely way this
-fails.** `LtWorkspace()` in `rocm_matmul_hipblaslt.hip` allocates the hipBLASLt workspace
-lazily in the GEMM path, growing on demand (`if (need > cap) { hipFree;
-hipMalloc; }`). Allocation inside a capture region is illegal and invalidates
-it. CUDA's contract comment (`cuda_backend.cu`, the "NO cudaMalloc/cudaFree inside the region" bullet) names exactly this and
-notes cuBLASLt's workspace is a one-time per-context alloc there. *Mitigation:*
+fails.** `LtWorkspace()` in `rocm_matmul_hipblaslt.hip` allocates the hipBLASLt
+workspace lazily in the GEMM path, growing on demand (`if (need > cap) {
+hipFree; hipMalloc; }`). Allocation inside a capture region is illegal and
+invalidates it. CUDA's contract comment names exactly this — the "NO
+cudaMalloc/cudaFree inside the region" bullet in `cuda_backend.cu` — and notes
+cuBLASLt's workspace is a one-time per-context alloc there. *Mitigation:*
 the decode-graph pre-warm runs the same shapes at the same padded size before
 capture, which should grow `cap` to its high-water mark. *If it does not:*
 `hipStreamEndCapture` fails loudly rather than corrupting — the acceptable
@@ -285,14 +294,12 @@ captured graphs anyway — but around *its* attention path, not ours. Our native
 `hipStreamCaptureModeThreadLocal` turns any illegal op into a loud failure.
 
 **D4 — the attribution is evidenced, not profiled.** §1's scaling result is real
-evidence: a monotonic fall across a 7.9x compute span, with the 0.6B/1.7B pair
-isolating it at constant layer count. But the alpha estimate has already moved
-once under new data (1.54x -> 1.36x), a standing warning against treating the
-fit as settled, and no same-tool trace (`rocprof` both sides) exists to isolate
-launch overhead from everything else capture changes. Until one does, "capture
-recovers ~1.6x at 0.6B" is a calibrated prediction, not a measured attribution:
-W4 says "consistent with", not "because of". The residual alpha ~= 1.36x is not
-claimed as a floor — it is the next thing to attack.
+evidence, and its refit history is a standing warning against treating the fit
+as settled. But no same-tool trace (`rocprof` both sides) isolates launch
+overhead from everything else capture changes. Until one does, "capture recovers
+~1.6x at 0.6B" is a calibrated prediction, not a measured attribution: W4 says
+"consistent with", not "because of". The residual alpha ~= 1.36x is not claimed
+as a floor — it is the next thing to attack.
 
 **D5 — one board, one arch.** gfx1200 only. hipGraph is not arch-specific and
 the four #41 boards are likelier-supported RDNA3/CDNA parts, but none has run

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -30,23 +30,60 @@ Measured on gfx1200, 2026-08-10, 128in/128out, our engine vs a real vLLM-ROCm
 oracle at this project's own pin (`555967922`), oracle in production config
 (**not** `--enforce-eager`):
 
-| Model | Ours (batch 8) | Oracle (batch 8) | Ratio |
-|---|---|---|---|
-| Gemma-3-1B-it | 146.43 tok/s | 438.09 tok/s | 2.99x |
-| Qwen3-0.6B | 184.69 tok/s | 552.65 tok/s | 2.99x |
+| Model | Layers | hidden x inter | Ours (batch 8) | Oracle (batch 8) | Ratio |
+|---|---|---|---|---|---|
+| Qwen3-0.6B | 28 | 1024 x 3072 | 184.69 tok/s | 552.65 tok/s | 2.99x |
+| Qwen3-1.7B | 28 | 2048 x 6144 | 150.50 tok/s | 286.42 tok/s | **1.90x** |
+| Gemma-3-1B-it | 26 | 1152 x 6912 | 146.43 tok/s | 438.09 tok/s | 2.99x |
 
-Two structurally different models (GeGLU/dual-rope/sandwich-norm vs
-SiLU/standard-attention), different sizes, different absolute speeds on both
-sides — and the SAME ratio to three significant figures. That is the signature
-of a backend-wide, architecture-independent overhead, not a per-kernel quality
-gap: a slow GeGLU kernel would move Gemma's ratio and not Qwen's.
+Single-stream agrees: ours TPOT 13.55 -> 24.09 ms across the two Qwen3 sizes,
+oracle 5.21 -> 12.34 ms/token, ratio 2.60x -> 1.95x.
 
-The oracle's run captured 51 piecewise + 35 full hipGraphs before its timed
-section. Ours captured none, because `SupportsGraphCapture()` is `false` on
-ROCm — so every decode step pays full host-side launch cost. **The hypothesis
-this spec tests is that graph capture is the dominant term in that 2.99x.** It
-is a hypothesis, not a conclusion: no `rocprof` trace has been taken on either
-side, and §8/D4 keeps that gap open rather than assuming.
+**The premise was tested by a controlled experiment BEFORE committing to
+implementation, and it survived.** Qwen3-0.6B vs Qwen3-1.7B is a clean control:
+**identical layer count (28)**, so an identical number of kernel launches per
+decode step, with roughly **4x the compute per step** (2x hidden, 2x
+intermediate). Launch overhead is fixed per step; compute is not. The gap fell
+**2.99x -> 1.90x**. A gap dominated by kernel quality would not move under that
+change; a gap dominated by fixed per-step overhead must. That is the cheapest
+available test of this spec's premise, and it is why the spec proceeds.
+
+**It also BOUNDS the expected win, which matters more than the direction.**
+Fitting `ratio = alpha * (1 + L/C)` to the two Qwen3 points (alpha = the
+size-independent efficiency advantage, L = fixed per-step overhead, C = compute
+per step):
+
+- **alpha ~= 1.54x** — persistent, does NOT shrink with size. Kernel quality,
+  torch.compile/inductor fusion, the Triton attention path.
+- **launch-overhead term ~= 1.45x at 0.6B, ~= 0.36x at 1.7B.**
+
+So roughly half the 0.6B gap is launch overhead, and the realistic outcome of
+this work is **0.6B 2.99x -> ~1.54x and 1.7B 1.90x -> ~1.54x**. That is a real,
+worthwhile win, and it is **not parity**: a ~1.5x residual from non-launch
+causes would remain, and this spec must not be written up as closing the gap.
+Gate 5 is calibrated against that number, not against parity.
+
+Two data points fitted with a one-line model is indicative, not rigorous: "4x
+compute" is an approximation (attention and MLP scale differently, and KV heads
+are identical at 8 in both), alpha is *assumed* size-independent, and no trace
+has been taken on either side. D4 carries that.
+
+The oracle's runs captured 51 piecewise + 35 full hipGraphs before their timed
+sections. Ours captured none, because `SupportsGraphCapture()` is `false` on
+ROCm, so every decode step pays full host-side launch cost.
+
+*Measurement provenance.* Checkpoints are stock upstream, SHA-256-verified
+against their HF blob hashes on download: `Qwen/Qwen3-0.6B`,
+`Qwen/Qwen3-1.7B` (shards `169ad53e...30ed5` / `912becff...deff9`),
+`unsloth/gemma-3-1b-it` (`3d4ef8d7...8516b6`, ungated mirror of the gated
+`google/gemma-3-1b-it`). Ours = `examples/vllm-bench` on `build-hip`; oracle =
+`vllm bench throughput` / `vllm bench latency` in the
+`vllm-rocm-oracle:555967922-gfx1200` container (§8/D3, and the build recipe in
+[rocm-gfx1200-m2-correctness.md](rocm-gfx1200-m2-correctness.md)). Single run
+per cell on a board that also drives a display — indicative, and NOT the
+2-3x-reproduced-idle standard gate 5 requires of the real measurement.
+`Qwen/Qwen3-8B` was considered and does not fit: ~16.4 GB of bf16 weights
+against 15.92 GiB of VRAM, before any KV cache.
 
 **Second, structural reason.** `vt::Backend`'s capture virtuals
 (`include/vt/backend.h:181-195`) are documented as a multi-backend seam
@@ -223,13 +260,26 @@ copy and restored byte-for-byte:
    destructors) must show a non-zero replay count — proving capture engaged
    rather than silently falling through to eager, which would make gate 5's
    numbers meaningless.
-5. **Performance, as a MEASUREMENT not a claim.** Re-run the §1 comparison on
-   Qwen3-0.6B, same-binary A/B (capture ON vs `VLLM_CPP_CUDAGRAPH=0`), both
-   arms on an idle box, reproduced 2-3x per AGENTS.md. Record the ratio
-   whatever it is. If the gap does not close materially, **that is a finding to
-   record, not a failure to bury** — it would refute §1's hypothesis and
-   redirect to the profiling in D4. Gemma-3 numbers must NOT be quoted as
-   improved (§1).
+5. **Performance, as a MEASUREMENT against a PRE-REGISTERED prediction.** Re-run
+   the §1 comparison on **both** Qwen3-0.6B and Qwen3-1.7B, same-binary A/B
+   (capture ON vs `VLLM_CPP_CUDAGRAPH=0`), both arms on an idle box, reproduced
+   2-3x per AGENTS.md. The prediction from §1's fit, written down before the
+   work so it cannot be retrofitted:
+
+   | Model | Today | Predicted with capture |
+   |---|---|---|
+   | Qwen3-0.6B | 2.99x | ~1.54x |
+   | Qwen3-1.7B | 1.90x | ~1.54x |
+
+   The load-bearing shape is that **both sizes should converge on the same
+   ratio**, since the size-dependent term is what capture removes. Convergence
+   is stronger evidence than either number alone. Record what actually happens.
+   A result materially worse than predicted is a finding to record, not a
+   failure to bury; it would mean the fixed-overhead term is smaller than the
+   fit implies and redirect to D4's profiling. **Do NOT quote Gemma-3 as
+   improved** — it has no decode-graph sibling and cannot be (§1, D6). **Do NOT
+   describe any outcome as reaching parity**; ~1.54x is the predicted floor for
+   this change alone.
 6. **`GetReferenceTierHits()` == 0** in any perf measurement (discrete board;
    should be structurally impossible, assert anyway).
 7. **Records green:** `scripts/agent-preflight.sh --staged`,
@@ -270,21 +320,37 @@ region is the genuinely unproven combination. *Mitigation:* W2 captures a real
 Qwen3 decode step, not just the W1 micro-test; `hipStreamCaptureModeThreadLocal`
 turns any illegal op into a loud capture failure.
 
-**D4 — "graph capture is the 2.99x" is a hypothesis, and the spec must not
-launder it into a conclusion.** No `rocprof`/`nsys`-equivalent trace has been
-taken on either side; the evidence is (a) the ratio is identical across two
-unrelated architectures, (b) the oracle demonstrably captures graphs and we
-demonstrably do not. That is strong, and it is not a profile. Per AGENTS.md
-("never declare a ceiling"; trace both sides with the same tool before a
-throughput claim), if gate 5 closes the gap the win is real but the
-*attribution* still wants a same-tool trace before it is written up as the
-explanation. If gate 5 does NOT close it, D4 becomes the next work item and the
-hypothesis is recorded as refuted.
+**D4 — the launch-overhead attribution is now EVIDENCED but still not PROFILED,
+and the spec must not launder the one into the other.** The §1 scaling
+experiment is real evidence: a controlled 4x compute increase at constant layer
+count moved the gap 2.99x -> 1.90x, which a kernel-quality-dominated gap would
+not do. What is still missing is a same-tool trace (`rocprof` on both sides) that
+*isolates* launch overhead from the other things graph capture changes. Until
+that exists, "graph capture recovers ~1.45x" is a calibrated prediction, not a
+measured attribution. Per AGENTS.md (trace both sides with the same tool before
+a throughput claim; never declare a ceiling), the write-up in W4 says
+"consistent with" and not "because of" unless the trace has been run. The
+residual alpha ~= 1.54x is explicitly NOT claimed to be a floor — it is the next
+thing to attack, and naming it is what keeps the gap open.
 
 **D5 — one board, one arch.** gfx1200 only. hipGraph is not arch-specific and
 the four #41 boards are all likelier-supported RDNA3/CDNA parts, but none of
 them has run this. Every record says gfx1200, and the other boards stay
 `PENDING-community` exactly as the W1 approach-(b) delta does today.
+
+**D6 — Gemma-3-1B does not sit on the Qwen3 scaling curve, and that is an open
+question this spec does not answer.** An earlier reading of the matching 2.99x
+on Gemma-3-1B and Qwen3-0.6B claimed it proved architecture-independence. The
+1.7B point refutes that reasoning: Gemma-3-1B has ~2.5x the MLP compute of
+Qwen3-0.6B (1152x6912 vs 1024x3072), so on the fitted curve it should land near
+**2.1x**, and it measures **2.99x**. So there IS an architecture-dependent
+component, and Gemma is relatively slower on our side than its compute alone
+explains — plausibly its unusual attention shape (head_dim 256, 4 query heads,
+1 KV head) or the GeGLU/dual-rope path, neither investigated. The original
+matching ratio was substantially coincidence. This does not block the work
+(Gemma has no decode-graph sibling and is unaffected either way, §1), but it is
+a real, recorded, unexplained residual and it must not be quietly dropped
+because it is inconvenient. It wants its own investigation after W3.
 
 ## 9. Work breakdown
 
@@ -308,8 +374,10 @@ them has run this. Every record says gfx1200, and the other boards stay
 - **W2 — flip `support_static_graph_mode()` and run a real model.** Qwen3-0.6B
   end to end with capture engaged. *Gate: 3, 4 — the correctness gates. Nothing
   proceeds past a red here.*
-- **W3 — measure.** Gate 5 + 6, same-binary A/B, idle box, 2-3x reproduced.
-  Record the result whatever it is.
+- **W3 — measure against the pre-registered prediction.** Gate 5 + 6, on BOTH
+  Qwen3-0.6B and Qwen3-1.7B, same-binary A/B, idle box, 2-3x reproduced. The
+  convergence of the two ratios is the load-bearing result, not either number.
+  Record what happens, including a miss.
 - **W4 — records.** This spec's `## Outcome` (what was measured, what was
   rejected, why the default is what it is), `backend-matrix.md`,
   `docs/ROCM.md` §5 M3, `docs/BENCHMARKS.md` if gate 5 yields an accepted
@@ -324,7 +392,10 @@ Return `NEEDS_DECISION` rather than improvising if:
 - D1 turns out to need a real allocator change (a pre-warm hook, a workspace
   cap) — that widens scope from "port a seam" into shared-allocator surgery and
   wants its own decision.
-- Gate 5 shows no material improvement — W3 stops and D4 (profiling) becomes the
-  next spec rather than iterating blind on this one.
+- Gate 5 lands materially short of the §1 prediction — concretely, if
+  Qwen3-0.6B does not fall below ~2.2x (i.e. under half the predicted 1.45x
+  recovery) — W3 stops and D4's profiling becomes the next spec rather than
+  iterating blind on this one. The threshold is stated here, in advance, so it
+  is a stop condition and not a judgement call made after seeing the number.
 
 Return `NEEDS_CONTEXT` if the issue in W0 cannot be filed (no work without one).


### PR DESCRIPTION
Scopes [#332](https://github.com/mudler/vllm.cpp/issues/332). Rebased onto
`b580452d` and re-verified there: 7 commits, 2 files, +338, linear.

## Row

`BACKEND-ROCM`

## Before starting

- **Issue/PR search and existing claim:** opened
  [#332](https://github.com/mudler/vllm.cpp/issues/332) for this specific gap.
  Checked the `BACKEND-ROCM` umbrella #41 and its thread, plus #269 (gfx1200
  M2/M4, my own). Distinct from the two tracked ROCm bugs #201 (`hipblasGemmEx`
  overload) and #132 (`-O0` teardown deadlock), neither of which reproduced on
  this board. Also disjoint from VikashLoomba's in-flight GDN kernel work for
  gfx1100 — different ops, different board.
- **Roadmap or matrix row:** `.agents/backend-matrix.md` `BACKEND-ROCM`
  (`ACTIVE`, unchanged by this PR); the `.agents/roadmap_v1.md` intake row for
  #332 is added here. `scripts/ready-for-helper.py` not run — this is a
  spec-before-code commit, not a helper claim on the row, and nothing here moves
  the row's lifecycle state.
- **Exact current-code and test/evidence anchors inspected:** `vt::Backend`'s six
  capture virtuals (`SupportsGraphCapture` through `DestroyGraph`,
  `include/vt/backend.h`) and their throwing base impls in `src/vt/backend.cpp`;
  the `--- CUDA-graph capture/replay` block in `src/vt/cuda/cuda_backend.cu`
  (the implementation to mirror) with its `"NO cudaMalloc/cudaFree inside the
  region"` contract comment; `support_static_graph_mode()` in
  `src/vllm/platforms/interface.h`, `cuda.cpp` and `rocm.cpp`; the
  `stays FALSE` scope note in `src/vt/rocm/rocm_backend.hip`;
  `LtWorkspace()` in `src/vt/rocm/rocm_matmul_hipblaslt.hip` (the D1 risk);
  `RegisterOp(OpId::kPagedAttention, DeviceType::kROCM, ...)` in
  `src/vt/rocm/rocm_ops.hip`; the ten consumers found by
  `grep -rn support_static_graph_mode src/vllm/model_executor/models/`; and the
  `CUDA backend: graph capture/replay re-executes captured ops` case in
  `tests/vt/test_cuda_backend.cpp` (the test shape to mirror).

  Anchors are symbols rather than `file:line` throughout, because an earlier
  draft went stale inside a day on a `main` this fast; the spec header records
  why. Each was re-verified with `grep -F` at `b580452d`.

## What changed

Adds `.agents/specs/rocm-decode-graph.md` and its intake row. **Spec only — no
implementation.** It scopes porting the `vt::Backend` graph-capture virtuals to
hipGraph: six virtuals in `rocm_backend.hip` mirroring the CUDA-graph
capture/replay block in `cuda_backend.cu`, a `support_static_graph_mode()`
override in `platforms/rocm.cpp`, and one RED-first capture/replay test. No
model-level edit is needed because every
decode-graph class already gates on
`support_static_graph_mode() && SupportsGraphCapture()` with no `is_cuda()`
anywhere, so Qwen3 dense/MoE, DeepSeek-V2/V4, Voxtral and Laguna would pick it
up unchanged. This would also be the **second** implementation of that seam —
Metal, Vulkan and ROCm all carry the same `stays FALSE` note today, so the
abstraction currently has exactly one implementation and is unproven as an
abstraction.

## Evidence

- [ ] `scripts/agent-preflight.sh` — **unticked deliberately: it does not fully
      pass here, and ticking it would be false.** All record and trailer gates
      are green; 3 NixOS-local test failures remain, traced below.
- [x] tests that cover this change: records-only, so none are owed. The spec's
      §6 defines the capture/replay test the implementation PR owes, red-first,
      with the two mutations that must break it.
- [x] same-change doc obligations: no lifecycle change (`BACKEND-ROCM` stays
      `ACTIVE`), so no `STATUS`/`BENCHMARKS`/`NOW` obligation and no `## Now`
      section under #374.

Run inside the dev shell (`nix develop .#rocm-shell -c
scripts/agent-preflight.sh`) at `b580452d`. Every record, doc and trailer gate
is green over `origin/main..HEAD`, including `check-agent-record`
(`ENGINE=149 MODEL=362 QUANT=82 KERNEL=51 BACKEND=80`), which is load-bearing
here: it fails on a dangling link, and that is what forced this branch to follow
the gfx1200 correctness record rather than assume it.

The 3 failures are host-environment, pre-existing on an unmodified base:
`test_release_archive` and `test_release_metadata` (our NixOS ELF binaries carry
absolute `/nix/store/...` RPATHs where the release-bundle validator wants
bundle-relative ones — release *packaging*, untouched here), and
`test_agent_onboard` (its fixture repo inherits host `init.defaultBranch=main`
against the test's hardcoded `master`; run with `GIT_CONFIG_COUNT=1
GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master` and it passes).

## Speed claims

- [x] This PR makes NO speed claim. It does contain numbers, but they record a
      deficit against vLLM rather than a win, are labelled indicative in the
      spec (single run per cell, board also driving a display, no `rocprof`
      trace either side), and are **not** entered in `docs/BENCHMARKS.md`.
      Gate 5 is what owes real numbers, and it is written as a pre-registered
      prediction so the result cannot be retrofitted.
- [ ] the operator ran the numbers under `${GPU_LOCK}` — N/A, this is a
      contributor's own board (RX 9060 XT, gfx1200).

## Honest gaps

- **The attribution is evidenced, not profiled.** The premise was tested before
  committing to it: across a 7.9x span of per-step compute the gap falls
  monotonically 2.99x → 1.90x → 1.46x (Qwen3-0.6B / 1.7B / 4B), and the
  0.6B/1.7B pair isolates it at constant layer count (28), which a
  kernel-quality-dominated gap would not do. But no same-tool trace separates
  launch overhead from everything else capture changes, so D4 requires the
  write-up to say "consistent with", not "because of", until one is run. The
  ~1.36x asymptote is provisional — a two-point fit gave ~1.54x and Qwen3-4B
  landed below it, forcing the refit (spec §1).
- **One board, one arch.** gfx1200 only. hipGraph is not arch-specific and the
  four #41 boards are likelier-supported parts, but none has run any of this.
  The other boards stay `PENDING-community`.
- **D1 is a real unverified risk, not a formality.** `LtWorkspace()` in
  `rocm_matmul_hipblaslt.hip` `hipMalloc`s the hipBLASLt workspace lazily
  inside the GEMM path, which is illegal mid-capture. The decode-graph pre-warm
  *should* grow it to high-water mark first; that is asserted, not verified, and
  W1 verifies it explicitly. It fails loudly at `hipStreamEndCapture` rather than
  corrupting, which is the acceptable direction.
- **Gate 3 could look like a regression.** Qwen3-0.6B's
  `'The capital of france is'` is a known version-sensitive near-tie — our CPU
  and ROCm backends disagree, and two real vLLM builds disagree with each other.
  A captured graph may move it again. The required outcome is an honest report
  against the real oracle, not a specific token.
- **Two adjacent defects found in passing and deliberately NOT fixed here:**
  `get_attn_backend_priority` in `platforms/rocm.cpp` returns `{}` (the M3
  attention NAME registration), and the comment just above it claiming
  `kPagedAttention` is *"not registered for kROCM"* — it is registered
  (`RegisterOp(OpId::kPagedAttention, DeviceType::kROCM, ...)` in
  `rocm_ops.hip`) and ran `selected=vt-native` on this board. Both want their
  own issue.
- **Qwen3-8B was considered and is out of reach**, in both directions: ~16.4 GB
  of bf16 weights against 15.92 GiB of VRAM, and no quantized path exists on
  ROCm (44 registered ops to CUDA's 84, none quantized, and a discrete board has
  no reference tier, so an unregistered op throws rather than degrading).
