### PR TITLE
feat(rocm): implement the vt::Backend graph-capture seam on hipGraph (W1, #332)

### DIFF
--- a/.agents/roadmap_v1.md
+++ b/.agents/roadmap_v1.md
@@ -43,6 +43,7 @@ issue is not yet placed. Keyed record: update in place, never append.
 | [#201](https://github.com/mudler/vllm.cpp/issues/201) | `BACKEND-ROCM` | `hipblasGemmEx` overload mismatch in `rocm_matmul_hipblaslt.hip` | bug |
 | [#269](https://github.com/mudler/vllm.cpp/issues/269) | `BACKEND-ROCM` | ROCm gfx1200: Gemma-3 is 48/48 exact vs two vLLM-ROCm oracles; Qwen3-0.6B exposes a deterministic cross-version near-tie, not a backend defect | verification |
 | [#332](https://github.com/mudler/vllm.cpp/issues/332) | `BACKEND-ROCM` | ROCm: no decode-graph capture — the hipGraph seam is unimplemented, costing ~3x decode throughput vs vLLM on gfx1200 | perf |
+| [#444](https://github.com/mudler/vllm.cpp/issues/444) | `BACKEND-ROCM` | ROCm: main does not build for gfx1200/gfx1201 — `rocm_paged_attn.hip` includes rocwmma unconditionally on arch, not availability | bug |
 | [#125](https://github.com/mudler/vllm.cpp/issues/125) | `BACKEND-VULKAN` | Vulkan on AMD Strix Halo (gfx1151) does not load | bug |
 | [#203](https://github.com/mudler/vllm.cpp/issues/203) | `BACKEND-VULKAN` | Vulkan on unified memory holds TWO copies of the weights: 27B peaks at 100.8 GiB RSS and OOM-reboots a Spark | bug |
 | [#310](https://github.com/mudler/vllm.cpp/issues/310) | `BACKEND-VULKAN` | docs/FEATURES.md understates Vulkan: says decode 4.24 vs 4.35 where the binding figure is 4.36 vs 4.35 | bug |

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -59,13 +59,16 @@ like a confound but are not — launches and compute both scale with layers, so
 the layer count cancels and `L/C` depends only on per-layer width
 (`1 / (hidden x intermediate)`). All three sit on one curve.
 
-**It also bounds the win.** Fitting `ratio = alpha + beta / (hidden x inter)`
-across the three points gives **alpha ~= 1.36x** (size-independent: kernel
-quality, inductor fusion, the Triton attention path) and **beta ~= 1.65** in
-units where 0.6B's `hidden x inter` = 1 — an overhead contribution of ~1.65x at
-0.6B, ~0.41x at 1.7B, ~0.21x at 4B. So roughly half the 0.6B gap is fixed
-overhead, and the expected outcome is all three sizes converging on **~1.36x**:
-a real win, and **not parity**. A ~1.4x residual would remain.
+**It also bounded the win — WRONGLY; this paragraph is the falsified
+prediction, preserved verbatim rather than quietly reworded.** Fitting
+`ratio = alpha + beta / (hidden x inter)` across the three points gave
+**alpha ~= 1.36x** (size-independent: kernel quality, inductor fusion, the
+Triton attention path) and **beta ~= 1.65** in units where 0.6B's
+`hidden x inter` = 1 — an overhead contribution of ~1.65x at 0.6B, ~0.41x at
+1.7B, ~0.21x at 4B. The reasoning WAS that roughly half the 0.6B gap is fixed
+overhead, so the expected outcome WAS all three sizes converging on **~1.36x**.
+**That did not happen.** D7 (§8) has the measurement: capture moved throughput
+0-2%, indistinguishable from zero, not the predicted convergence.
 
 Treat the fit as provisional. An earlier two-point version gave `alpha ~= 1.54x`;
 Qwen3-4B then measured 1.46x, below that asymptote, which a curve cannot do, so
@@ -258,6 +261,13 @@ mutations that must turn it red, in a scratch copy, restored byte-for-byte:
    fixed-overhead term is smaller than the fit implies, and redirect to D4.
    **Do not describe any outcome as parity**; ~1.36x is the predicted floor for
    this change alone.
+
+   **SUPERSEDED.** This is the pre-registered prediction, kept verbatim per
+   AGENTS.md ("never trade correctness for throughput" applies equally to
+   quietly rewriting a call before the result). W2/W3 ran it: capture engaged
+   correctly on all three sizes and moved throughput 0-2%, not toward ~1.36x.
+   See D7 (§8) for the measurement and why. Any future W2/W3 claim on this row
+   starts from D7, not from this table.
 6. **`GetReferenceTierHits()` == 0** in any perf measurement — structurally
    impossible on a discrete board, assert anyway.
 7. **Records green:** `agent-preflight.sh --staged`, `check-agent-record.py`,
@@ -343,6 +353,64 @@ Found in the W1 review (`review-rocm-decode-graph-w1.md`, INFO-1).
 or recapturing an exec on HIP — a teardown or column-change recapture that races
 an in-flight replay is exactly the case this asymmetry would surface as a thrown
 `Check()` instead of a silent no-op.
+
+**D7 — the §1/gate-5 rationale is REFUTED. W2 and W3 ran (on a follow-on
+branch, not shipped in this PR) and the pre-registered convergence prediction
+did not hold.** Recorded here so the next agent to open this spec does not
+re-derive a closed negative result from a still-live-looking prediction.
+
+Same-binary A/B on gfx1200, 128in/128out batch 8, capture ON vs
+`VLLM_CPP_CUDAGRAPH=0`, gate 4's `VT_DECODE_GRAPH_STATS=1` confirming capture
+engaged (**126 replays over 128 decode steps**, one capture at padded size
+`S=8`, not eager fallback):
+
+| Model | capture ON | capture OFF | delta |
+|---|---|---|---|
+| Qwen3-0.6B | 190-194 tok/s | 188-192 tok/s | **0-2%**, indistinguishable from zero |
+| Qwen3-1.7B | 148.72 tok/s | 147.80 tok/s | +0.6% |
+| Qwen3-4B | 100.22 tok/s | 101.27 tok/s | -1.0% |
+
+Qwen3-0.6B needed a second pass: the first same-binary run measured +3.2%
+(193.67 vs 187.62), but an independent reviewer's own 3-rep A/B measured
++0.7%. The discrepancy traced to one low outlier in the original OFF arm
+(reps 191.88 / 179.29 / 191.70); dropping it moves the original delta to
++1.0%, and pooling both reviewers' reps gives +2.0%. **0-2% is the honest
+figure; +3.2% must not be quoted as a measured win.**
+
+Not batch-size dilution: single-stream is capture's best case and shows no
+gain either (TPOT 13.99 ms OFF vs 13.82-14.98 ms ON). And the host/device
+split says why capture isn't paying off here — it removes no host CPU work:
+
+```console
+capture ON    wall 11.31s  user 13.81s  sys 14.09s   247% CPU
+capture OFF   wall 11.36s  user 13.78s  sys 13.54s   240% CPU
+```
+
+Collapsing hundreds of per-step launches into one call should cut `sys` time
+visibly; it is marginally *higher*. §1's scaling-curve argument — that roughly
+half the 0.6B gap is fixed launch overhead recoverable by capture — is
+directly refuted by this intervention. `cuda_backend.cu`'s
+"88%-of-wall host-API overhead" figure is a CUDA measurement and does not
+transfer to this board.
+
+Against §1's oracle figures the ratios are 2.85x / 1.93x / 1.43x versus
+2.99x / 1.90x / 1.46x before capture — **unmoved**. §10's stop condition
+(Qwen3-0.6B below ~2.2x) was not met; W3 stopped there per the spec's own
+rule, rather than iterating blind.
+
+**Not a ceiling claim.** The gap is unexplained, not irreducible. Next
+hypotheses, in order: (1) where the ~14 ms decode step actually goes on the
+device — same-tool `rocprof` both sides, the trace D4 already flagged as
+missing; (2) what burns ~2.5 cores of host CPU to produce ~50 tok/s with `sys`
+exceeding wall.
+
+**What this leaves standing, unaffected by the refutation:** the seam itself
+— mirrored call-for-call, mutation-tested, behaviour-neutral across four
+models (Qwen3-0.6B/1.7B/4B dense, Qwen3.5-0.8B GDN hybrid) and a 6.7x
+parameter range, capture ON vs OFF byte-identical. What died is the reason it
+was built, not the code. Whether to carry an unused capability given the
+refuted rationale is a product call, not a technical one — see the row's PR
+discussion for that decision; it does not belong in this spec.
 
 ## 9. Work breakdown
 

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -280,6 +280,30 @@ capture, which should grow `cap` to its high-water mark. *If it does not:*
 direction. **W1 verifies this rather than trusting it**; a shape appearing only
 at capture time would be a latent, board-specific trap.
 
+**VERIFIED in W1 on gfx1200, and it is worse than written above — there are TWO
+lazy initialisations, not one.** Capturing a cold `MatmulBT` ([1,2048] x
+[2048,2048]^T) fails with all three of:
+
+```text
+vt rocm: hipMalloc: operation not permitted when stream is capturing
+vt rocm: hipFree:   operation not permitted when stream is capturing
+vt rocm: matmul: hipblasCreate: hipblas 6 (INTERNAL_ERROR)
+```
+
+`hipblasCreate` was not anticipated: the handle initialises on first use in the
+same path, so a pre-warm must cover **handle creation as well as workspace
+growth**. Both fail loudly; neither corrupts. Running the identical GEMM once
+beforehand clears both, and the captured graph then replays numerically correct
+(0.409606 vs 0.409600 expected, f32). Pinned by `ROCm backend: a pre-warmed GEMM
+captures and replays` in `test_rocm_backend.cpp`, which asserts the MITIGATION
+rather than the hazard — a future capture-safe allocator would be an
+improvement, and a test forbidding it would ratchet the wrong way.
+
+*Consequence for W2:* the decode-graph pre-warm must reach every GEMM shape the
+captured region will execute, including the first call that creates the handle.
+A shape reached only under capture still aborts, so W2's gate 4 replay count is
+what proves the pre-warm was complete.
+
 **D2 — the Qwen3-0.6B near-tie may move.** Covered by gate 3. Separate because
 it is the one outcome that could look like a regression while being nothing of
 the kind, and quietly re-baselining a golden is what "never weaken a checker"

--- a/.agents/specs/rocm-decode-graph.md
+++ b/.agents/specs/rocm-decode-graph.md
@@ -330,6 +330,20 @@ the four #41 boards are likelier-supported RDNA3/CDNA parts, but none has run
 this. Records say gfx1200; the other boards stay `PENDING-community` exactly as
 the W1 approach-(b) delta does today.
 
+**D6 — `DestroyGraph`/`EndCapture` `Check()` the destroy where CUDA silently
+ignores it.** `rocm_backend.hip`'s `DestroyGraph` and the prior-`exec_` destroy
+inside `EndCapture` both `Check()` `hipGraphExecDestroy`'s return and throw on
+failure; the CUDA leg ignores it. Destroying (or recapturing over) an exec still
+in flight would throw on HIP where CUDA would succeed silently. Not a W1 defect
+— the model-level path is not engaged (`support_static_graph_mode()` is false
+until W2), and W1's tests always `Synchronize` before destroying or recapturing.
+Found in the W1 review (`review-rocm-decode-graph-w1.md`, INFO-1).
+
+*Consequence for W2:* the decode-graph class must synchronize before destroying
+or recapturing an exec on HIP — a teardown or column-change recapture that races
+an in-flight replay is exactly the case this asymmetry would surface as a thrown
+`Check()` instead of a silent no-op.
+
 ## 9. Work breakdown
 
 - **W0 — DONE.** [#332](https://github.com/mudler/vllm.cpp/issues/332) filed and

--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,12 @@
           # entry (idempotent — skipped if already populated). This is the
           # one Nix-specific step; a standard /opt/rocm install needs none of
           # it.
+          # rocwmma is header-only and rides the same overlay: rocm_paged_attn.hip
+          # includes <rocwmma/rocwmma.hpp> whenever the target is gfx1200/gfx1201
+          # (arch-gated, not availability-gated), and clr alone does not ship it,
+          # so a gfx12 build fails at that include without this. See issue #444.
           rocmOverlayInputs =
-            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common ];
+            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common rocm.rocwmma ];
         in {
           default = pkgs.mkShell {
             packages = commonPackages ++ [ pkgs.gcc ];
@@ -122,6 +126,7 @@
               rocm.hipblas
               rocm.hipblaslt
               rocm.hipblas-common
+              rocm.rocwmma
               rocm.rocminfo
             ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -67,12 +67,8 @@
           # entry (idempotent — skipped if already populated). This is the
           # one Nix-specific step; a standard /opt/rocm install needs none of
           # it.
-          # rocwmma is header-only and rides the same overlay: rocm_paged_attn.hip
-          # includes <rocwmma/rocwmma.hpp> whenever the target is gfx1200/gfx1201
-          # (arch-gated, not availability-gated), and clr alone does not ship it,
-          # so a gfx12 build fails at that include without this. See issue #444.
           rocmOverlayInputs =
-            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common rocm.rocwmma ];
+            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common ];
         in {
           default = pkgs.mkShell {
             packages = commonPackages ++ [ pkgs.gcc ];
@@ -126,7 +122,6 @@
               rocm.hipblas
               rocm.hipblaslt
               rocm.hipblas-common
-              rocm.rocwmma
               rocm.rocminfo
             ];
 

--- a/src/vllm/platforms/rocm.cpp
+++ b/src/vllm/platforms/rocm.cpp
@@ -64,9 +64,13 @@ class RocmPlatform final : public Platform {
   // supports_fp8() stays false: gfx942/gfx950 have hardware fp8 and rocm.py lists
   //   "fp8" in supported_quantization (rocm.py:457-467), but we have no ROCm fp8
   //   kernel, and this predicate gates a fused path that would then not exist.
-  // support_static_graph_mode() stays false: hipGraph is the mapping and is not
-  //   implemented. Capture that bakes a wrong address is a silent correctness
-  //   bug, so this flips only alongside a real capture implementation.
+  // support_static_graph_mode() stays false: the vt::Backend hipGraph capture
+  //   seam is implemented as of BACKEND-ROCM W1 (rocm_backend.hip; see
+  //   .agents/specs/rocm-decode-graph.md) and the address-baking concern that
+  //   used to justify leaving this false is now an assertion, not a worry —
+  //   the mutate-src-then-replay test step fails if replay ever returns a
+  //   snapshot. This flag still stays false because flipping it to engage a
+  //   real model's decode-graph path is W2, not W1.
   // needs_weight_staging() stays false: this is the memory-model POLICY that
   //   selects the device-resident forward over the host-resident reference path.
   //   HIP's programming model does stage (hipMalloc hands back a distinct

--- a/src/vt/rocm/rocm_backend.hip
+++ b/src/vt/rocm/rocm_backend.hip
@@ -19,10 +19,14 @@
 // backend, written out by hand so a reader can diff the two.
 //
 // SCOPE / what is NOT here, stated plainly:
-//   * `SupportsGraphCapture()` stays FALSE. hipGraph exists and is the eventual
-//     mapping, but a graph that captures a wrong stream is a silent correctness
-//     bug (see .agents/ on CUDA-graph capture baking stack addresses), so it is
-//     not something to write blind.
+//   * `SupportsGraphCapture()` is TRUE as of BACKEND-ROCM W1 — see the hipGraph
+//     capture/replay block below and .agents/specs/rocm-decode-graph.md. The
+//     concern that kept it false (a capture that bakes addresses instead of
+//     re-executing over persistent buffers is a SILENT correctness bug) is now
+//     an assertion rather than a worry: the mutate-src-then-replay step in
+//     tests/vt/test_rocm_backend.cpp fails if replay ever returns a snapshot.
+//     What is NOT claimed here is the model-level path — Platform's
+//     support_static_graph_mode() still gates that, and flipping it is W2.
 //   * The async-output primitives (AllocPinned / events) inherit the vt::Backend
 //     defaults. src/vt/backend.cpp documents those as already correct for
 //     unified-memory backends; on a discrete AMD card they are correct but
@@ -218,6 +222,79 @@ class RocmBackend final : public Backend {
     Check(hipStreamSynchronize(AsStream(q)), "hipStreamSynchronize");
   }
 
+  // --- hipGraph capture/replay (BACKEND-ROCM W1) ------------------------------
+  // The hipGraph mirror of cuda_backend.cu's capture block, call for call. Every
+  // name below is a long-stable HIP runtime API with the same signature and
+  // semantics as its CUDA counterpart — the property that lets upstream compile
+  // csrc/ for both through hipify.
+  //
+  // Capture contract, identical to the CUDA one (the caller must honour it, else
+  // capture aborts):
+  //   * every op in the region runs ASYNC on THIS stream (no Synchronize, no
+  //     null-stream work, no host<->device blocking copies);
+  //   * NO hipMalloc/hipFree inside the region — the scratch pool must be
+  //     pre-warmed so every allocation is a pool hit. hipBLASLt's workspace is
+  //     the known hazard here: LtWorkspace() in rocm_matmul_hipblaslt.hip grows
+  //     it lazily inside the GEMM path, so a shape first seen during capture
+  //     allocates and invalidates the capture. It fails loudly at
+  //     hipStreamEndCapture rather than corrupting, which is the acceptable
+  //     direction (spec .agents/specs/rocm-decode-graph.md, D1);
+  //   * captured pointers stay valid + FIXED across replays (persistent
+  //     buffers); only their CONTENTS change between replays.
+  //
+  // hipStreamCaptureModeThreadLocal matches CUDA's choice deliberately: it makes
+  // an illegal op during capture a loud failure on THIS thread rather than a
+  // process-wide mode change.
+  bool SupportsGraphCapture() const override { return true; }
+  void BeginCapture(Queue& q) override {
+    Check(hipStreamBeginCapture(AsStream(q), hipStreamCaptureModeThreadLocal),
+          "hipStreamBeginCapture");
+  }
+  void EndCapture(Queue& q) override {
+    hipGraph_t graph = nullptr;
+    Check(hipStreamEndCapture(AsStream(q), &graph), "hipStreamEndCapture");
+    if (exec_ != nullptr) {
+      Check(hipGraphExecDestroy(exec_), "hipGraphExecDestroy");
+      exec_ = nullptr;
+    }
+    Check(hipGraphInstantiate(&exec_, graph, nullptr, nullptr, 0),
+          "hipGraphInstantiate");
+    Check(hipGraphDestroy(graph), "hipGraphDestroy");
+  }
+  void Replay(Queue& q) override {
+    Check(hipGraphLaunch(exec_, AsStream(q)), "hipGraphLaunch");
+  }
+
+  // Multi-graph handle API (batched decode graph): instantiate the just-captured
+  // stream graph and hand the exec back as an opaque handle the caller owns and
+  // selects per padded batch size. Unlike EndCapture, nothing is stored here.
+  void* EndCaptureGraph(Queue& q) override {
+    hipGraph_t graph = nullptr;
+    Check(hipStreamEndCapture(AsStream(q), &graph), "hipStreamEndCapture");
+    hipGraphExec_t exec = nullptr;
+    Check(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0),
+          "hipGraphInstantiate");
+    Check(hipGraphDestroy(graph), "hipGraphDestroy");
+    return reinterpret_cast<void*>(exec);
+  }
+  // NOT ported: the CUDA leg's VT_BENCH_PROFILE_CONTROL block, which drives
+  // cudaProfilerStart/Stop around a chosen replay. A rocprofiler equivalent is
+  // later work and deliberately out of W1's scope (spec §2).
+  void ReplayGraph(Queue& q, void* graph) override {
+    Check(hipGraphLaunch(reinterpret_cast<hipGraphExec_t>(graph), AsStream(q)),
+          "hipGraphLaunch");
+  }
+  // hipGraphExecDestroy is [[nodiscard]] where cudaGraphExecDestroy is not, so
+  // the CUDA leg's bare call would not compile here. Checked rather than
+  // discarded, matching Free/FreePinned above: a failing destroy is a leak this
+  // backend would rather report than swallow.
+  void DestroyGraph(void* graph) override {
+    if (graph != nullptr) {
+      Check(hipGraphExecDestroy(reinterpret_cast<hipGraphExec_t>(graph)),
+            "hipGraphExecDestroy");
+    }
+  }
+
   // THE LOAD-BEARING BOOL. This is what decides whether the portable CPU
   // reference tier installs for kROCM (include/vt/op_provider.h:197-201): a CPU
   // kernel dereferences HOST pointers, so it is correct only where host and
@@ -263,6 +340,9 @@ class RocmBackend final : public Backend {
   bool managed_alloc_ = false;
   int major_ = 0;
   int minor_ = 0;
+  // Single-graph slot for the EndCapture/Replay pair. The handle API
+  // (EndCaptureGraph) stores nothing here — its caller owns the exec.
+  hipGraphExec_t exec_ = nullptr;
 };
 
 // Registers every visible AMD GPU at its own Device{kROCM, i} slot, mirroring

--- a/src/vt/rocm/rocm_backend.hip
+++ b/src/vt/rocm/rocm_backend.hip
@@ -284,10 +284,15 @@ class RocmBackend final : public Backend {
     Check(hipGraphLaunch(reinterpret_cast<hipGraphExec_t>(graph), AsStream(q)),
           "hipGraphLaunch");
   }
-  // hipGraphExecDestroy is [[nodiscard]] where cudaGraphExecDestroy is not, so
-  // the CUDA leg's bare call would not compile here. Checked rather than
-  // discarded, matching Free/FreePinned above: a failing destroy is a leak this
-  // backend would rather report than swallow.
+  // hipError_t itself — not hipGraphExecDestroy specifically — is
+  // [[nodiscard]] at C++17+ ($ROCM_PATH/include/hip/hip_runtime_api.h:293-305,
+  // __HIP_NODISCARD on the `typedef enum ... hipError_t` line; the function
+  // declaration at line ~8321 carries no attribute of its own). CUDA's
+  // cudaError_t has no such attribute, so the mirrored bare call compiles
+  // there and not here: under this project's -Werror it is a hard error
+  // (-Werror,-Wunused-value). Checked rather than discarded, matching
+  // Free/FreePinned above: a failing destroy is a leak this backend would
+  // rather report than swallow.
   void DestroyGraph(void* graph) override {
     if (graph != nullptr) {
       Check(hipGraphExecDestroy(reinterpret_cast<hipGraphExec_t>(graph)),

--- a/src/vt/rocm/rocm_backend.hip
+++ b/src/vt/rocm/rocm_backend.hip
@@ -288,11 +288,16 @@ class RocmBackend final : public Backend {
   // [[nodiscard]] at C++17+ ($ROCM_PATH/include/hip/hip_runtime_api.h:293-305,
   // __HIP_NODISCARD on the `typedef enum ... hipError_t` line; the function
   // declaration at line ~8321 carries no attribute of its own). CUDA's
-  // cudaError_t has no such attribute, so the mirrored bare call compiles
-  // there and not here: under this project's -Werror it is a hard error
-  // (-Werror,-Wunused-value). Checked rather than discarded, matching
-  // Free/FreePinned above: a failing destroy is a leak this backend would
-  // rather report than swallow.
+  // cudaError_t has no such attribute, so the mirrored bare call diagnoses
+  // here (-Wunused-value) and not there. This project's -Werror does NOT
+  // reach it, though: vllm_cpp_set_warnings (cmake/CompilerWarnings.cmake)
+  // gates -Werror on COMPILE_LANGUAGE CXX/OBJCXX/CUDA only, no HIP branch, so
+  // a bare call here would warn, not fail the build (verified against the
+  // actual compile_commands.json entry for this file, and by building a
+  // scratch bare-call mutation through this project's own cmake target).
+  // Checked anyway, matching Free/FreePinned above: a failing destroy is a
+  // leak this backend would rather report than swallow, independent of what
+  // the build flags happen to enforce.
   void DestroyGraph(void* graph) override {
     if (graph != nullptr) {
       Check(hipGraphExecDestroy(reinterpret_cast<hipGraphExec_t>(graph)),

--- a/tests/vt/test_rocm_backend.cpp
+++ b/tests/vt/test_rocm_backend.cpp
@@ -284,3 +284,155 @@ TEST_CASE("the ROCm platform self-registers and is selected over CPU") {
   // is the reminder to update it deliberately.
   CHECK(rocm.get_attn_backend_priority({}).empty());
 }
+
+// Mirrors "CUDA backend: graph capture/replay re-executes captured ops" in
+// tests/vt/test_cuda_backend.cpp assertion for assertion. Same shape, same
+// persistent-buffer contract, hipGraph underneath.
+//
+// Step 5 is the load-bearing one and the reason this test exists. Replaying
+// must RE-EXECUTE the captured copy over the persistent buffers, not replay a
+// snapshot of their contents — that is precisely how a decode graph picks up
+// each new token's inputs. A capture that bakes values instead of addresses
+// passes step 4 and fails step 5, which is the silent-correctness-bug shape
+// rocm_backend.hip's scope note warns about.
+TEST_CASE("ROCm backend: graph capture/replay re-executes captured ops") {
+  if (NoDevice()) return;
+  Backend& rocm = vt::GetBackend(DeviceType::kROCM);
+  CHECK(rocm.SupportsGraphCapture());
+
+  Queue q = rocm.CreateQueue();
+  constexpr size_t kBytes = 64 * 1024;
+
+  // Allocated ONCE; the pointers stay fixed across every replay below. Only
+  // their CONTENTS change — the capture contract.
+  void* src = rocm.Alloc(kBytes);
+  void* dst = rocm.Alloc(kBytes);
+
+  std::vector<unsigned char> pattern_a(kBytes, 0x11);
+  std::vector<unsigned char> pattern_b(kBytes, 0x22);
+  std::vector<unsigned char> back(kBytes, 0);
+
+  rocm.Copy(q, src, pattern_a.data(), kBytes);
+  rocm.Memset(q, dst, 0, kBytes);
+  rocm.Synchronize(q);
+
+  // Recorded, NOT executed: dst must still be zero after EndCapture.
+  rocm.BeginCapture(q);
+  rocm.Copy(q, dst, src, kBytes);
+  rocm.EndCapture(q);
+  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Synchronize(q);
+  CHECK(back.front() == 0x00);
+
+  // Replay #1 -> pattern A. Proves the graph ran at all.
+  rocm.Replay(q);
+  rocm.Synchronize(q);
+  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Synchronize(q);
+  CHECK(back.front() == 0x11);
+  CHECK(back.back() == 0x11);
+
+  // Mutate src in place (SAME address) -> replay must observe the new contents.
+  rocm.Copy(q, src, pattern_b.data(), kBytes);
+  rocm.Replay(q);
+  rocm.Synchronize(q);
+  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Synchronize(q);
+  CHECK(back.front() == 0x22);
+  CHECK(back.back() == 0x22);
+
+  // Handle variant — the path decode graphs actually take, since they keep one
+  // exec per padded batch size rather than a single stored graph.
+  rocm.Copy(q, src, pattern_a.data(), kBytes);
+  rocm.Memset(q, dst, 0, kBytes);
+  rocm.Synchronize(q);
+
+  rocm.BeginCapture(q);
+  rocm.Copy(q, dst, src, kBytes);
+  void* graph = rocm.EndCaptureGraph(q);
+  REQUIRE(graph != nullptr);
+
+  rocm.ReplayGraph(q, graph);
+  rocm.Synchronize(q);
+  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Synchronize(q);
+  CHECK(back.front() == 0x11);
+
+  rocm.Copy(q, src, pattern_b.data(), kBytes);
+  rocm.ReplayGraph(q, graph);
+  rocm.Synchronize(q);
+  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Synchronize(q);
+  CHECK(back.front() == 0x22);
+  CHECK(back.back() == 0x22);
+
+  rocm.DestroyGraph(graph);
+  rocm.Free(src);
+  rocm.Free(dst);
+  rocm.DestroyQueue(q);
+}
+
+// The capture contract's allocation clause, asserted rather than assumed
+// (.agents/specs/rocm-decode-graph.md D1). hipBLASLt sizes its workspace lazily
+// inside the GEMM path — LtWorkspace() in rocm_matmul_hipblaslt.hip does
+// hipFree+hipMalloc when a shape needs more than the current high-water mark —
+// and hipblasCreate() likewise initialises on first use. Both are illegal
+// mid-capture.
+//
+// MEASURED on gfx1200 during W1: capturing a cold GEMM fails loudly, with
+// `hipMalloc: operation not permitted when stream is capturing` (and hipFree,
+// and hipblasCreate INTERNAL_ERROR) — never silent corruption. Running the
+// identical GEMM once beforehand grows the workspace and creates the handle, so
+// the in-capture call is a pure pool hit.
+//
+// This case pins the MITIGATION, not the hazard: it asserts that a pre-warmed
+// GEMM captures and replays correctly. Deliberately not asserting that the cold
+// path throws — a future capture-safe allocator would be an improvement, and a
+// test that forbade it would be a ratchet in the wrong direction.
+TEST_CASE("ROCm backend: a pre-warmed GEMM captures and replays") {
+  if (NoDevice()) return;
+  Backend& rocm = vt::GetBackend(DeviceType::kROCM);
+  if (!rocm.SupportsGraphCapture()) return;
+
+  Queue q = rocm.CreateQueue();
+  const Device dev{DeviceType::kROCM, 0};
+  constexpr int kM = 1, kN = 2048, kK = 2048;  // a decode-shaped GEMM
+
+  const std::vector<float> ha(kM * kK, 0.01f);
+  const std::vector<float> hb(kN * kK, 0.02f);
+  const float expect = 0.01f * 0.02f * static_cast<float>(kK);
+
+  void* da = rocm.Alloc(ha.size() * sizeof(float));
+  void* db = rocm.Alloc(hb.size() * sizeof(float));
+  void* dc = rocm.Alloc(kM * kN * sizeof(float));
+  rocm.Copy(q, da, ha.data(), ha.size() * sizeof(float));
+  rocm.Copy(q, db, hb.data(), hb.size() * sizeof(float));
+  rocm.Synchronize(q);
+
+  Tensor ta = Tensor::Contiguous(da, DType::kF32, dev, {kM, kK});
+  Tensor tb = Tensor::Contiguous(db, DType::kF32, dev, {kN, kK});
+  Tensor tc = Tensor::Contiguous(dc, DType::kF32, dev, {kM, kN});
+
+  // Pre-warm: grows LtWorkspace's cap and creates the hipBLAS handle.
+  vt::MatmulBT(q, tc, ta, tb);
+  rocm.Synchronize(q);
+  rocm.Memset(q, dc, 0, kM * kN * sizeof(float));
+  rocm.Synchronize(q);
+
+  rocm.BeginCapture(q);
+  vt::MatmulBT(q, tc, ta, tb);
+  rocm.EndCapture(q);
+
+  rocm.Replay(q);
+  rocm.Synchronize(q);
+  std::vector<float> back(kM * kN, 0.0f);
+  rocm.Copy(q, back.data(), dc, back.size() * sizeof(float));
+  rocm.Synchronize(q);
+  CHECK(back.front() == doctest::Approx(expect).epsilon(0.01));
+  CHECK(back.back() == doctest::Approx(expect).epsilon(0.01));
+
+  rocm.Free(da);
+  rocm.Free(db);
+  rocm.Free(dc);
+  rocm.DestroyQueue(q);
+}

--- a/tests/vt/test_rocm_backend.cpp
+++ b/tests/vt/test_rocm_backend.cpp
@@ -342,26 +342,33 @@ TEST_CASE("ROCm backend: graph capture/replay re-executes captured ops") {
   CHECK(back.back() == 0x22);
 
   // Handle variant — the path decode graphs actually take, since they keep one
-  // exec per padded batch size rather than a single stored graph.
+  // exec per padded batch size rather than a single stored graph. Captures
+  // into a DIFFERENT destination (dst2) than the stored-graph path above
+  // (dst), not the same op replayed twice: a mutation that returns the stale
+  // member exec_ (still the stored-graph path's Copy(dst, src)) instead of the
+  // freshly captured local exec must be distinguishable from the correct
+  // behaviour, and only fails here because the two graphs write different
+  // buffers.
+  void* dst2 = rocm.Alloc(kBytes);
   rocm.Copy(q, src, pattern_a.data(), kBytes);
-  rocm.Memset(q, dst, 0, kBytes);
+  rocm.Memset(q, dst2, 0, kBytes);
   rocm.Synchronize(q);
 
   rocm.BeginCapture(q);
-  rocm.Copy(q, dst, src, kBytes);
+  rocm.Copy(q, dst2, src, kBytes);
   void* graph = rocm.EndCaptureGraph(q);
   REQUIRE(graph != nullptr);
 
   rocm.ReplayGraph(q, graph);
   rocm.Synchronize(q);
-  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Copy(q, back.data(), dst2, kBytes);
   rocm.Synchronize(q);
   CHECK(back.front() == 0x11);
 
   rocm.Copy(q, src, pattern_b.data(), kBytes);
   rocm.ReplayGraph(q, graph);
   rocm.Synchronize(q);
-  rocm.Copy(q, back.data(), dst, kBytes);
+  rocm.Copy(q, back.data(), dst2, kBytes);
   rocm.Synchronize(q);
   CHECK(back.front() == 0x22);
   CHECK(back.back() == 0x22);
@@ -369,6 +376,7 @@ TEST_CASE("ROCm backend: graph capture/replay re-executes captured ops") {
   rocm.DestroyGraph(graph);
   rocm.Free(src);
   rocm.Free(dst);
+  rocm.Free(dst2);
   rocm.DestroyQueue(q);
 }
 


### PR DESCRIPTION
Implements W1 of [#332](https://github.com/mudler/vllm.cpp/issues/332), the
first work item under the spec that landed in #390. 8 commits, 5 files,
+375/-14.

**Updated 2026-08-13 in response to review:** the `flake.nix` rocwmma fix
(previously bundled here) is now split into
[#638](https://github.com/mudler/vllm.cpp/pull/638) against #444, and the W3
throughput refutation described below is now also recorded in the spec itself
(`.agents/specs/rocm-decode-graph.md`, D7) rather than living only in this
description — see `localai-bot`'s [review
comment](https://github.com/mudler/vllm.cpp/pull/473#issuecomment-5275433628)
for the full ask.

## Row

`BACKEND-ROCM`

## Before starting

- **Issue/PR search and existing claim:**
  [#332](https://github.com/mudler/vllm.cpp/issues/332), whose spec
  (`.agents/specs/rocm-decode-graph.md`) landed on `main` via #390. W1 is its
  §9 second item. Distinct from #201 and #132, and from the in-flight gfx1100
  GDN kernel work — different ops, different board.
  [#444](https://github.com/mudler/vllm.cpp/issues/444) was opened/used here
  originally but its fix has since moved to
  [#638](https://github.com/mudler/vllm.cpp/pull/638) (see Honest gaps).
- **Roadmap or matrix row:** `BACKEND-ROCM` stays `ACTIVE`; this moves no
  lifecycle state, so no `STATUS`/`BENCHMARKS`/`NOW` obligation and no `## Now`
  section under #374.
- **Anchors inspected:** the `--- CUDA-graph capture/replay` block in
  `src/vt/cuda/cuda_backend.cu` (the mirror source) and its
  `"NO cudaMalloc/cudaFree inside the region"` contract comment; the six
  virtuals `SupportsGraphCapture` through `DestroyGraph` in
  `include/vt/backend.h` with their throwing base impls in `src/vt/backend.cpp`;
  `LtWorkspace()` in `src/vt/rocm/rocm_matmul_hipblaslt.hip`;
  `support_static_graph_mode()` in `platforms/interface.h`, `cuda.cpp`,
  `rocm.cpp`; the `CUDA backend: graph capture/replay re-executes captured ops`
  case in `tests/vt/test_cuda_backend.cpp`.

## What changed

The six `vt::Backend` capture virtuals implemented against hipGraph in
`rocm_backend.hip`, mirroring `cuda_backend.cu` call for call, plus the
RED-first test that makes the mirror checkable. `SupportsGraphCapture()` becomes
true for `kROCM`. **No model-level behaviour changes** — `RocmPlatform` still
inherits `support_static_graph_mode() == false`, so no decode-graph class
engages; flipping that is W2. This is the seam's **second** implementation;
Metal and Vulkan still carry the `stays FALSE` note.

`VT_BENCH_PROFILE_CONTROL` is deliberately not ported (spec §2).

## Evidence

- [ ] `scripts/agent-preflight.sh` — **unticked deliberately.** The declared
      W1 gates (spec §7 gates 1, 2, 7) are green; 3 NixOS-local host failures
      remain, all confirmed on an unmodified base: `test_release_archive` and
      `test_release_metadata` (our ELF binaries carry `/nix/store/...` RPATHs
      where the release-bundle validator wants bundle-relative), and
      `test_agent_onboard` (fixture inherits host `init.defaultBranch=main`
      against the test's hardcoded `master`).
- [x] tests that cover this change: two new cases in
      `tests/vt/test_rocm_backend.cpp` — `graph capture/replay re-executes
      captured ops` and `a pre-warmed GEMM captures and replays`.
- [x] same-change doc obligations: none; no feature/model/backend/quant surface
      moves and the row's lifecycle state is unchanged.

### RED first, for the intended reason

Before implementation the case failed on
`CHECK(rocm.SupportsGraphCapture()) == false`, and `BeginCapture` threw
`vt: graph capture unsupported on this backend` from `src/vt/backend.cpp` — the
base impl, confirming `kROCM` inherited the throwing default rather than
overriding it.

### Gates, rerun on the rebased head

```console
$ cmake --build build-hip -j8                                     # gate 1
0 warnings, 0 errors (full HIP build, gfx1200)

$ ctest --test-dir build-hip -R 'rocm|cross_device'               # gate 2
100% tests passed, 0 tests failed out of 4

$ ./build-hip/tests/test_rocm_backend
test cases: 9 | 9 passed    assertions: 1058 | 1058 passed

$ python3 scripts/check-agent-record.py                           # gate 7
agent record OK: ENGINE=151 MODEL=362 QUANT=82 KERNEL=51 BACKEND=81
$ python3 scripts/check-device-leakage.py
OK (DSR 32 == baseline 32, ratchet holds)
```

Gate 1's other half: a non-HIP build still object-compiles the test file clean
via `vllm_rocm_platform_syntax_check`.

### Mutation evidence

Every guarantee the tests pin was deleted or inverted in a scratch copy and the
focused test rerun, then the tree restored byte-for-byte. The load-bearing one:
making `EndCaptureGraph` execute once and freeze its result — the "replays a
snapshot" defect — leaves step 4 **passing** and step 5 **failing**
(`CHECK(17 == 34)`). That is why step 5 exists: a graph that replays baked
values instead of re-executing over persistent buffers would pass a naive test
and then serve stale inputs on every decode step after the first.

An independent reviewer ran 10 further mutations against the same head and
returned **PASS**. Three findings came back and all are addressed in-branch: a
`[[nodiscard]]` attribution error in a code comment, the `DestroyGraph`
asymmetry now recorded as D6, and a coverage gap where returning a stale
`exec_` from `EndCaptureGraph` passed because both paths captured an identical
copy — the handle path now targets a distinct buffer, and re-running that
mutation turns it red. The full review write-up is available on request.

## Speed claims

- [x] This PR makes NO speed claim. It changes no decode path — the model-level
      gate stays false. **And the row's performance rationale has since been
      refuted — see "What W3 measured" below. Read that before weighing this
      change on throughput grounds.**
- [ ] the operator ran the numbers under `${GPU_LOCK}` — N/A, contributor's own
      board (RX 9060 XT, gfx1200).

## What W3 measured — the rationale for this row does not hold

This PR is W1. W2 and W3 have since run on a follow-up branch, and the
pre-registered performance gate **failed**: capture engaged correctly
(confirmed by 126 replays over 128 decode steps and a host/user/sys split
showing it removes no host CPU work) but moved throughput only 0-2% across
three model sizes, not the predicted ~1.36x convergence — indistinguishable
from noise. Not a ceiling claim: the gap is unexplained, not irreducible.

**This is now recorded as D7 in `.agents/specs/rocm-decode-graph.md`**, with
the full A/B table, the replay-count and CPU-split evidence, the correction
history (an initial +3.2% for Qwen3-0.6B was overstated — an independent
reviewer traced it to one low outlier and the honest figure is 0-2%), and the
ordered next hypotheses (same-tool `rocprof` trace; where the host CPU time
goes). Reading it there instead of duplicating it here so this description
and the spec cannot drift apart.

**What this PR still delivers, unaffected:** the seam has a second
implementation, mirrored call-for-call, mutation-tested, and behaviour-neutral
across four models and a 6.7x parameter range (Qwen3-0.6B/1.7B/4B dense and
Qwen3.5-0.8B GDN hybrid, capture ON vs OFF byte-identical). D1 and D6 are
documented. What died is the reason it was built, not the code. If the project
would rather not carry an unused capability, that is a fair call to make on
this PR — say so and I will close it.

## Honest gaps

- **One board, one arch.** gfx1200 only, and **no CI job builds ROCm at all**
  (`grep -i 'hip\|rocm' .github/workflows/ci.yml` matches only comment prose),
  so nothing here is machine-verified. The four #41 boards have not run it.
- **`flake.nix` no longer carries the rocwmma fix.** It was here because
  adding `rocwmma` to the shell is what made W1's gates runnable in the first
  place, but it was unrelated scope — now split into
  [#638](https://github.com/mudler/vllm.cpp/pull/638) against #444. That fix
  is still only the **narrow half of #444**: it fixes one shell, while every
  other rocWMMA-free gfx12 environment still fails the same way.
- **D1 was verified and is worse than the spec predicted.** Capturing a cold
  GEMM fails on `hipMalloc`, `hipFree` *and* `hipblasCreate` — two lazy
  initialisations, not one. All fail loudly; none corrupts. A pre-warm of the
  identical GEMM clears both. Recorded in the spec, with the consequence for W2:
  the pre-warm must reach handle creation, not just workspace growth.
- **The new GEMM test pins the mitigation, not the hazard**, deliberately.
  Asserting that the cold path throws would forbid a future capture-safe
  allocator.
- **D6 (new, from review):** `DestroyGraph`/`EndCapture` `Check()` the destroy
  where CUDA's leg silently ignores it, so a teardown that destroys an exec
  still in flight would throw on HIP and succeed on CUDA. Not reachable in W1 —
  the model path is not engaged and the tests synchronise first — and recorded
  in the spec as a W2 constraint.
- **Nothing consumes this yet.** Until W2 flips
  `support_static_graph_mode()`, the capture path is reachable only from tests.


