### PR TITLE
build(nix): add rocwmma to the ROCm dev shell so gfx12 builds again (#444)

### DIFF
--- a/.agents/specs/rocm-gfx1200-m2-correctness.md
+++ b/.agents/specs/rocm-gfx1200-m2-correctness.md
@@ -9,7 +9,12 @@ near-tie prompt is not a defect on either of our backends — see Outcome.
 gfx1200 M0/M1 report, first M2 attempt on this board. Distinct defect from
 #201 (`hipblasGemmEx` overload) and #132 (`-O0` teardown deadlock), neither of
 which reproduced here (and both since fixed on main, `ce134e1d`, picked up
-when this investigation rebased onto `origin/main` 2026-08-10).
+when this investigation rebased onto `origin/main` 2026-08-10). Also distinct
+from [#444](https://github.com/mudler/vllm.cpp/issues/444) (rocWMMA headers
+absent from the dev shell, so a gfx12 build configures and then fails midway) —
+a build-environment defect on this same board, not a correctness one. Its narrow
+half, adding `rocwmma` to `rocm-shell`, lands in PR #638; #444 stays open for
+the rest.
 **Board:** AMD Radeon RX 9060 XT (`gfx1200`, Navi 44, RDNA4, discrete — no
 reference tier). ROCm 7.2.3 (nixpkgs `rocmPackages.*`), hipClang/Clang 22.0.0.
 M0/M1 independently MET on this board (separate report to #41).
@@ -216,9 +221,14 @@ doesn't hold still on it.
 
 ## Environment note (reproducibility)
 
-This board is accessed through `nix develop .#rocm-shell` (local, uncommitted
-`flake.nix` addition — see the M0/M1 report) for the ROCm/HIP `build-hip`
-build itself; the oracle containers are unrelated to that and need no ROCm
+This board is accessed through `nix develop .#rocm-shell` for the ROCm/HIP
+`build-hip` build itself. That shell has been committed since `f93a1290a`
+(2026-08-10); the "local, uncommitted `flake.nix` addition" this paragraph used
+to describe is stale. One caveat if you already have the shell: the overlay is
+cached behind a `$ROCM_OVERLAY/.complete` sentinel, so an existing checkout
+keeps its rocWMMA-free overlay after #638 merges and fails with the identical
+`'rocwmma/rocwmma.hpp' file not found`. Remove `$ROCM_OVERLAY` to
+re-materialise it. The oracle containers are unrelated to that and need no ROCm
 toolchain on the host beyond the kernel driver + `/dev/kfd`/`/dev/dri`.
 `ROCM_PATH` for `build-hip` is nixpkgs' `clr` output (has
 `lib/cmake/hip-lang`); hipBLAS/hipBLASLt/hipblas-common are merged into a

--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,12 @@
           # entry (idempotent — skipped if already populated). This is the
           # one Nix-specific step; a standard /opt/rocm install needs none of
           # it.
+          # rocwmma is header-only and rides the same overlay: rocm_paged_attn.hip
+          # includes <rocwmma/rocwmma.hpp> whenever the target is gfx1200/gfx1201
+          # (arch-gated, not availability-gated), and clr alone does not ship it,
+          # so a gfx12 build fails at that include without this. See issue #444.
           rocmOverlayInputs =
-            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common ];
+            [ rocm.hipblas rocm.hipblaslt rocm.hipblas-common rocm.rocwmma ];
         in {
           default = pkgs.mkShell {
             packages = commonPackages ++ [ pkgs.gcc ];
@@ -122,6 +126,7 @@
               rocm.hipblas
               rocm.hipblaslt
               rocm.hipblas-common
+              rocm.rocwmma
               rocm.rocminfo
             ];
 


### PR DESCRIPTION
Split out of #473 per `localai-org-maint-bot`'s review there: PR #473 (the `vt::Backend` hipGraph capture seam, W1 of #332) is meant to stay scoped to the graph-capture seam, and this dev-shell fix is unrelated scope that belongs with #444 instead.

## What changed

Since `9302732f`, `rocm_paged_attn.hip` includes `<rocwmma/rocwmma.hpp>` whenever the target is gfx1200/gfx1201. The guard is on ARCH, not on availability, so targeting a gfx12 board fires the include whether or not rocWMMA exists. `clr` — the store path this shell uses as `ROCM_PATH` — does not ship it, so `nix develop .#rocm-shell` could not build `main` at all on a gfx12 board:

```
src/vt/rocm/rocm_paged_attn.hip:8:10: fatal error:
  'rocwmma/rocwmma.hpp' file not found
```

Reproduced on pristine `upstream/main` at `0f2b12ed` in a clean worktree with no other commits applied, so it is not a local-branch artifact.

rocwmma is header-only, so it rides the existing overlay: `rocmOverlayInputs` symlinks each input's `include/` into `$ROCM_OVERLAY/include`, which is already on `CPATH`. Adding it to the shell's packages list too keeps the two lists reading the same. Note the overlay is cached behind a `.complete` sentinel, so an existing shell needs `$ROCM_OVERLAY` removed once to pick this up.

**This is the NARROW half of #444 and does not close it.** It fixes this shell only; every other rocWMMA-free environment targeting gfx12 still fails the same way. The issue asks for CMake-level detection that fails configure with a message naming the missing package, which is the real fix and stays open.

Deliberately NOT done here: gating the include on `__has_include`. It works (verified under hipcc, which correctly reports the header absent), but `VT_ROCWMMA_OK` also selects the kernel BODY — `PagedAttnPrefillWmmaWave` at `rocm_paged_attn.hip:900` casts every parameter to `(void)` and returns when the macro is undefined. Deciding that macro by availability rather than arch would compile a paged-attention kernel that silently writes nothing on a gfx12 board with no rocWMMA. A build failure is the correct outcome there; this commit supplies the missing dependency instead of hiding the symptom.

## Evidence

With this change `nix develop .#rocm-shell` builds the HIP target on gfx1200 with 0 warnings, and `ctest -R 'rocm|cross_device'` is 4/4.

Issue: https://github.com/mudler/vllm.cpp/issues/444

🤖 Generated with [Claude Code](https://claude.com/claude-code)