### PR TITLE
record(GEMMA4-ROCM-KEEP): the 2x R9700 KEEP recipe, and the denominator it still lacks

### DIFF
--- a/.agents/specs/gemma4-rocm-fp8-moe.md
+++ b/.agents/specs/gemma4-rocm-fp8-moe.md
@@ -88,4 +88,6 @@ FMHA_WMMA2 (quality fail + 0.67x @11k). Isolated P1 cm1 wg256 (~1.13x KEEP; need
 
 ### Residual compiler / ACO
 
-Faithful HIP cm1 hsaco on gfx1201: 192 VGPR, 339 spills, 940 B private, vs KEEP SharedK 35 spills / 120 B. Mechanism of the isolated 1.13x, not a named LLVM defect. Avoidability (regalloc vs live-range vs fundamental) is open. Phase-2 ROCm/LLVM rebuild stays blocked until a discriminator names a smallest component and a measurable prediction. A general codegen fix, if one exists, is a separate claim from the 3.35x bar.
+Faithful HIP cm1 hsaco on gfx1201: 192 VGPR, 339 spills, 940 B private, vs KEEP SharedK 35 spills / 120 B. Output-slicing bottoms out at 235 spills / 736 B (D_PT=1). Mechanism of the isolated 1.13x, not by itself a named LLVM defect.
+
+Matched RADV/ACO (Mesa 26.0.3, discrete R9700, llama.cpp coopmat1 spec Br=16 Bc=64 wg=128 sg=32 row_split=4): official pipeline stats are **0 spilled VGPR, 0 scratch** at VGPR=256 (f16 and q8_0 d=512). That is an (a)-leaning HIP-LLVM vs ACO disparity on equivalent ownership. Smallest LLVM/rocWMMA component is not named. Phase-2 rebuild stays blocked until that component and a measurable prediction exist. A general codegen fix, if one exists, is a separate claim from the 3.35x bar.

--- a/.agents/specs/gemma4-rocm-fp8-moe.md
+++ b/.agents/specs/gemma4-rocm-fp8-moe.md
@@ -64,9 +64,32 @@ in the deferred layer-loop path).
 Hardware: 2x R9700 gfx1201, ROCm 7.2.4, kernel 7.0.0-29-generic.
 Model: Gemma-4-26B-A4B-it FP8. Fair protocol: `PREFIX_CACHE=0` + unique pads.
 
-Recipe (product): SharedK-WMMA on, FLASH/FMHA/scoreless off, `PREFILL_GEMM_M=2048`,
-`PEER_ACT=1`, batch MoE `T>=64`, decode `KV_SPLITS=16` / `SLIDE_SPLITS=8` /
-`SLIDE_WARPS=16` / `SPLIT_WARPS=12`. Speculative, ngram, layer-split: **off**.
+Recipe as run: SharedK-WMMA on, FLASH/FMHA/scoreless off,
+`VT_GEMMA4_PREFILL_GEMM_M=2048`, `VT_GEMMA4_PREFILL_PEER_ACT=1`, batch MoE
+`T>=64`, decode `KV_SPLITS=16` / `SLIDE_SPLITS=8` / `SLIDE_WARPS=16` /
+`SPLIT_WARPS=12`. Speculative, ngram, layer-split: **off**.
+
+**Four of those names are not read by any product code in this tree, so this
+recipe is not reproducible as written.** `VT_ATTN_DECODE_KV_SPLITS`,
+`VT_ATTN_DECODE_SLIDE_SPLITS` and `VT_ATTN_DECODE_SPLIT_WARPS` appear only in
+`tests/vt/test_gemma4_rocm_fp8_seams.cpp`, and `VT_ATTN_DECODE_SLIDE_WARPS`
+appears nowhere at all; `git grep` over `src/` and `include/` returns zero hits
+for all four. That is [#845](https://github.com/mudler/vllm.cpp/issues/845): the
+seam test asserts `EnvInt(name, 16) == 16` with the variable unset, a tautology
+that passes whether or not the knob exists, which is how three names that
+nothing reads came to look real. The first two knob names above were also
+abbreviated and are spelled here as the product spells them
+(`PEER_ACT` is `VT_GEMMA4_PREFILL_PEER_ACT`, `gemma4_moe.cpp:1026`;
+`PREFILL_GEMM_M` is `VT_GEMMA4_PREFILL_GEMM_M`, `:1016`, and `2048` is its
+default, not an override).
+
+This file's `**Status:**` line records the run as `PR tip
+feat/gemma4-rocm-fp8-split` with **no commit SHA**, so which tree produced these numbers cannot be
+established from this repository. Either the four decode splits were live on that
+tree and it is not this one, or they were inert and the numbers were produced by
+the shipped defaults. Owed to the contributor: the tree SHA, and which of the two
+it was. Until then the decode figure in particular has no recipe behind it, and
+`docs/USAGE.md` publishes only the knobs a reader can actually set.
 
 | Depth | median prefill t/s | notes |
 |------:|-------------------:|-------|
@@ -91,3 +114,29 @@ FMHA_WMMA2 (quality fail + 0.67x @11k). Isolated P1 cm1 wg256 (~1.13x KEEP; need
 Faithful HIP cm1 hsaco on gfx1201: 192 VGPR, 339 spills, 940 B private, vs KEEP SharedK 35 spills / 120 B. Output-slicing bottoms out at 235 spills / 736 B (D_PT=1). Mechanism of the isolated 1.13x, not by itself a named LLVM defect.
 
 Matched RADV/ACO (Mesa 26.0.3, discrete R9700, llama.cpp coopmat1 spec Br=16 Bc=64 wg=128 sg=32 row_split=4): official pipeline stats are **0 spilled VGPR, 0 scratch** at VGPR=256 (f16 and q8_0 d=512). That is an (a)-leaning HIP-LLVM vs ACO disparity on equivalent ownership. Smallest LLVM/rocWMMA component is not named. Phase-2 rebuild stays blocked until that component and a measurable prediction exist. A general codegen fix, if one exists, is a separate claim from the 3.35x bar.
+
+## Owed
+
+- **A vLLM-ROCm denominator for every number in "Measured KEEP".** They are
+  engine-side figures with nothing on the other side, so under AGENTS.md "Gates"
+  they are not a throughput result at all, and `docs/BENCHMARKS.md` keeps this
+  backend at `PENDING: no binding throughput number`. The oracle is not
+  hypothetical: `docs/ROCM.md` §5 documents two working Docker vLLM-ROCm recipes
+  on this hardware family, tier 2 building this project's pinned commit
+  `555967922` inside `rocm/vllm-dev:base` in about 6.5 minutes. Owed: the same
+  model, quantization, prompt set, request shape, concurrency and cache policy on
+  both sides of one idle 2x R9700 box, and the ratio per depth. Only the
+  contributor has that hardware.
+- **The tree SHA behind the 2026-08-13 run**, and whether the four decode splits
+  named in the recipe were live on it. See the note under "Measured KEEP" and
+  [#845](https://github.com/mudler/vllm.cpp/issues/845).
+- **`.agents/benchmark-record.md` is deliberately not appended here.** It is the
+  append-only measurement log, and a number whose tree is unidentified and whose
+  denominator is missing must not enter it: once logged, a figure gets quoted as
+  measured. It goes in when the two items above are discharged.
+- **The Vulkan Q8 comparison stays open, not closed.** Same box, ~1.74x at 11k
+  and ~2.47x at 42k in Vulkan's favour. AGENTS.md forbids reading that as a
+  ceiling. The next traceable hypothesis is the one this file already names: the
+  HIP-LLVM versus ACO register-allocation disparity, 339 spills against ACO's 0,
+  and it needs the smallest LLVM/rocWMMA component named before a phase-2
+  rebuild.

--- a/.agents/specs/gemma4-rocm-fp8-moe.md
+++ b/.agents/specs/gemma4-rocm-fp8-moe.md
@@ -58,3 +58,34 @@ and env-gated MoE paths do not. Revisit as a **separate** PR with CUDA golden.
 
 `VT_GEMMA4_MLP_MOE_PARALLEL` is documented but **not** wired in this tip (was only
 in the deferred layer-loop path).
+
+## Measured KEEP (2026-08-13, contributor lab)
+
+Hardware: 2x R9700 gfx1201, ROCm 7.2.4, kernel 7.0.0-29-generic.
+Model: Gemma-4-26B-A4B-it FP8. Fair protocol: `PREFIX_CACHE=0` + unique pads.
+
+Recipe (product): SharedK-WMMA on, FLASH/FMHA/scoreless off, `PREFILL_GEMM_M=2048`,
+`PEER_ACT=1`, batch MoE `T>=64`, decode `KV_SPLITS=16` / `SLIDE_SPLITS=8` /
+`SLIDE_WARPS=16` / `SPLIT_WARPS=12`. Speculative, ngram, layer-split: **off**.
+
+| Depth | median prefill t/s | notes |
+|------:|-------------------:|-------|
+| ~3k | 2112 | 3 reps, Paris |
+| ~11k | 2014 | first rep 1170 outlier dropped from claim; median 2014 |
+| ~18k | 1705 | 3 reps |
+| ~42k | 1099 | 2 reps |
+
+Decode stream 64 tok: **55.5 t/s** temp=0, **49.1 t/s** temp=0.7.
+Quality: Paris, arith `63`, `gemma4` parser `tool_calls`, `/health` `/metrics`.
+No engine-fatal / hipError in the closeout log.
+
+Same-box Vulkan Q8 unique-pad bar: **3503 @11k / 2714 @42k**. KEEP gap ~1.74x / 2.47x.
+This row ships the reliable ROCm plateau. It does **not** close that bar.
+
+### Rejected (do not default-on)
+
+FMHA_WMMA2 (quality fail + 0.67x @11k). Isolated P1 cm1 wg256 (~1.13x KEEP; need ~3.35x isolated). Layer-split FIFO (~0.60x vs the Q8 bar). Head-TP peer-read (peer BW). hipBLASLt dual-GPU (fatal or slower).
+
+### Residual compiler / ACO
+
+Faithful HIP cm1 hsaco on gfx1201: 192 VGPR, 339 spills, 940 B private, vs KEEP SharedK 35 spills / 120 B. Mechanism of the isolated 1.13x, not a named LLVM defect. Avoidability (regalloc vs live-range vs fundamental) is open. Phase-2 ROCm/LLVM rebuild stays blocked until a discriminator names a smallest component and a measurable prediction. A general codegen fix, if one exists, is a separate claim from the 3.35x bar.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -229,7 +229,7 @@ on CUDA/CPU builds beyond the documented behavior.
 | `VT_GEMMA4_PREFILL_BATCH_MOE` | auto / `1` in lab recipe | `=1` group-by-expert prefill GEMM for `T>=64`; `=0` serial M=1 (slow). Unset = auto |
 | `VT_GEMMA4_MLP_MOE_PARALLEL` | off | `=1` run Gemma4 MLP and MoE on two HIP streams (lab; wall ~flat on R9700). Not wired in this PR tip (decode-graph-free split) |
 | `VT_ATTN_PREFILL_FLASH` | off | `=1` SGLang-style BM×BN GQA flash prefill (lab A/B) |
-| `VT_GEMMA4_PREFILL_GEMM_M` | `256` | Tokens per expert in prefill-batch GEMM chunks (`16..2048`). Larger M → fewer launches; lab `512` ~+37% prefill vs `64` |
+| `VT_GEMMA4_PREFILL_GEMM_M` | `256` | Tokens per expert in prefill-batch GEMM chunks (`16..2048`). Larger M → fewer launches. Lab KEEP on dual R9700 uses `2048` |
 | `VT_GEMMA4_HOST_EXPERT_MB` | `512` | Host-side expert staging budget (MiB) for non-resident paths |
 | `VT_GEMMA4_LAYER_TRACE` | off | `=1` layer GPU-synced phase timers; `=2` per-layer heartbeats |
 | `VLLM_CPP_HTTP_FIXED_POOL` | `1` (fixed) | `=0` reverts the HTTP worker pool to the legacy dynamic mode. Production uses the capacity-derived fixed pool; the opt-out exists for same-binary A/B attribution |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -229,7 +229,7 @@ on CUDA/CPU builds beyond the documented behavior.
 | `VT_GEMMA4_PREFILL_BATCH_MOE` | auto / `1` in lab recipe | `=1` group-by-expert prefill GEMM for `T>=64`; `=0` serial M=1 (slow). Unset = auto |
 | `VT_GEMMA4_MLP_MOE_PARALLEL` | off | `=1` run Gemma4 MLP and MoE on two HIP streams (lab; wall ~flat on R9700). Not wired in this PR tip (decode-graph-free split) |
 | `VT_ATTN_PREFILL_FLASH` | off | `=1` SGLang-style BM×BN GQA flash prefill (lab A/B) |
-| `VT_GEMMA4_PREFILL_GEMM_M` | `256` | Tokens per expert in prefill-batch GEMM chunks (`16..2048`). Larger M → fewer launches. Lab KEEP on dual R9700 uses `2048` |
+| `VT_GEMMA4_PREFILL_GEMM_M` | `2048` | Tokens per expert in prefill-batch GEMM chunks (`16..8192`; out-of-range values are ignored and the default is used). Larger M → fewer launches; lab `512` ~+37% prefill vs `64`, and `512`→`2048` ~+80 eng @11k vs the WMMA baseline (2026-08-10), which is why the default is `2048`. Lab KEEP on dual R9700 uses the default |
 | `VT_GEMMA4_HOST_EXPERT_MB` | `512` | Host-side expert staging budget (MiB) for non-resident paths |
 | `VT_GEMMA4_LAYER_TRACE` | off | `=1` layer GPU-synced phase timers; `=2` per-layer heartbeats |
 | `VLLM_CPP_HTTP_FIXED_POOL` | `1` (fixed) | `=0` reverts the HTTP worker pool to the legacy dynamic mode. Production uses the capacity-derived fixed pool; the opt-out exists for same-binary A/B attribution |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -363,7 +363,7 @@ CPU elementwise GEMM (f32/f16/bf16) runs AVX2 and AVX-512 tiers on x86 where the
 | XPU, TPU | Not started | CUDA, CPU, Metal and Vulkan are the built backends |
 | Custom logits processors on CUDA | Open, not root-caused | Segfaults in a CUDA build, 232/232 green on CPU |
 | Memory budgeting (`ROAD-V1-MEM`, #83) | M1+M2 landed (absolute bytes) | `--kv-cache-memory` sizes the KV pool from an absolute byte budget (ABI v16, group-aware divisor); `--num-blocks` overrides; `--gpu-memory-utilization` needs the M3 profile run (dgx-gated). See `specs/kv-sizing.md` |
-| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident + SharedK-WMMA. Lab KEEP fair ~2014 t/s@11k / ~1099@42k (2xR9700). Decode-graph/forward extract deferred. [spec](../.agents/specs/gemma4-rocm-fp8-moe.md) |
+| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident experts, SharedK-WMMA prefill (RDNA4); decode-graph and forward extract deferred. Env `VT_GEMMA4_*`/`VT_ATTN_*`, seam `test_gemma4_rocm_fp8_seams`. [spec](../.agents/specs/gemma4-rocm-fp8-moe.md) |
 
 ## How to read this page
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -363,7 +363,7 @@ CPU elementwise GEMM (f32/f16/bf16) runs AVX2 and AVX-512 tiers on x86 where the
 | XPU, TPU | Not started | CUDA, CPU, Metal and Vulkan are the built backends |
 | Custom logits processors on CUDA | Open, not root-caused | Segfaults in a CUDA build, 232/232 green on CPU |
 | Memory budgeting (`ROAD-V1-MEM`, #83) | M1+M2 landed (absolute bytes) | `--kv-cache-memory` sizes the KV pool from an absolute byte budget (ABI v16, group-aware divisor); `--num-blocks` overrides; `--gpu-memory-utilization` needs the M3 profile run (dgx-gated). See `specs/kv-sizing.md` |
-| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident experts, SharedK-WMMA prefill (RDNA4); decode-graph and forward extract deferred. Env `VT_GEMMA4_*`/`VT_ATTN_*`, seam `test_gemma4_rocm_fp8_seams`. [spec](../.agents/specs/gemma4-rocm-fp8-moe.md) |
+| Gemma4 MoE ROCm FP8 + SharedK-WMMA | Partial | Dual-GPU FP8 resident + SharedK-WMMA. Lab KEEP fair ~2014 t/s@11k / ~1099@42k (2xR9700). Decode-graph/forward extract deferred. [spec](../.agents/specs/gemma4-rocm-fp8-moe.md) |
 
 ## How to read this page
 

--- a/docs/ROCM.md
+++ b/docs/ROCM.md
@@ -9,8 +9,11 @@ Gemma-3-1B-it is 48/48 token-identical to two independent vLLM-ROCm oracles;
 Qwen3-0.6B exposed a deterministic cross-version near-tie. Qwen3.5-0.8B also
 runs all-native through the GDN stack, but its CPU/ROCm divergence is still an
 open correctness gap. The Gemma-4 FP8 MoE and SharedK-WMMA path has contributor
-runtime evidence on 2x R9700; this repository has only CPU link coverage for
-that path, and no matched oracle performance result.
+runtime evidence on 2x R9700 (KEEP fair ~2014 t/s @~11k / ~1099 @~42k,
+`PREFIX_CACHE=0`; decode ~55 t/s). This repository has only CPU link coverage
+for that path, and no matched vLLM-ROCm oracle performance result. Vulkan Q8
+prefill on the same box is faster (~3503 / ~2714); the ROCm path is the
+reliable recipe, not that bar.
 
 This page exists because several people offered hardware in
 [issue #41](https://github.com/mudler/vllm.cpp/issues/41), and it answers the

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3899,9 +3899,17 @@ ENVIRONMENT.md (`VT_GEMMA4_RESIDENT_*`, `VT_ATTN_*`). Defaults stay safe off RDN
 GetBlas keeps two per-thread hipBLAS handles (`tls_slots[2]`, device 1 → slot 1)
 so a 0→1 hop does not destroy GPU0's handle. `ProductGetBlasHandle` is the
 test accessor for that file-local `GetBlas`. HIP live probe is a separate CTest
-target (exit 77 if `HIP_VISIBLE_DEVICES` empty); it enters capture so production `StreamIsCapturing` is load-bearing. No new env. This PR does **not**
-restructure the Gemma-4 layer loop or enable decode hipGraph (those stay lab-only
-until a CUDA token-exact gate can land them).
+target (exit 77 if `HIP_VISIBLE_DEVICES` empty); it enters capture so production `StreamIsCapturing` is load-bearing. No new env.
+This path does **not** restructure the Gemma-4 layer loop or enable decode hipGraph
+(those stay lab-only until a CUDA token-exact gate can land them).
+
+Contributor KEEP recipe (2x R9700 gfx1201, ROCm 7.2.4, `PREFIX_CACHE=0`, unique
+pads, 2026-08-13): SharedK-WMMA on, FLASH/FMHA off, `VT_GEMMA4_PREFILL_GEMM_M=2048`,
+`PEER_ACT=1`, batch MoE `T>=64`, decode KV-splits 16 / slide-splits 8. Fair median
+prefill **2014 t/s @~11k** and **1099 t/s @~42k**; stream decode **55 t/s** temp=0.
+Paris / arith `63` / `gemma4` tool_calls held. Speculative, ngram, FMHA, and
+layer-split are **out of this recipe**. This is a reliable plateau, not Vulkan
+prefill parity. Details: [spec](../.agents/specs/gemma4-rocm-fp8-moe.md).
 
 ## LTX-2.5 text conditioning
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3904,12 +3904,22 @@ This path does **not** restructure the Gemma-4 layer loop or enable decode hipGr
 (those stay lab-only until a CUDA token-exact gate can land them).
 
 Contributor KEEP recipe (2x R9700 gfx1201, ROCm 7.2.4, `PREFIX_CACHE=0`, unique
-pads, 2026-08-13): SharedK-WMMA on, FLASH/FMHA off, `VT_GEMMA4_PREFILL_GEMM_M=2048`,
-`PEER_ACT=1`, batch MoE `T>=64`, decode KV-splits 16 / slide-splits 8. Fair median
-prefill **2014 t/s @~11k** and **1099 t/s @~42k**; stream decode **55 t/s** temp=0.
-Paris / arith `63` / `gemma4` tool_calls held. Speculative, ngram, FMHA, and
-layer-split are **out of this recipe**. This is a reliable plateau, not Vulkan
-prefill parity. Details: [spec](../.agents/specs/gemma4-rocm-fp8-moe.md).
+pads, 2026-08-13): SharedK-WMMA on, FLASH/FMHA off, `VT_GEMMA4_PREFILL_GEMM_M=2048`
+(the default), `VT_GEMMA4_PREFILL_PEER_ACT=1` (the default), batch MoE `T>=64`.
+Fair median prefill **2014 t/s @~11k** and **1099 t/s @~42k**; stream decode
+**55 t/s** temp=0. Paris / arith `63` / `gemma4` tool_calls held. Speculative,
+ngram, FMHA, and layer-split are **out of this recipe**. Details:
+[spec](../.agents/specs/gemma4-rocm-fp8-moe.md).
+
+These are contributor-lab numbers against **no denominator**: no pinned vLLM-ROCm
+run on the same box, same model, same quantization and same request shape exists
+for them, so `docs/BENCHMARKS.md` still records this backend as `PENDING: no
+binding throughput number` and this recipe does not change that. The decode
+figure is also not reproducible from the knobs above: the as-run recipe set four
+further decode splits that no product code in this tree reads
+([#845](https://github.com/mudler/vllm.cpp/issues/845)), and they are recorded in
+the spec rather than here, because a recipe on this page has to be one a reader
+can follow.
 
 ## LTX-2.5 text conditioning
 


### PR DESCRIPTION
record(GEMMA4-ROCM-KEEP): the 2x R9700 KEEP recipe, and the denominator it still lacks

Records the contributor KEEP recipe for Gemma-4-26B-A4B-it FP8 on dual R9700
(gfx1201, ROCm 7.2.4) and what it is still missing. Documents only: no kernel
change, no default change, no env change.

## What is recorded

Fair protocol `PREFIX_CACHE=0` plus unique pads, 2026-08-13.

| Depth | median prefill t/s |
|------:|-------------------:|
| ~3k | 2112 |
| ~11k | 2014 |
| ~18k | 1705 |
| ~42k | 1099 |

Decode stream 55.5 t/s at temp=0, 49.1 t/s at temp=0.7. Paris, arith `63` and
`gemma4` `tool_calls` held. Same-box Vulkan Q8 unique-pad prefill is 3503 @11k and
2714 @42k, so the ROCm path is 1.74x and 2.47x behind it there.

The rejected levers are named with their numbers: FMHA_WMMA2 (quality fail plus
0.67x @11k), isolated P1 cm1 wg256 (~1.13x where ~3.35x isolated is needed),
layer-split FIFO (~0.60x), Head-TP peer-read, hipBLASLt dual-GPU. So is the
residual: the faithful HIP cm1 hsaco spills 339 VGPR against RADV/ACO's 0 on an
equivalent llama.cpp coopmat1 spec, which is the mechanism behind the isolated
1.13x and is not yet a named LLVM component.

## What is NOT recorded, and why

**There is no denominator.** Every number above is engine-side with nothing on
the other side of it — no pinned vLLM-ROCm run on the same box, model,
quantization, request shape, concurrency and cache policy. Under AGENTS.md
"Gates" that is not a throughput result, so `docs/BENCHMARKS.md` keeps this
backend at `PENDING: no binding throughput number` and this PR does not touch that
row. `.agents/benchmark-record.md` is also deliberately not appended: it is the
append-only measurement log, and a figure that enters it gets quoted afterwards as
measured.

The oracle is not hypothetical. `docs/ROCM.md` §5 documents two working Docker
vLLM-ROCm recipes on this hardware family, the second building this project's
pinned commit `555967922` inside `rocm/vllm-dev:base` in about 6.5 minutes. What
is missing is a run, and only the contributor has 2x R9700.

**The recipe is not reproducible as written.** Four of the names in it are read by
no product code in this tree. `VT_ATTN_DECODE_KV_SPLITS`,
`VT_ATTN_DECODE_SLIDE_SPLITS` and `VT_ATTN_DECODE_SPLIT_WARPS` occur only in
`tests/vt/test_gemma4_rocm_fp8_seams.cpp`; `VT_ATTN_DECODE_SLIDE_WARPS` occurs
nowhere at all; `git grep` over `src/` and `include/` returns zero hits for all
four. That is #845, whose seam test asserts `EnvInt(name, 16) == 16` with the
variable unset — a tautology that passes whether or not the knob exists, which is
how names nothing reads came to look real.

The `**Status:**` line names the run's tree as `PR tip feat/gemma4-rocm-fp8-split`
with no commit SHA, so this repository cannot establish which tree produced the
numbers. Either the four decode splits were live on that tree and it is not this
one, or they were inert and the shipped defaults produced these figures. **Only
the contributor can say which**, and until he does the decode figure has no recipe
behind it. Both items are listed under `## Owed` in
`.agents/specs/gemma4-rocm-fp8-moe.md`.

## Repairs in this revision

`docs/ENVIRONMENT.md` described `VT_GEMMA4_PREFILL_GEMM_M` as default `256` over
`16..2048`. `gemma4_moe.cpp:1016-1021` accepts `16..8192` and returns `2048`, and
has since 2026-08-10. The row was already wrong on `main` and this branch edits
that exact row, so it is repaired in flow. The same edit had dropped a recorded
measurement — lab `512` ~+37% prefill vs `64` — and AGENTS.md says to move
evidence, never to drop it, so it is restored beside the `512`→`2048` ~+80 eng
@11k result that explains the default.

`PEER_ACT` and `PREFILL_GEMM_M` are now spelled as the product spells them,
`VT_GEMMA4_PREFILL_PEER_ACT` and `VT_GEMMA4_PREFILL_GEMM_M`, and both are already
the default. `docs/USAGE.md` publishes only knobs a reader can actually set and
says outright that the decode figure is not reproducible from them; the spec keeps
the full as-run recipe, because a record holds what happened and a user page has
to be followable.

`docs/FEATURES.md` returns to `main`'s text. A throughput figure's home is
`docs/BENCHMARKS.md` under the projection table, this change alters no feature,
backend or quantization surface, and fitting the number into a cell already 219 of
its 220 characters cost the row its `VT_GEMMA4_*`/`VT_ATTN_*` pointer and the
`test_gemma4_rocm_fp8_seams` seam name.

The title no longer says "plateau". The PR body always said the right thing — that
this does not close the Vulkan bar, and it names the ACO disparity as the next
hypothesis — but the title is what survives into `git log`, and "plateau" reads
there as the ceiling claim AGENTS.md forbids.

The branch was rebuilt by rebase onto `affc2a7fd`, so it carries no untrailered
merge commit and both original commits keep their authorship. The `docs/USAGE.md`
conflict against #837's landed GetBlas text was resolved as a union.

## Known-unrelated CI

`windows-msvc-cpu` and `windows-msvc-vulkan` are red on every open PR from a break
predating this branch (#503, #584). The previous `sanitize-cpu (address,undefined)`
red on this branch was `test_ltx2_video`, from a lane 215 commits ahead of the old
base; the rebase carries it away.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: ClaudeCode:claude-opus-5 [ClaudeCode]
