### PR TITLE
build: make the tree compile on gcc 16, and add a CI lane so it stays that way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,6 +958,46 @@ jobs:
             echo "Running test_ops_matmul_elem with VT_CPU_MATMUL_TIER=${tier}"
             VT_CPU_MATMUL_TIER="${tier}" build/tests/test_ops_matmul_elem
           done
+  build-newest-gcc:
+    # COMPILE-ONLY coverage on a compiler NEWER than any other lane's. Every
+    # other Linux lane installs the distro `g++`, which on ubuntu-latest is
+    # gcc 13, so a header that only compiles because of a TRANSITIVE include
+    # goes green here and red on a current distro. That is not hypothetical:
+    # ::getpid without <unistd.h> was fixed once and came back in five more
+    # files, one of them src/vllm/entrypoints/openai/server_main.cpp — a
+    # SHIPPED binary that does not build on gcc 16 (reported on issue #41).
+    #
+    # Deliberately does NOT run ctest: this lane exists to catch compile-time
+    # portability, and build-test-cpu already owns execution. Keeping it to a
+    # build is roughly one extra compile per PR.
+    concurrency:
+      group: ci-build-newest-gcc-${{ github.event_name }}-${{ github.ref }}-${{ github.repository }}
+      cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container: gcc:16
+    steps:
+      - name: Install build tools
+        # The gcc image ships the toolchain only; git is needed BEFORE checkout
+        # so actions/checkout uses git rather than the slower tarball path.
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            ca-certificates cmake git ninja-build python3
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v4
+      - name: Report the compiler this lane is actually pinning
+        run: g++ --version
+      - name: Configure
+        run: |
+          cmake -S . -B build-newest-gcc -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DVLLM_CPP_BUILD_TESTS=ON
+      - name: Build
+        # Same bounded parallelism as build-test-cpu: a bare -j OOM-kills the
+        # runner during the parallel link of the test executables.
+        run: cmake --build build-newest-gcc -j 2
   build-test-cpu-arm64:
     # Independent Arm execution evidence: the x86 lane cannot prove HWCAP
     # dispatch, Arm instructions, or the host ABI. The native runner exercises

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -15,12 +15,37 @@ function(vllm_cpp_set_warnings target)
   if(NOT VLLM_CPP_SANITIZE STREQUAL "OFF")
     set(_vllm_cpp_werror "")
   endif()
+
+  # GCC >= 16 reports -Warray-bounds inside LIBSTDC++ and the vendored nlohmann
+  # json for code that is correct, so the diagnostic stays VISIBLE but stops
+  # being fatal on those compilers only. Everything <= 15 is unchanged and still
+  # fails the build on a real out-of-bounds.
+  #
+  # It is the same false-positive class this file already documents above for
+  # the sanitizer lanes, and it is not something the calling code can avoid:
+  # `_Sp_counted_base::_M_release()` is identical machine code for every
+  # shared_ptr type, so after inlining GCC attributes ONE instantiation's
+  # destructor to ANOTHER instantiation's allocation size. On gcc 16.1.1 that
+  # presents as "array subscript 'std::mutex[0]' is partly outside array bounds
+  # of 'unsigned char [32]'" pointing at a json.dump() call, in a translation
+  # unit that contains no shared_ptr<std::mutex> at all.
+  #
+  # libstdc++ carries its own `#pragma GCC diagnostic` suppressions around that
+  # very destructor (bits/shared_ptr_base.h), i.e. the standard library treats
+  # this as a warning to silence rather than a bug to fix in user code. Upstream
+  # is GCC PR tree-optimization/122197; Eigen, assimp and CMSSW all disable the
+  # check the same way on the affected releases.
+  set(_vllm_cpp_array_bounds "")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+    set(_vllm_cpp_array_bounds -Wno-error=array-bounds)
+  endif()
   if(MSVC)
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:CXX>:/W4 /WX>)
   else()
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra ${_vllm_cpp_werror}>
+      $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra ${_vllm_cpp_werror} ${_vllm_cpp_array_bounds}>
     # OBJCXX (.mm — the Metal backend) is a SEPARATE COMPILE_LANGUAGE from CXX,
     # so the CXX genex above does not reach it. Without this line the Metal TUs
     # would be the only unwarned code in the tree (BACKEND-METAL-MLX W0).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -22,6 +22,22 @@ example targets are named after the directories they are built from, so an
 in-source build makes the linker write each executable over its own source
 directory (issue #85).
 
+### Host compilers
+
+gcc 13 and 14 and clang are exercised by CI, and **gcc 16 builds the tree,
+including the OpenAI server**. Before this it did not: several files, one of
+them the server's own `main`, called `getpid()` without including `<unistd.h>`
+and compiled only because an older libstdc++ happened to pull that header in
+for them. A compile-only CI lane on the newest released gcc now guards this,
+because every other Linux lane uses the distro compiler and cannot see it.
+
+On gcc 16 the `array-bounds` warning is reported but is **not** treated as an
+error, unlike on every earlier gcc. That release emits it inside libstdc++ and
+the vendored JSON library for code that is correct, and no change to the
+calling code avoids it (`cmake/CompilerWarnings.cmake` explains the mechanism
+and cites the upstream gcc bug). A genuine out-of-bounds still fails the build
+on gcc 15 and earlier, which is what the rest of CI enforces.
+
 ### Setting the compiled build identity
 
 `vllm-server --version` reports the CMake project version by default. Release

--- a/examples/ltx2_gen/main.cpp
+++ b/examples/ltx2_gen/main.cpp
@@ -425,7 +425,17 @@ int main(int argc, char** argv) {
   // Each retake knob rides the SAME per-generation array. Supplying one without
   // the window is refused by the engine rather than ignored, so a half-typed
   // retake reports what is missing instead of rendering the ordinary path.
-  for (const auto& kv : {std::make_pair("retake_start_time", &retake_start),
+  // The knobs are a NAMED array rather than a braced-init-list iterated in
+  // place. Both are correct -- a braced-init-list bound to the range variable
+  // has its backing array lifetime-extended for the whole loop -- but the
+  // in-place form draws -Wdangling-reference from gcc 16, which
+  // `build-newest-gcc` found on its first run. The warning is a false positive
+  // and it is not silenced: the range now has automatic storage and a name, so
+  // no reference binds to a temporary and the question does not arise. Making
+  // the loop variable a copy does NOT help; the diagnostic is about the range
+  // reference, not the element.
+  const std::pair<const char*, std::string*> retake_knobs[] = {
+      std::make_pair("retake_start_time", &retake_start),
                          std::make_pair("retake_end_time", &retake_end),
                          std::make_pair("retake_frame_rate", &retake_fps),
                          std::make_pair("regenerate_video", &regen_video),
@@ -452,7 +462,8 @@ int main(int argc, char** argv) {
                          std::make_pair("video_skip_step", &video_skip_step),
                          std::make_pair("video_stg_blocks", &video_stg_blocks),
                          std::make_pair("a2v_guidance_scale", &a2v_scale),
-                         std::make_pair("v2a_guidance_scale", &v2a_scale)}) {
+                         std::make_pair("v2a_guidance_scale", &v2a_scale)};
+  for (const auto& kv : retake_knobs) {
     if (kv.second->empty()) continue;
     gen_keys.emplace_back(kv.first);
     gen_values.push_back(*kv.second);

--- a/src/vllm/entrypoints/openai/server_main.cpp
+++ b/src/vllm/entrypoints/openai/server_main.cpp
@@ -57,6 +57,7 @@
 #include <chrono>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>  // ::getpid below; guarded because MSVC has no such header
 #include <thread>
 #endif
 

--- a/src/vllm/model_executor/models/qwen3_5.cpp
+++ b/src/vllm/model_executor/models/qwen3_5.cpp
@@ -1,5 +1,6 @@
 #if defined(__unix__)
 #include <sys/mman.h>
+#include <unistd.h>  // ::sysconf(_SC_PAGESIZE) in the readahead hint below
 #endif
 // vllm.cpp original; see qwen3_5.h. Forward math mirrored 1:1 from the pinned
 // upstream (qwen3_next.py::Qwen3NextDecoderLayer / Qwen3NextModel.forward,

--- a/tests/support/process_id.h
+++ b/tests/support/process_id.h
@@ -1,0 +1,47 @@
+// vllm.cpp original (test harness); no upstream mirror.
+//
+// ONE portable process id for the whole test tree.
+//
+// WHY IT EXISTS. Tests name their temporary directories after the running
+// process so two concurrent runs cannot collide. `::getpid()` is POSIX, and its
+// declaration lives in `<unistd.h>`, which MSVC does not ship at all. So the
+// obvious spelling does not fail on Windows — it does not COMPILE, and it takes
+// both `windows-msvc-*` lanes down with it. Exactly the shape of issue #603,
+// which is why `tests/support/test_env.h` next door exists.
+//
+// It also fails on a CURRENT POSIX toolchain for the opposite reason. Several
+// files called `::getpid()` while including nothing that declares it, and
+// compiled anyway because an older libstdc++ pulled `<unistd.h>` in for them.
+// gcc 16 does not:
+//
+//   error: '::getpid' has not been declared; did you mean 'getpt'?
+//
+// That was fixed once in three files and came back in five more, because each
+// new loader test copies the temp-directory helper from the last one. A per-file
+// `#ifdef` would be copied just as faithfully and get it wrong again, so the
+// portable spelling lands ONCE, here, and new tests include it.
+#pragma once
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace vllm_test {
+
+// The current process id, for building a name no other process will pick.
+//
+// NOT for anything but naming. The two platforms agree that this is a unique
+// live-process identifier and agree on nothing else about it, so it is used for
+// uniqueness only, never compared against a recorded value or reused after the
+// process exits.
+inline int ProcessId() {
+#if defined(_WIN32)
+  return ::_getpid();
+#else
+  return static_cast<int>(::getpid());
+#endif
+}
+
+}  // namespace vllm_test

--- a/tests/vllm/models/test_indextts2_s2mel_loader.cpp
+++ b/tests/vllm/models/test_indextts2_s2mel_loader.cpp
@@ -20,6 +20,7 @@
 #include "vllm/model_executor/models/indextts2_config.h"
 #include "vllm/model_executor/models/indextts2_s2mel_loader.h"
 
+#include "support/process_id.h"
 namespace {
 
 std::string U64Le(uint64_t v) {
@@ -117,7 +118,7 @@ std::string BuildTail(int64_t hidden = 8, int64_t in_ch = 4, int64_t wn = 8,
 std::string WriteTemp(const std::string& bytes, const std::string& tag) {
   const std::filesystem::path path =
       std::filesystem::temp_directory_path() /
-      ("indextts2_s2mel_" + tag + "_" + std::to_string(::getpid()) + ".safetensors");
+      ("indextts2_s2mel_" + tag + "_" + std::to_string(vllm_test::ProcessId()) + ".safetensors");
   std::ofstream out(path, std::ios::binary);
   out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
   out.close();

--- a/tests/vllm/models/test_indextts2_talker_loader.cpp
+++ b/tests/vllm/models/test_indextts2_talker_loader.cpp
@@ -16,6 +16,7 @@
 #include "vllm/model_executor/models/indextts2_config.h"
 #include "vllm/model_executor/models/indextts2_talker_loader.h"
 
+#include "support/process_id.h"
 namespace {
 
 std::string U64Le(uint64_t v) {
@@ -79,7 +80,7 @@ std::string BuildTalker(int64_t H = 8, int64_t L = 2, int64_t I = 16, int64_t TV
 
 std::string WriteTemp(const std::string& bytes, const std::string& tag) {
   const std::filesystem::path p = std::filesystem::temp_directory_path() /
-      ("indextts2_talker_" + tag + "_" + std::to_string(::getpid()) + ".safetensors");
+      ("indextts2_talker_" + tag + "_" + std::to_string(vllm_test::ProcessId()) + ".safetensors");
   std::ofstream out(p, std::ios::binary);
   out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
   return p.string();

--- a/tests/vllm/models/test_ltx2_text_encoder.cpp
+++ b/tests/vllm/models/test_ltx2_text_encoder.cpp
@@ -37,6 +37,7 @@
 
 #include "doctest/doctest.h"
 #include "support/max_abs_diff.h"
+#include "support/process_id.h"
 #include "vllm/model_executor/model_loader/safetensors_reader.h"
 #include "vllm/model_executor/models/gemma4.h"
 #include "vllm/model_executor/models/ltx2_loader.h"
@@ -1457,7 +1458,7 @@ TEST_CASE("ltx2 text: a non-f32 compute dtype is REFUSED, never silently widened
 
 TEST_CASE("ltx2 text: the tokenizer and HF sidecars come out of TENSORS, not files") {
   const fs::path dir =
-      fs::temp_directory_path() / ("ltx2_text_assets_" + std::to_string(::getpid()));
+      fs::temp_directory_path() / ("ltx2_text_assets_" + std::to_string(vllm_test::ProcessId()));
   fs::create_directories(dir);
 
   const std::string tokenizer = R"({"version":"1.0","model":{"type":"BPE"}})";

--- a/tests/vllm/models/test_minimax_music3_loader.cpp
+++ b/tests/vllm/models/test_minimax_music3_loader.cpp
@@ -43,6 +43,7 @@
 #include "vllm/model_executor/models/minimax_music3_loader.h"
 #include "vllm/model_executor/models/vocoder1d.h"
 
+#include "support/process_id.h"
 using vllm::MiniMaxMusic3AccountReport;
 using vllm::MiniMaxMusic3AccountTensors;
 using vllm::MiniMaxMusic3Config;
@@ -164,7 +165,7 @@ std::vector<StEntry> EntriesFor(const std::vector<MiniMaxMusic3TensorSpec>& spec
 
 std::string TempPath(const char* stem) {
   return (std::filesystem::temp_directory_path() /
-          (std::string("music3_") + stem + "_" + std::to_string(::getpid()) + ".safetensors"))
+          (std::string("music3_") + stem + "_" + std::to_string(vllm_test::ProcessId()) + ".safetensors"))
       .string();
 }
 
@@ -733,7 +734,7 @@ TEST_CASE("music3 load: a component whose file lost a tensor throws BY NAME") {
 TEST_CASE("music3 resolve: a NATIVE-arm checkpoint is refused, naming what is missing") {
   const std::filesystem::path root =
       std::filesystem::temp_directory_path() /
-      ("music3_native_" + std::to_string(::getpid()));
+      ("music3_native_" + std::to_string(vllm_test::ProcessId()));
   std::filesystem::remove_all(root);
   // The layout convert_minimax_music3_to_diffusers.py:30,34,38 reads, and the
   // one sglang_omni/models/minimax_music3/checkpoint.py:35-56 serves.
@@ -776,7 +777,7 @@ TEST_CASE("music3 resolve: ONE native marker is enough to be diagnosed as the na
   for (const char* marker : {"flowmatching_vae.pth", "dav.pth", "qwen_7B"}) {
     const std::filesystem::path root =
         std::filesystem::temp_directory_path() /
-        ("music3_partial_" + std::string(marker) + "_" + std::to_string(::getpid()));
+        ("music3_partial_" + std::string(marker) + "_" + std::to_string(vllm_test::ProcessId()));
     std::filesystem::remove_all(root);
     std::filesystem::create_directories(root);
     if (std::string(marker) == "qwen_7B") {
@@ -804,7 +805,7 @@ TEST_CASE("music3 resolve: ONE native marker is enough to be diagnosed as the na
 
 TEST_CASE("music3 resolve: a tree that is NEITHER arm names the components it lacks") {
   const std::filesystem::path root =
-      std::filesystem::temp_directory_path() / ("music3_empty_" + std::to_string(::getpid()));
+      std::filesystem::temp_directory_path() / ("music3_empty_" + std::to_string(vllm_test::ProcessId()));
   std::filesystem::remove_all(root);
   std::filesystem::create_directories(root);
   CHECK(!vllm::MiniMaxMusic3IsNativeArm(root.string()));


### PR DESCRIPTION
`::getpid()` without `<unistd.h>` compiles on the distro `g++` every Linux lane
installs (gcc 13 on `ubuntu-latest`) because a transitive include supplies the
declaration. On gcc 16 it does not, and five files in this tree rely on it —
one of them `src/vllm/entrypoints/openai/server_main.cpp`, a shipped binary.
Each gains the include it actually needs.

`build-newest-gcc` is a compile-only lane on `container: gcc:16`, so the class
cannot come back silently. It deliberately does not run ctest — `build-test-cpu`
owns execution — which keeps it to roughly one extra compile per pull request.
The image was confirmed to exist (`library/gcc:16`, pushed 2026-08-12), so the
lane will not fail on a missing tag.

`cmake/CompilerWarnings.cmake` stops treating `-Warray-bounds` as fatal on
GNU >= 16 only. That diagnostic fires inside libstdc++ and the vendored nlohmann
json for code that is correct; making the vendored headers SYSTEM does not
suppress it, because the reported location lands in our own translation unit
after inlining. The warning stays VISIBLE, and every compiler at 15 or below is
unchanged and still fails the build on a genuine out-of-bounds.

## Maintainer change on top

The `server_main.cpp` include was added unguarded, among the plain includes.
That file is one of five in `REQUIRED_CPP` in
`scripts/check-windows-portability.py`, whose `POSIX_PATTERNS[0]` matches a bare
`#include <unistd.h>` on any line reachable from a Windows build — so as written
it would newly red both `windows-msvc-*` lanes, the opposite of this PR's intent.

Dropping it would also have been wrong: the `::getpid()` that needs it (`:158`)
is guarded by `#if defined(VT_BENCH_PROFILE_CONTROL) && !defined(_WIN32)`, and
that macro is set under `VLLM_CPP_CUDA` plus the opt-in
`VLLM_CPP_BENCH_PROFILE_CONTROL`. A CUDA build with the profiler enabled, on
gcc 16, genuinely needs the declaration — and this PR's own lane is CPU-only, so
it would not have caught that.

The include therefore moves into the `VT_BENCH_PROFILE_CONTROL && !_WIN32` block
that already carries `<cerrno>`, `<chrono>`, `<fcntl.h>` and `<sys/stat.h>` for
the same feature. It is now guarded by exactly the condition that guards its only
user. `check-windows-portability.py` returns `Windows portability contract OK`.
The four test-file includes are untouched: none is in `REQUIRED_CPP`, none is
built on Windows, and each has an unguarded `::getpid()` that needs the header.

## The lane earned its keep immediately

`build-newest-gcc` failed on this very pull request, on a SIXTH file the five
include repairs above do not cover:

```
src/vllm/model_executor/models/qwen3_5.cpp:5296:27: error: '::sysconf' has not
  been declared; did you mean 'swscanf'?
src/vllm/model_executor/models/qwen3_5.cpp:5296:35: error: '_SC_PAGESIZE' was
  not declared in this scope
```

`g++ (GCC) 16.2.0`. A different symbol pair from the same header, so a `::getpid`
sweep would never have found it; `<sys/mman.h>` was already included for the same
block and carried the file this far on gcc 13 through a transitive declaration.
Fixed in this branch, inside the `#if defined(__unix__)` guard the file already
has, which is the same condition guarding the call site.


## Owed, not done here

`build-newest-gcc` is not wired into `baseline-summary` or
`scripts/main-baseline.py`'s `EXPECTED_JOBS`, so the published baseline verdict
does not yet cover gcc 16. That is deliberate: #1155 is editing the same list to
address the structural half of #503, and two branches rewriting it would conflict. Wire it in after
whichever lands second.

Issue: #503

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: ClaudeCode:claude-opus-5 [ClaudeCode]
Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>

