### PR TITLE
test(BACKEND-TENSTORRENT): pin the last unmutated gate constant (#2005)

### DIFF
--- a/.agents/benchmark-record.md
+++ b/.agents/benchmark-record.md
@@ -28790,8 +28790,7 @@ ships inside every judged window until TT exposes a live bitmap.
 Row [`BACKEND-TENSTORRENT-QWEN35`](https://github.com/mudler/vllm.cpp/issues/1715)
 context, base `21fe11cf1`, production entry point (`vllm-cli --device auto`
 → W2a allow-list dispatch, tt_cluster UMD lines in evidence). Every leg a
-fresh process under one `$HOME/gpu.lock`; probes follow a JIT-caching cold
-proc (110.9 s for 8 tokens, discarded). Evidence:
+fresh process under one `$HOME/gpu.lock`; one earlier unlogged JIT-warm probe was discarded before logging started. Evidence:
 [`../docs/bench-evidence/tt-qwen35-first-speed-20260826.log`](../docs/bench-evidence/tt-qwen35-first-speed-20260826.log).
 
 **Numbers (greedy b1):** default arm 12-token runs **0.080 / 0.089 / 0.089

--- a/tests/tools/test_tt_clock_state.py
+++ b/tests/tools/test_tt_clock_state.py
@@ -116,6 +116,7 @@ class CrossArmRules(unittest.TestCase):
         self.assertTrue(any("median offset" in r for r in rs))
 
     def test_mean_rule_is_independent_of_median_rule(self):
+        self.assertEqual(ttc.MAX_CROSS_ARM_MEAN_OFFSET_PCT, 1.0)
         # Median pinned, mean dragged: 31 samples at -3%, 33 AT the median.
         # Sorted positions 32/33 land on 800 so BOTH medians are 800; the
         # skew pulls arm B's mean off by ~1.47% (>1%) while arm B alone
@@ -250,7 +251,7 @@ class RefoldBusyCollapseLogic(unittest.TestCase):
         """Test that refold collapses to exactly {cap} for busy samples — gap (a).
 
         The mutation that went undetected was widening the busy filter (e.g.,
-        changing `if b` to `if b or aiclk > 1000`), which would include idle
+        changing `if b` to `if b or a >= 800`), which would include idle
         samples and cause the collapse to fail. This test constructs a
         representative raw window with genuine mid-window spread and asserts the
         collapsed set is exactly {cap}.


### PR DESCRIPTION
test(BACKEND-TENSTORRENT): pin the last unmutated gate constant (#2005)

Fresh review of the merged tt_clock_state work (#2006, head b3182637b at
review time) returned one FAIL-grade finding: MAX_CROSS_ARM_MEAN_OFFSET_PCT
was the one copied threshold without an assertEqual pin, so mutating it
1.0 -> 1.01 passed the whole 22-case suite while the suite header claims
every gate constant is mutation-red. Pinned inside the existing mean-rule
test using the NVIDIA reference suite's own constant-pin idiom
(test_gpu_clock_state.py), not a redundant extra case.

Red-first evidence: hand-applied mutant 1.03 ->
AssertionError: 1.03 != 1.0, FAILED (failures=1); byte-for-byte restore ->
Ran 22 tests, OK. Rebased over the same-day landings twice; preflight green
on 7f72fd27c apart from the two numpy-gated environmental skips CI runs.

Alongside, the two traceability repairs from the same pass: the refold
docstring exemplar named a loop variable that does not exist
(`aiclk > 1000`) and now states the real mutant shape (`a >= 800`); and
the Qwen3.5 record paragraph quoted a discarded JIT-warm probe (110.9 s for
8 tokens) that no committed log holds — reworded to say only what
docs/bench-evidence/tt-qwen35-first-speed-20260826.log shows.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]
