### PR TITLE
fix(BACKEND-TENSTORRENT-QWEN35): record the served geometry in the capture lane (#2294)

### DIFF
--- a/.agents/specs/tenstorrent-qwen35.md
+++ b/.agents/specs/tenstorrent-qwen35.md
@@ -57,9 +57,9 @@ a stale persistent buffer over a live device shadow — wrong tokens on
 the default decode path); the fix spends the reservation on every
 content-establishing transition and refuses to serve when
 `device_current` is set (`d2fd05c6e`); suite 51/51 · 5852, sacred pair
-16/16 STRICT both legs. The review's latent geometry finding is
-[#2294](https://github.com/mudler/vllm.cpp/issues/2294), owed below.
-See `## Evidence`, W7. The tt-metal-side residual (a multi-destination
+16/16 STRICT both legs. The review's latent geometry finding landed as its
+own red-first fix ([#2294](https://github.com/mudler/vllm.cpp/issues/2294));
+see `## Evidence`. The tt-metal-side residual (a multi-destination
 write that reaches several offset views at once) stays recorded as the
 upstream-shaped alternative.
 
@@ -387,14 +387,6 @@ the row.
   `SupportsCompressedConvState()` flip in `src/vt/tenstorrent/tenstorrent_backend.cpp`,
   outside the W1 delegated file set. Escalated to the operator 2026-08-23; blocks the
   W2 e2e gate on the default (bf16-state) arm, not on `VT_GDN_STATE_BF16=0`.
-- **#2294 (found by the W7 review, latent)** — `CopyDeviceDeviceIfCapture`
-  records src's geometry in dst's slot without updating `dev_rows`/`dev_cols`;
-  its guard checks slot byte sizes only, so equal bytes at different
-  `[rows,cols]` (or element size) would serve src-shaped bytes through a later
-  exact-shape `EnsureDevice2D` hit. No differing-geometry D2D caller exists
-  today (audited at the repair head); the fix is the same one-liner W7 applied
-  to `CopyDeviceDeviceIfResident` plus a bit-identical audit or a
-  differing-geometry test — the arm runs under capture.
 - **W7 serve arms are production-unreached on the measured workloads** —
   the avoided counters read 0 in every probed leg (vllm-cli ×3, e2e
   ambient ×2 per arm); the arms are guard-evaluated on every staging
@@ -1277,3 +1269,22 @@ Gates: opt-out leg 16/16 PASS (9 strict, 7 near-tie, max gap 0.5 nats at
 prompt[15] tok=9) exit 0; ambient leg 16/16 (10 strict, max 0.375) exit 0 —
 unchanged; suite 40/40 / 3757/3757 exit 0. Evidence:
 `docs/bench-evidence/tt-2115-eager-arm-pair-20260828.log`.
+
+### #2294 — the capture-lane copy records the served geometry (2026-08-30)
+
+The W7 review's latent finding, fixed red-first. `CopyDeviceDeviceIfCapture`
+installed a SRC-shaped clone into dst's slot but left `dev_rows`/`dev_cols`
+naming dst's old geometry; its guard checks slot byte sizes only, so equal
+bytes at differing `[rows,cols]` passed, and a later exact-shape
+`EnsureDevice2D` false-hit the fast path and served the wrongly-shaped
+shadow. The red is the ttnn inner-dim throw (`a_shape[-1] == b_shape[-2]`,
+8 vs 16) on the consume matmul — a loud failure, not silent corruption —
+plus the lane's missing avoided-copy counter. Fix: record src's
+`logical_shape()` in the commit block (the same lines W7 put on
+`CopyDeviceDeviceIfResident`) and bump `StagingAvoidedDeviceCopy` so both
+D2D arms are observable (the eager tests' `ForceEager` scopes decline the
+capture lane, so no existing counter assertion shifts). Focused case
+131/131 green; suite 52/52 · 5983 (baseline on the unmodified tree:
+51/51 · 5852 green first). No differing-geometry D2D caller exists in
+production today (the W7-review audit); the test is the guard for the one
+that appears.

--- a/src/vt/tenstorrent/tenstorrent_ops.cpp
+++ b/src/vt/tenstorrent/tenstorrent_ops.cpp
@@ -5961,11 +5961,20 @@ bool CopyDeviceDeviceIfCapture(void* dst, const void* src) {
     std::lock_guard<std::mutex> g(SlotMutex());
     BufferSlot* d = FindSlot(dst);
     if (d == nullptr) return false;
+    // The shadow just installed is SRC-shaped, and equal byte size does not
+    // mean equal geometry: the record must name the served geometry, or a
+    // later stage at dst's recorded exact geometry would hit the fast path
+    // and be handed a wrongly-shaped tensor. The capture lane mirrors the
+    // eager device-resident arm (#2294).
+    const auto ds = src_dev.logical_shape();
     d->device = std::move(cloned);
+    d->dev_rows = static_cast<uint32_t>(ds[0]);
+    d->dev_cols = static_cast<uint32_t>(ds[1]);
     d->device_current = true;
     d->host_current = false;
     d->device_reserved = false;  // real bytes installed — reservation spent
   }
+  StagingAvoidedDeviceCopy().fetch_add(1, std::memory_order_relaxed);
   return true;
 }
 

--- a/tests/vt/test_tenstorrent_backend.cpp
+++ b/tests/vt/test_tenstorrent_backend.cpp
@@ -4609,6 +4609,87 @@ TEST_CASE("kTENSTORRENT W7 D2D copy records the served geometry") {
   backend.Free(mb4); backend.Free(mb5); backend.Free(mos); backend.Free(mo);
 }
 
+// The capture-lane twin of the eager case above. #2294: CopyDeviceDeviceIfCapture
+// also installs SRC's shadow into dst's slot, and equal byte size does not mean
+// equal geometry there either. A stale record lets a later stage at dst's
+// recorded exact geometry hit the fast path and be handed a wrongly-shaped
+// src-shaped tensor. The case arms the lane through the live env read the same
+// way the inertness-guard case sets it, and pins the lane with the same
+// avoided-copy counter the eager arm bumps.
+struct ForceHostFreeDecode {
+  const bool had = std::getenv("VT_TT_HOST_FREE_DECODE") != nullptr;
+  const std::string saved =
+      had ? std::string(std::getenv("VT_TT_HOST_FREE_DECODE")) : std::string();
+  ForceHostFreeDecode() { ::setenv("VT_TT_HOST_FREE_DECODE", "1", 1); }
+  ~ForceHostFreeDecode() {
+    if (had) ::setenv("VT_TT_HOST_FREE_DECODE", saved.c_str(), 1);
+    else ::unsetenv("VT_TT_HOST_FREE_DECODE");
+  }
+};
+TEST_CASE("kTENSTORRENT #2294 capture-lane D2D copy records the served geometry") {
+  if (!TenstorrentPresent()) {
+    MESSAGE("SKIPPED: no Tenstorrent device on this box");
+    return;
+  }
+  ForceHostFreeDecode host_free;
+  REQUIRE(vt::OpRegistered(vt::OpId::kMatmulBT, DeviceType::kTENSTORRENT));
+  // 32 elements on both sides ([4,8] src vs [8,4] dst) — equal 64-byte slots
+  // (Alloc registers the 64-rounded size), different geometry.
+  constexpr int64_t R = 8, C = 4, N = 16;
+  Backend& backend = vt::GetBackend(DeviceType::kTENSTORRENT);
+  using vt::tenstorrent::GetStagingStats;
+  using vt::tenstorrent::ResetStagingStats;
+  std::vector<uint16_t> sb(C * R), db(R * C), wb4(N * R), wb5(N * C);
+  for (size_t i = 0; i < sb.size(); ++i) sb[i] = static_cast<uint16_t>(0x3800 + (i % 13));
+  for (size_t i = 0; i < db.size(); ++i) db[i] = static_cast<uint16_t>(0x3c00 + (i % 7));
+  for (size_t i = 0; i < wb4.size(); ++i) wb4[i] = static_cast<uint16_t>(0x3f00 + (i % 5));
+  for (size_t i = 0; i < wb5.size(); ++i) wb5[i] = static_cast<uint16_t>(0x4000 + (i % 9));
+  void* ma = backend.Alloc(C * R * 2);
+  void* md = backend.Alloc(R * C * 2);
+  void* mr = backend.Alloc(R * C * 2);
+  void* mb4 = backend.Alloc(N * R * 2);
+  void* mb5 = backend.Alloc(N * C * 2);
+  void* mos = backend.Alloc(C * N * 4);
+  void* mo = backend.Alloc(R * N * 4);
+  Queue q = backend.CreateQueue();
+  backend.Copy(q, ma, sb.data(), C * R * 2);
+  backend.Copy(q, md, db.data(), R * C * 2);
+  backend.Copy(q, mr, sb.data(), R * C * 2);  // dst's post-copy flat bytes as [R, C]
+  backend.Copy(q, mb4, wb4.data(), N * R * 2);
+  backend.Copy(q, mb5, wb5.data(), N * C * 2);
+  Tensor s = Tensor::Contiguous(ma, vt::DType::kBF16, Device{DeviceType::kTENSTORRENT, 0}, {C, R});
+  Tensor d = Tensor::Contiguous(md, vt::DType::kBF16, Device{DeviceType::kTENSTORRENT, 0}, {R, C});
+  Tensor r = Tensor::Contiguous(mr, vt::DType::kBF16, Device{DeviceType::kTENSTORRENT, 0}, {R, C});
+  Tensor b4 = Tensor::Contiguous(mb4, vt::DType::kBF16, Device{DeviceType::kTENSTORRENT, 0}, {N, R});
+  Tensor b5 = Tensor::Contiguous(mb5, vt::DType::kBF16, Device{DeviceType::kTENSTORRENT, 0}, {N, C});
+  Tensor os = Tensor::Contiguous(mos, vt::DType::kF32, Device{DeviceType::kTENSTORRENT, 0}, {C, N});
+  Tensor o = Tensor::Contiguous(mo, vt::DType::kF32, Device{DeviceType::kTENSTORRENT, 0}, {R, N});
+  auto mm = reinterpret_cast<vt::MatmulFn>(vt::GetOp(vt::OpId::kMatmulBT, DeviceType::kTENSTORRENT));
+  mm(q, os, s, b4);  // stage the src [C, R] shadow
+  mm(q, o, d, b5);   // stage dst — its slot owns a persistent buffer
+  mm(q, o, r, b5);   // the reference: the same flat bytes declared [R, C]
+  std::vector<float> want(R * N);
+  backend.Copy(q, want.data(), mo, R * N * 4);
+  ResetStagingStats();
+  backend.Copy(q, md, ma, R * C * 2);  // whole-slot D2D copy: dst's shadow is src-shaped
+  vt::tenstorrent::StagingStats st = GetStagingStats();
+  CHECK_MESSAGE(st.stages_avoided_device_copy == 1,
+                "the capture-lane copy must go device->device, got "
+                    << st.stages_avoided_device_copy);
+  mm(q, o, d, b5);  // consume dst at its DECLARED [R, C] geometry
+  st = GetStagingStats();
+  CHECK_MESSAGE(st.uploads_persistent_bf16 == 0,
+                "dst must serve from its copied shadow, got "
+                    << st.uploads_persistent_bf16);
+  std::vector<float> o2(R * N);
+  backend.Copy(q, o2.data(), mo, R * N * 4);
+  for (size_t i = 0; i < want.size(); ++i)
+    CHECK_MESSAGE(want[i] == o2[i], "dst at its declared geometry differs at "
+                            << i << ": " << want[i] << " vs " << o2[i]);
+  backend.Free(ma); backend.Free(md); backend.Free(mr);
+  backend.Free(mb4); backend.Free(mb5); backend.Free(mos); backend.Free(mo);
+}
+
 // W7 drift repair (#2282): the reservation must not survive content
 // establishment, and the reserved arm must never discard a live shadow.
 // Captured on the host-free e2e drift (LEG B, prompt[1] tok=0): a pool

--- a/tests/vt/test_tenstorrent_backend.cpp
+++ b/tests/vt/test_tenstorrent_backend.cpp
@@ -4613,9 +4613,18 @@ TEST_CASE("kTENSTORRENT W7 D2D copy records the served geometry") {
 // also installs SRC's shadow into dst's slot, and equal byte size does not mean
 // equal geometry there either. A stale record lets a later stage at dst's
 // recorded exact geometry hit the fast path and be handed a wrongly-shaped
-// src-shaped tensor. The case arms the lane through the live env read the same
-// way the inertness-guard case sets it, and pins the lane with the same
-// avoided-copy counter the eager arm bumps.
+// src-shaped tensor. The whole-slot D2D copy runs INSIDE a real trace capture
+// region (BeginCapture/EndCapture, then Replay to execute the captured op):
+// under an active capture the eager arm CopyDeviceDeviceIfResident structurally
+// declines, so the capture lane is the only path that can serve the copy and
+// the avoided-copy counter is lane-exclusive — deleting the capture lane's
+// call site cannot stay green (the host fallback would read back inside the
+// captured region, violating the ttnn trace contract, and the counter would
+// read 0). The consume at dst's declared [R, C] geometry pins the
+// served-geometry record: without it the stage false-hits the exact-shape
+// fast path and hands the matmul the wrongly-shaped [C, R] tensor, which
+// throws. The case arms the lane through the live env read the same way the
+// inertness-guard case sets it.
 struct ForceHostFreeDecode {
   const bool had = std::getenv("VT_TT_HOST_FREE_DECODE") != nullptr;
   const std::string saved =
@@ -4670,11 +4679,24 @@ TEST_CASE("kTENSTORRENT #2294 capture-lane D2D copy records the served geometry"
   mm(q, o, r, b5);   // the reference: the same flat bytes declared [R, C]
   std::vector<float> want(R * N);
   backend.Copy(q, want.data(), mo, R * N * 4);
+  // Program-cache warm contract (ttnn trace fatals on "Cannot load new
+  // binaries during trace capture"): run the SAME D2D copy once eagerly,
+  // outside capture — the host-free lane arms it and the first use enables
+  // the program cache and compiles the captured ttnn::empty + ttnn::copy
+  // pair. Drop its counter contribution before the capture region.
+  backend.Copy(q, md, ma, R * C * 2);
   ResetStagingStats();
-  backend.Copy(q, md, ma, R * C * 2);  // whole-slot D2D copy: dst's shadow is src-shaped
+  // Capture region holds only the whole-slot D2D copy: dst's shadow becomes
+  // src-shaped. Replay executes it (non-blocking; the readback below
+  // synchronizes, mirroring the matmul capture/replay recipe above).
+  backend.BeginCapture(q);
+  backend.Copy(q, md, ma, R * C * 2);
+  backend.EndCapture(q);
+  backend.Replay(q);
   vt::tenstorrent::StagingStats st = GetStagingStats();
   CHECK_MESSAGE(st.stages_avoided_device_copy == 1,
-                "the capture-lane copy must go device->device, got "
+                "under an active capture only the capture lane may serve the "
+                    "copy, got "
                     << st.stages_avoided_device_copy);
   mm(q, o, d, b5);  // consume dst at its DECLARED [R, C] geometry
   st = GetStagingStats();


### PR DESCRIPTION
fix(BACKEND-TENSTORRENT-QWEN35): record the served geometry in the capture lane (#2294)

CopyDeviceDeviceIfCapture installed a src-shaped clone into dst's slot
without updating dev_rows/dev_cols; its byte-only guard let equal bytes at
differing geometry pass, and a later exact-shape EnsureDevice2D false-hit
the fast path and served the wrongly-shaped shadow. The red is the ttnn
inner-dim throw on the consume matmul, not silent corruption. The commit
block now records src's logical_shape, mirroring the lines W7 put on
CopyDeviceDeviceIfResident, and bumps StagingAvoidedDeviceCopy so both D2D
arms are observable. The new capture-lane case runs its whole-slot copy
inside a real BeginCapture/EndCapture/Replay region after one eager
program-cache warmup, where the eager arm structurally declines: the
counter assertion is lane-exclusive, and the review's deleted-call-site
mutation goes red (the first version stayed green through the eager arm
and was repaired red-first). Fixes #2294.

Gates on the final head 5818c9a1b, rerun by the operator after the fresh
reviewer's PASS: focused case 131/131 green; full TT suite 52/52 · 5983
green (baseline on the parent: 51/51 · 5852 green first); sacred pair
16/16 STRICT both ambient legs; mutation evidence for the geometry
record, the counter, and the call-site reachability. No differing-geometry
D2D caller exists in production today (the W7-review audit); the test is
the guard for the one that appears.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]