### PR TITLE
fix(CHECKER-STYLE-MERGE-BASE): the trailer gates run on a branch behind main (#2366)

### DIFF
--- a/.agents/specs/checker-style-merge-base.md
+++ b/.agents/specs/checker-style-merge-base.md
@@ -90,4 +90,6 @@ description; the red-before captures in the implementer report.
 One PR for spec and implementation (repository default, recorded
 policy). Spec committed before implementation on
 `row/CHECKER-STYLE-MERGE-BASE`. The PR body carries `Closes #2366`, and
-`.agents/issue-index.md` gains its append-only row in the same PR.
+No `.agents/issue-index.md` row: the index is retired upstream by
+`7dc2ef1ea` (ENG-RECORD-CONFLICT-SURFACES W6 — GitHub is the issue
+index), and this PR does not resurrect the file.

--- a/.agents/specs/checker-style-merge-base.md
+++ b/.agents/specs/checker-style-merge-base.md
@@ -1,0 +1,93 @@
+# Spec — `CHECKER-STYLE-MERGE-BASE`: the style checker walks from the merge base, so preflight stops forcing a merge
+
+Issue: [#2366](https://github.com/mudler/vllm.cpp/issues/2366). Owner row:
+`CHECKER-STYLE-MERGE-BASE`. Branch `row/CHECKER-STYLE-MERGE-BASE`, base
+`d574f514a` (origin/main, pinned at worktree creation).
+
+## Scope
+
+One behavior change, two files, plus the tests that pin them:
+
+1. `scripts/check-commit-style.py` `validate_range` (lines 114-131) ports
+   the #773 repair the trailers checker already carries
+   (`check-commit-trailers.py:402-407`): resolve the range base to
+   `merge_base(base, head)` instead of refusing a non-ancestor base with
+   `range base must be an ancestor of range head` (lines 125-126).
+   Unrelated histories still fail closed: no merge base means no range.
+   The cutover comparison logic is untouched.
+2. `scripts/agent-preflight.sh` drops the ancestry SKIP arm for status 1
+   (the `TRAILER_BEHIND` block, lines 569-576). The gates then run for a
+   branch behind main over `${BASE_SHA}..HEAD`, whose commit set is the
+   branch's own commits under any ancestry. The unresolved-base arm, the
+   ancestry-ERROR arm (status > 1, unborn HEAD), and both range-count
+   arms stay exactly as they are, with their verbatim-pinned messages.
+3. The comment above the dropped arm (lines 550-554) cites "#999" for the
+   owed repair; that issue does not exist on the forge. The comment is
+   rewritten to cite #2366 and the landed repair.
+
+Exclusions: `check-commit-trailers.py` is already correct (#773, #2157)
+and is not modified. `BASE_UNRESOLVED`, `ANCESTRY_UNKNOWN`, and
+`RANGE_UNKNOWN` texts are verbatim-pinned and untouched. No change to
+what the gates enforce — only to when they run.
+
+## Design
+
+`rev-list BASE..HEAD` selects exactly "commits reachable from HEAD, not
+from BASE" regardless of ancestry, so the commit set under judgement is
+already correct for a behind branch. The refusal lived only in the style
+checker's validation and in the preflight guard compensating for it. With
+the merge-base walk ported, a behind branch's gates run over the same
+commits a post-rebase branch would present, and `agent-ready` stops
+forcing a merge to reach green.
+
+## Risks
+
+- CI hands `pull_request.base.sha`-style ranges whose base stops being an
+  ancestor as soon as main advances (#773's original finding). The style
+  checker gains the same tolerance the trailers checker has had, so the
+  two walks converge instead of diverging.
+- A genuinely unrelated history has no merge base; both checkers fail
+  closed with a stated error rather than inventing a range.
+- The skip-count semantics of `agent-ready.py` are unchanged: fewer
+  SKIPs on behind branches is the intended effect, not a weakening of
+  any assertion.
+
+## Tests
+
+- `tests/scripts/test_check_commit_style.py`: a fixture repo whose range
+  base is behind head (shared history, base not an ancestor) currently
+  raises; the new test asserts `validate_range` returns failures computed
+  over `merge_base..HEAD`. RED before the fix.
+- `tests/scripts/test_agent_preflight_skip_report.py`: a behind-base
+  branch case asserting both gates RUN — no `SKIP commit-trailers` /
+  `SKIP commit-style` lines, exit 0 on a clean range. RED before the fix
+  (both gates skip today).
+- Existing suites stay green unchanged, including every verbatim message
+  pin that this change does not touch.
+
+Each new assertion mutated red per the house rule; the reviewer re-derives
+them by mutation (re-add the ancestor refusal; re-add the SKIP arm) and
+expects both new tests to red.
+
+## Gates
+
+Focused: `test_check_commit_style.py`,
+`test_agent_preflight_skip_report.py`, `test_check_commit_trailers.py`.
+Then the full `scripts/agent-preflight.sh`, then
+`python3 scripts/agent-ready.py`. Evidence: run logs captured in the PR
+description; the red-before captures in the implementer report.
+
+## Stop conditions
+
+- If the merge-base port cannot keep the cutover comparison total (an
+  incomparable commit case), STOP and report `NEEDS_DECISION`; do not
+  weaken the cutover contract to land the range fix.
+- If a verbatim-pinned message outside the dropped arm must change for
+  the suite to pass, that is a scope violation — STOP and report.
+
+## Git integration
+
+One PR for spec and implementation (repository default, recorded
+policy). Spec committed before implementation on
+`row/CHECKER-STYLE-MERGE-BASE`. The PR body carries `Closes #2366`, and
+`.agents/issue-index.md` gains its append-only row in the same PR.

--- a/scripts/agent-preflight.sh
+++ b/scripts/agent-preflight.sh
@@ -635,11 +635,11 @@ esac
 #
 # The ancestry arm is the one #998 was filed for. It USED to be spelled as a
 # silent `&&` in the condition, so a base that was not an ancestor deleted both
-# gates from the report and the run still printed "All gates green.". The guard
-# itself stays, because check-commit-style.py refuses a non-ancestor base at
-# validate_range (#999 owes that repair, and until it lands, dropping the guard
-# would turn every branch behind main RED instead of honest). What changes is
-# that the skip now SAYS SO and costs the banner.
+# gates from the report and the run still printed "All gates green.". The SKIP
+# arm that replaced it is gone now (#2366): check-commit-style.py walks from
+# the merge base, and `rev-list ${BASE_SHA}..HEAD` selects the branch's own
+# commits under any ancestry, so a branch behind the base runs both gates
+# instead of being told to merge first.
 if [ -z "$BASE_SHA" ]; then
   echo "Commit trailers vs ${BASE_REF}:"
   skip "commit-trailers" "$BASE_UNRESOLVED"
@@ -648,13 +648,6 @@ elif [ "$ANCESTRY_STATUS" -gt 1 ]; then
   echo "Commit trailers vs ${BASE_REF} ${BASE_SHA}:"
   skip "commit-trailers" "$ANCESTRY_UNKNOWN"
   skip "commit-style" "$ANCESTRY_UNKNOWN"
-elif [ "$ANCESTRY_STATUS" -ne 0 ]; then
-  echo "Commit trailers vs ${BASE_REF} ${BASE_SHA}:"
-  TRAILER_BEHIND="${BASE_REF} ${BASE_SHA} is not an ancestor of HEAD, so this
-branch is behind it and the trailer gates did NOT run. Merge ${BASE_REF} and
-rerun. Neither gate reported anything about this tree."
-  skip "commit-trailers" "$TRAILER_BEHIND"
-  skip "commit-style" "$TRAILER_BEHIND"
 elif [ "$RANGE_STATUS" -ne 0 ] || [ "$RANGE_NUMERIC" -eq 0 ]; then
   echo "Commit trailers vs ${BASE_REF} ${BASE_SHA}:"
   skip "commit-trailers" "$RANGE_UNKNOWN"
@@ -704,7 +697,8 @@ fi
 
 # Reachable ONLY when both arrays are empty. A skip used to survive this line,
 # which made the banner a claim the run had not earned (#998). The DEFAULT exit
-# status stays 0 for a skip: a branch behind origin/main is ordinary work, and
+# status stays 0 for a skip: a checkout whose base does not resolve is ordinary
+# work, and
 # exit 1 would merge "a gate did not run" into the signal that means "a gate ran
 # and failed". A caller that cannot read the report asks for --fail-on-skip.
 if [ "${#skipped[@]}" -eq 0 ]; then

--- a/scripts/check-commit-style.py
+++ b/scripts/check-commit-style.py
@@ -100,6 +100,22 @@ def _resolve_commit(repo: Path, revision: str) -> str:
     return resolved[0]
 
 
+def _merge_base(repo: Path, a: str, b: str) -> str:
+    """The merge base of two revisions; raises when they share no history."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", a, b],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError("range base and head have no merge base (unrelated histories)")
+    oid = result.stdout.strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", oid):
+        raise ValueError("merge base did not resolve to one commit")
+    return oid
+
+
 def _is_ancestor(repo: Path, older: str, newer: str) -> bool:
     result = subprocess.run(
         ["git", "-C", str(repo), "merge-base", "--is-ancestor", older, newer],
@@ -122,8 +138,14 @@ def validate_range(
 
     base_oid = _resolve_commit(repo, base)
     head_oid = _resolve_commit(repo, head)
-    if not _is_ancestor(repo, base_oid, head_oid):
-        raise ValueError("range base must be an ancestor of range head")
+    # From the MERGE BASE, not the base tip (#773, ported from
+    # check-commit-trailers.py). CI passes `pull_request.base.sha`, which stops
+    # being an ancestor of head as soon as main advances past the branch -- so
+    # this used to raise and return WITHOUT READING A SINGLE COMMIT, meaning
+    # the style contract was never enforced on any external contribution.
+    # Unrelated histories still fail closed: no merge base means no range, and
+    # inventing one would be worse than refusing.
+    base_oid = _merge_base(repo, base_oid, head_oid)
     cutover_oid = _resolve_commit(repo, cutover) if cutover is not None else None
     if cutover_oid is not None and not _is_ancestor(repo, cutover_oid, head_oid):
         raise ValueError("cutover must be reachable from range head")

--- a/tests/scripts/test_agent_preflight_skip_report.py
+++ b/tests/scripts/test_agent_preflight_skip_report.py
@@ -284,50 +284,51 @@ class PreflightHarness(unittest.TestCase):
 
 
 class SkipIsReportedTests(PreflightHarness):
-    def test_a_non_ancestor_base_reports_skip_and_no_green_banner(self) -> None:
-        """RED before: prints `All gates green.` with the trailer block absent.
+    def test_a_branch_behind_the_base_runs_both_trailer_gates(self) -> None:
+        """RED before: both trailer gates reported SKIP and the ok count fell.
 
-        Occurrence 1 of #998: a branch behind `main`. The two trailer gates were
-        not run, nothing said so, and the banner claimed otherwise.
+        The first occurrence of #998 was a branch behind `main` whose trailer
+        block said nothing. The SKIP arm that replaced the silent `&&` is gone
+        now (#2366): a base that is not an ancestor of HEAD no longer deletes
+        the two gates from the report. `rev-list BASE..HEAD` selects the
+        branch's own commits under any ancestry, and check-commit-style.py
+        walks from the merge base, so a branch behind the base is gated, not
+        skipped.
         """
 
         self.set_origin_main(self.divergent)
         report = self.preflight()
         self.assert_ran_something(report)
 
-        self.assertTrue(
-            any("commit-trailers" in line for line in report.skip),
-            f"the trailer block did not report a SKIP:\n{report}",
+        for label in ("commit-trailers", "commit-style"):
+            with self.subTest(gate=label):
+                self.assertNotIn(
+                    f"SKIP {label}",
+                    report.text,
+                    f"{label} skipped on a branch behind the base:\n{report}",
+                )
+                self.assertIn(
+                    label,
+                    report.ok,
+                    f"{label} did not report ok:\n{report}",
+                )
+        self.assertEqual(
+            [],
+            report.skip,
+            f"a behind-base branch reported a skip:\n{report}",
         )
         self.assertTrue(
-            any("commit-style" in line for line in report.skip),
-            f"the style gate did not report a SKIP:\n{report}",
-        )
-        self.assertFalse(
             report.green,
-            f"a run that skipped {len(report.skip)} gate(s) still printed the "
-            f"green banner:\n{report}",
-        )
-        self.assertIn(
-            "SKIPPED",
-            report.text,
-            f"the summary does not count the skipped gates:\n{report}",
-        )
-        # The reason has to travel with the skip, or the reader learns only that
-        # something did not happen.
-        self.assertIn(
-            "ancestor",
-            report.text,
-            f"no reason printed beside the SKIP:\n{report}",
+            f"both trailer gates ran and passed, but no green banner:\n{report}",
         )
 
     def test_the_ok_count_falls_only_with_a_reported_skip(self) -> None:
-        """RED before: the count falls by two and there are zero SKIP lines.
+        """A gate that stops running has to say so; a behind base stops none.
 
-        This is occurrence 3 exactly, and it is the case that makes a SILENT
-        drop impossible rather than merely unlikely. Asserting the presence of a
-        SKIP line elsewhere does not cover it: a future block could vanish the
-        same way and every other case here would stay green.
+        This was occurrence 3 of #998, back when a non-ancestor base deleted
+        the two trailer gates and the ok count fell without a word. Since
+        #2366 the behind run executes the same gates as the control, so the
+        count cannot fall and no skip is owed for the ancestry alone.
         """
 
         self.set_origin_main(self.base)
@@ -339,19 +340,17 @@ class SkipIsReportedTests(PreflightHarness):
         behind = self.preflight()
         self.assert_ran_something(behind)
 
-        missing = len(ancestor.ok) - len(behind.ok)
-        self.assertGreater(
-            missing,
-            0,
-            "harness precondition failed: the two runs report the same number "
-            f"of gates, so there is no drop to account for.\n{behind}",
+        self.assertEqual(
+            len(ancestor.ok),
+            len(behind.ok),
+            f"{len(ancestor.ok) - len(behind.ok)} gate(s) disappeared from the "
+            "report and no SKIP accounts for them. Every gate that stops "
+            f"running has to say so.\n{behind}",
         )
         self.assertEqual(
-            missing,
-            len(behind.skip),
-            f"{missing} gate(s) disappeared from the report and "
-            f"{len(behind.skip)} were reported as skipped. Every gate that "
-            f"stops running has to say so.\n{behind}",
+            [],
+            behind.skip,
+            f"a behind-base branch reported a skip:\n{behind}",
         )
 
     def test_a_base_that_moves_mid_run_does_not_change_the_verdict(self) -> None:
@@ -467,12 +466,12 @@ class TheBannerStaysReachableTests(PreflightHarness):
     def test_a_skipped_run_exits_zero_and_a_failing_run_does_not(self) -> None:
         """SKIP and FAIL are different facts and keep different exit codes.
 
-        A branch behind `main` is ordinary work, so a skip does not fail the
-        run. Widening exit 1 to mean "a gate did not run" would merge the two
-        facts into one signal, which is the conflation this row removes.
+        A base that does not resolve is ordinary work, so a skip does not fail
+        the run. Widening exit 1 to mean "a gate did not run" would merge the
+        two facts into one signal, which is the conflation this row removes.
         """
 
-        self.set_origin_main(self.divergent)
+        self.unset_origin_main()
         skipped = self.preflight()
         self.assert_ran_something(skipped)
         self.assertNotEqual([], skipped.skip, f"nothing was skipped:\n{skipped}")
@@ -849,13 +848,13 @@ class FailOnSkipTests(PreflightHarness):
     def test_the_flag_makes_a_skip_exit_1_and_the_default_still_exits_0(self) -> None:
         """Both facts in one case, because each is the other's justification.
 
-        Exit 0 by default is the row's own §3.4 decision: a branch behind
-        `origin/main` is ordinary work. Exit 1 under the flag is what a program
+        Exit 0 by default is the row's own §3.4 decision: a checkout whose
+        base does not resolve is ordinary work. Exit 1 under the flag is what a program
         needs, because the exit status carries two of the three states and a
         program cannot read the report that carries the third.
         """
 
-        self.set_origin_main(self.divergent)
+        self.unset_origin_main()
 
         plain = self.preflight()
         self.assert_ran_something(plain)
@@ -924,9 +923,9 @@ class AgentReadyRefusesASkipTests(PreflightHarness):
         )
 
     def test_a_skipped_preflight_stops_the_handoff_gate(self) -> None:
-        """RED before: preflight exits 0 over two skipped gates and this passes."""
+        """RED before: preflight exits 0 over skipped gates and this passes."""
 
-        self.set_origin_main(self.divergent)
+        self.unset_origin_main()
 
         # PRECONDITION: the same tree must actually make preflight skip, or the
         # case below proves nothing about a skip.

--- a/tests/scripts/test_check_commit_style.py
+++ b/tests/scripts/test_check_commit_style.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -139,9 +140,18 @@ class RangeContract(RepositoryTest):
         advances past the branch. The commits under judgement are still the
         branch's own: `merge_base(base, head)..head`. The base tip carries a
         commit head does not contain, which is what makes the range "behind".
+        A violating commit sits below the base tip on the shared history, so
+        both `base..head` and the true `merge_base..head` exclude it. Pinning
+        `_merge_base` to an earlier commit is the only way the range reaches
+        it: a walk that calls the helper but keeps the literal base tip must
+        leave the violation out and fail this test.
         """
 
         repo = self.new_repo()
+        earlier = self.commit(
+            repo, "policy: seed the earlier commit", "Explain the earlier commit."
+        )
+        violation = self.commit(repo, "policy: omit the body on main", None)
         base = self.commit(repo, "policy: establish the base", "Explain the base.")
         git(repo, "switch", "-c", "feature")
         no_body = self.commit(repo, "policy: omit the body", None)
@@ -158,6 +168,19 @@ class RangeContract(RepositoryTest):
         self.assertTrue(any(no_body[:12] in failure for failure in failures))
         self.assertTrue(any(period[:12] in failure for failure in failures))
         self.assertTrue(all(base[:12] not in failure for failure in failures))
+        self.assertTrue(all(violation[:12] not in failure for failure in failures))
+
+        with mock.patch.object(
+            check_commit_style, "_merge_base", return_value=earlier
+        ) as merge_base:
+            resolved = check_commit_style.validate_range(
+                repo, main_tip, period, cutover=None
+            )
+
+        merge_base.assert_called_once()
+        self.assertEqual(len(resolved), 3)
+        self.assertTrue(any(violation[:12] in failure for failure in resolved))
+        self.assertTrue(all(base[:12] not in failure for failure in resolved))
 
     def test_merge_commits_are_excluded(self) -> None:
         repo = self.new_repo()

--- a/tests/scripts/test_check_commit_style.py
+++ b/tests/scripts/test_check_commit_style.py
@@ -132,6 +132,33 @@ class RangeContract(RepositoryTest):
         self.assertTrue(any("authored body" in failure for failure in failures))
         self.assertTrue(any("end in a period" in failure for failure in failures))
 
+    def test_range_base_behind_head_walks_from_the_merge_base(self) -> None:
+        """A base the head has diverged from is walked from its merge base.
+
+        `pull_request.base.sha` stops being an ancestor of head as soon as main
+        advances past the branch. The commits under judgement are still the
+        branch's own: `merge_base(base, head)..head`. The base tip carries a
+        commit head does not contain, which is what makes the range "behind".
+        """
+
+        repo = self.new_repo()
+        base = self.commit(repo, "policy: establish the base", "Explain the base.")
+        git(repo, "switch", "-c", "feature")
+        no_body = self.commit(repo, "policy: omit the body", None)
+        period = self.commit(repo, "policy: end the subject.", "Explain the period.")
+        git(repo, "switch", "main")
+        self.commit(repo, "policy: advance main", "Explain main.")
+        main_tip = git(repo, "rev-parse", "HEAD")
+
+        failures = check_commit_style.validate_range(
+            repo, main_tip, period, cutover=None
+        )
+
+        self.assertEqual(len(failures), 2)
+        self.assertTrue(any(no_body[:12] in failure for failure in failures))
+        self.assertTrue(any(period[:12] in failure for failure in failures))
+        self.assertTrue(all(base[:12] not in failure for failure in failures))
+
     def test_merge_commits_are_excluded(self) -> None:
         repo = self.new_repo()
         base = self.commit(repo, "policy: establish the base", "Explain the base.")
@@ -167,10 +194,14 @@ class RangeContract(RepositoryTest):
         left = self.commit(repo, "policy: advance left", "Explain left.")
         git(repo, "switch", "-c", "right", root)
         right = self.commit(repo, "policy: advance right", "Explain right.")
+        # A genuinely unrelated history: `left` and `right` share `root` as
+        # their merge base and walk from it, so only an orphan branch fails.
+        git(repo, "switch", "--orphan", "isolated")
+        orphan = self.commit(repo, "policy: start an unrelated line", "Explain it.")
 
         cases = (
             ("missing", right, None, "revision"),
-            (left, right, None, "range base must be an ancestor"),
+            (orphan, right, None, "no merge base"),
             (root, right, left, "cutover must be reachable"),
         )
         for base, head, cutover, error in cases:


### PR DESCRIPTION
fix(CHECKER-STYLE-MERGE-BASE): the trailer gates run on a branch behind main (#2366)

Closes #2366

What changed: `scripts/check-commit-style.py::validate_range` walks from
`merge_base(base, head)` instead of refusing any range whose base is not
an ancestor of head, and `scripts/agent-preflight.sh` drops the
ancestry SKIP arm that existed only to compensate for that refusal. A
task branch behind main - the ordinary state mid-campaign - now runs
both trailer gates over its own commits instead of being told "Merge
origin/main and rerun", which is what forced a merge commit into every
PR and punished rebasing an unpushed branch. The commit range the
gates judge is unchanged: `rev-list BASE..HEAD` selects the branch's
own commits under any ancestry.

Why: the refusal was the one asymmetry left between the two checker
walks - the trailers checker has walked from the merge base since #773
(fail-closed on unrelated histories), because CI feeds ranges whose
base stops being an ancestor as soon as main advances. The style
checker never got that port, and preflight's skip arm cited "#999" for
the owed repair - an issue that does not exist on this forge. The
comment now cites this issue and the landed repair. Unrelated
histories still fail closed; the cutover comparison is byte-identical;
the unresolved-base, ancestry-error, and range-count arms keep their
verbatim-pinned texts.

How a reviewer verifies it:

- Red-first: `test_range_base_behind_head_walks_from_the_merge_base`
  raised the old ValueError before the change;
  `test_a_branch_behind_the_base_runs_both_trailer_gates` captured the
  live SKIP pair in the preflight transcript. After the change both are
  green and the three focused suites read 95 tests OK.
- Mutations, fresh reviewer, scratch worktree, byte-for-byte restores:
  (M1) re-adding the ancestor refusal reds the behind-base style test;
  (M2) neutering the merge-base walk reds it after the repair - the
  test patches `_merge_base` to return an earlier commit and asserts a
  style-violating ancestor of the base tip enters the failures only
  through the patched base (red at `2 != 3`, green on restore); (M3)
  re-adding a behind SKIP arm reds the preflight test and the ok-count
  parity test; (M4) making unrelated histories silently pass reds the
  fail-closed test.
- Reachability: every preflight run exercises both surfaces - the
  trailer block on whatever base the branch carries, and the style
  checker through it - so the gates this PR fixes are the gates every
  local run executes, not a class tested in isolation.
- Five existing tests pinned the deleted refusal or the deleted skip
  arm; they now pin the new behavior (fail-closed orphan histories,
  gate-count parity on a behind run, skip exit-code semantics through
  the unresolved-base arm).

Process note, disclosed: the fresh implementer raced two parallel
edits to agent-preflight.sh, detected the dropped edit, re-applied it
and verified by grep before the green run; the first review returned
NOT-PASS on a test-strength finding (the behind-base test could not
detect a neutered walk) and the repair landed as its own commit with
the mutation re-run to red.

Gate classification on this tree: preflight green with the five
arg-gated discovery skips named in #2367 - the main-side defect that
makes agent-ready unsatisfiable on every host since the discovery loop
landed. This PR neither causes nor fixes that; it is classified there
as the named blocker.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]
