### PR TITLE
fix(ci): run the index renderer's suite, not the retired index's (#2371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           python3 scripts/check-agent-record.py --report
           python3 tests/scripts/test_agent_record.py
-          python3 tests/scripts/test_check_issue_index_append_only.py
+          python3 tests/scripts/test_agent_issue_index.py
       - name: Accepted binary-release design and record anchors stay in sync
         run: |
           python3 scripts/check-release-binary-contract.py


### PR DESCRIPTION
fix(ci): run the index renderer's suite, not the retired index's (#2371)

Closes #2371

What changed: the "Canonical roadmap tables and links are consistent"
CI step in .github/workflows/ci.yml re-points its third line from the
deleted tests/scripts/test_check_issue_index_append_only.py at the
retirement's replacement suite tests/scripts/test_agent_issue_index.py.

Why: 7dc2ef1ea retired .agents/issue-index.md and deleted the append-
only test with it, but the step kept invoking the file. Every CI run
since finishes its real work (check-agent-record OK, 113 tests OK) and
then exits 2 on the missing file, reding the agent-record job on
main's own head (da2291339) and on every open PR (#2370, #2368).

Evidence: the named suite passes on this head (31 tests, rc=0); a
fresh reviewer confirmed the diff is exactly one line, that the old
test is absent from origin/main while the replacement exists, that no
other live reference to the deleted file remains, and that the gate
detects a broken reference (mutation: the old line references a
nonexistent file; restored byte-for-byte, sha256 verified).

Classification of the other reds those runs showed, filed rather than
fixed here: the DSA schedule test and glm5_next_weights MSVC build
breaks are #2372, owned by MODEL-TEXT-GLM-MOE-DSA and
MODEL-MM-GLM53-FLASH.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]
