### PR TITLE
fix(BUILD-MAIN-TIP-TESTFIX): main tip builds again — DSA test follows W9, glm5_next_weights stops shadowing (#2372)

### DIFF
--- a/.agents/specs/build-main-tip-testfix.md
+++ b/.agents/specs/build-main-tip-testfix.md
@@ -35,8 +35,8 @@ blocking every PR's CI at the merge ref:
    drives that same schedule, so its call gains the same explicit `nullptr`
    slot. The selection stays where W9 put it: the parameter it names.
 2. Loader: rename the shadowing declarations only — branch-local `v` at line
-   223 becomes `v_group` (use at 224), line 226 becomes `v_inner` (use at
-   227). The first branch's `v` and everything else in the function stay
+   223 becomes `v_group` (use at 225), line 226 becomes `v_inner` (use at
+   228). The first branch's `v` and everything else in the function stay
    byte-identical. No logic, ordering, or refusal behavior changes; both
    `KvInt` calls keep their exact arguments.
 

--- a/.agents/specs/build-main-tip-testfix.md
+++ b/.agents/specs/build-main-tip-testfix.md
@@ -1,0 +1,92 @@
+# Spec — `BUILD-MAIN-TIP-TESTFIX`: main tip builds again — the DSA schedule test follows W9's signature, and glm5_next_weights stops shadowing under MSVC
+
+Issue: [#2372](https://github.com/mudler/vllm.cpp/issues/2372). Owner row:
+`BUILD-MAIN-TIP-TESTFIX` (user-directed take-over of the two facets the issue
+named: MODEL-TEXT-GLM-MOE-DSA's test and MODEL-MM-GLM53-FLASH's warning).
+Branch `row/BUILD-MAIN-TIP-TESTFIX`, base `1e65b8364` (origin/main, pinned at
+worktree creation).
+
+## Scope
+
+Two build breaks on main's tip, neither introduced by any open PR, each
+blocking every PR's CI at the merge ref:
+
+1. `tests/vllm/models/test_glm_moe_dsa_schedule.cpp:304` — the call to
+   `mla::ForwardMlaAttentionBlock` passes 11 arguments. W9 (`11f34effb`,
+   MODEL-TEXT-GLM-MOE-DSA) inserted `Tensor* attn_pre_o_proj` before
+   `MlaSharedSelection* shared`
+   (`src/vllm/model_executor/layers/attention/mla_attention.cpp:423-428`), so
+   the test's `MlaSharedSelection*` lands in the `Tensor*` slot:
+   `error: cannot convert 'vllm::mla::MlaSharedSelection*' to 'vt::Tensor*'`.
+   Breaks `build-test-cpu`, `build-newest-gcc`, and both `sanitize-cpu` jobs.
+2. `src/vllm/model_executor/models/glm5_next_weights.cpp:223,226` — MSVC
+   `warning C4456: declaration of 'v' hides previous local declaration`
+   (twice), escalated by `error C2220` under the Windows -Werror regime. An
+   if-condition declaration is visible in the else branch, so the second and
+   third `const GgufValue* v` of `KdaHeadCount`'s else-if chain shadow the
+   first. gcc/clang do not warn by default, which is why Linux CI stayed
+   green. Breaks both `windows-msvc-*` jobs.
+
+## Design
+
+1. Test: mirror the production call. `glm_moe_dsa_forward.cpp:455-460` passes
+   `/*attn_pre_o_proj=*/nullptr, shared` — "`attn_pre_o_proj` is DeepSeek-V4's
+   early return (#2323); this model applies `o_proj` in the block." The test
+   drives that same schedule, so its call gains the same explicit `nullptr`
+   slot. The selection stays where W9 put it: the parameter it names.
+2. Loader: rename the shadowing declarations only — branch-local `v` at line
+   223 becomes `v_group` (use at 224), line 226 becomes `v_inner` (use at
+   227). The first branch's `v` and everything else in the function stay
+   byte-identical. No logic, ordering, or refusal behavior changes; both
+   `KvInt` calls keep their exact arguments.
+
+## Upstream anchors
+
+vLLM `deepseek_v2.py:1372-1377` (`topk_indices_buffer`), cited by the
+production comment the test call now mirrors (`glm_moe_dsa_forward.cpp:450-454`).
+The test fix carries no behavior change; its anchor is the production call it
+copies. The shadow rename has no upstream anchor — it is a platform-compiler
+constraint of the Windows -Werror regime, not a mirrored behavior.
+
+## Tests
+
+- Red-first (gcc facet): configure and build the `test_glm_moe_dsa_schedule`
+  target on this worktree BEFORE the fix and capture the type error in the
+  build log.
+- Red-first (MSVC facet): impossible on this host — no MSVC. The red evidence
+  is the CI log at PR #2370's head (`windows-msvc-cpu`, C4456 at 223,31 and
+  226,31). Unavoidable adaptation, named here; the arm's green proof is CI on
+  this PR's head.
+- Green: the same target builds and the test binary passes.
+- Mutation: (a) revert the test call to the 11-arg form — the focused build
+  reds again; (b) reintroduce a shadow and compile the TU with `-Wshadow` —
+  gcc flags it, proving a local detection mechanism exists for what only MSVC
+  flags by default.
+- Full gate: `scripts/agent-preflight.sh` on the final head, chained to the
+  exact-SHA push.
+
+## Gates
+
+- Focused: `cmake --build build --target test_glm_moe_dsa_schedule`, then run
+  the test binary.
+- Full: preflight rc=0 on the final head.
+- CI (external authority): the six #2372 job names are expected green on this
+  PR's head — that is the MSVC arm's green evidence. The `agent-record` red
+  (#2371, fixed by #2373) and `documentation-checkpoint` (#2375, main-only)
+  are unrelated and out of scope.
+
+## Stop conditions
+
+- If the `nullptr` slot turns out wrong for this schedule (the test's shared
+  semantics change behavior, not just compilation), STOP and return
+  `NEEDS_DECISION`: the schedule's intent belongs to MODEL-TEXT-GLM-MOE-DSA's
+  W9 owner, not a build repair.
+- If the shadow rename needs to touch anything beyond the two branch
+  declarations and their immediate uses, STOP: the defect is bigger than the
+  CI log shows.
+
+## Git integration
+
+One pull request, spec + fixes together (the repository default; the user
+ordered this row mid-session with no split request). The squash body carries
+`Closes #2372`.

--- a/.agents/specs/build-main-tip-testfix.md
+++ b/.agents/specs/build-main-tip-testfix.md
@@ -27,6 +27,12 @@ blocking every PR's CI at the merge ref:
    first. gcc/clang do not warn by default, which is why Linux CI stayed
    green. Breaks both `windows-msvc-*` jobs.
 
+**Split while in review.** Facet 1 landed on main from an independent find:
+`08fa2f5aa` (#2395) applies the same twelve-argument repair to the schedule
+test, found by building main. The rebased branch (base now `0b4766c96`) drops
+its duplicate of that change as already applied and carries only facet 2. It
+still closes #2372, which names both breaks and this is the one left standing.
+
 ## Design
 
 1. Test: mirror the production call. `glm_moe_dsa_forward.cpp:455-460` passes

--- a/src/vllm/model_executor/models/glm5_next_weights.cpp
+++ b/src/vllm/model_executor/models/glm5_next_weights.cpp
@@ -220,12 +220,12 @@ int64_t KdaHeadCount(const GgufFile& g, const std::string& p,
   if (const GgufValue* v = g.FindKv(p + "attention.linear_head_count")) {
     meta_key = p + "attention.linear_head_count";
     from_meta = KvInt(*v, meta_key);
-  } else if (const GgufValue* v = g.FindKv(p + "ssm.group_count")) {
+  } else if (const GgufValue* v_group = g.FindKv(p + "ssm.group_count")) {
     meta_key = p + "ssm.group_count";
-    from_meta = KvInt(*v, meta_key);
-  } else if (const GgufValue* v = g.FindKv(p + "ssm.inner_size")) {
+    from_meta = KvInt(*v_group, meta_key);
+  } else if (const GgufValue* v_inner = g.FindKv(p + "ssm.inner_size")) {
     const std::string inner_key = p + "ssm.inner_size";
-    const int64_t inner = KvInt(*v, inner_key);
+    const int64_t inner = KvInt(*v_inner, inner_key);
     VT_CHECK(inner > 0 && inner % kda_head_dim == 0,
              "glm5_next gguf: " + inner_key + " is " + std::to_string(inner) +
                  " and " + p + "kda.head_dim is " +


### PR DESCRIPTION
fix(BUILD-MAIN-TIP-TESTFIX): glm5_next_weights stops shadowing v under MSVC -Werror (#2372)

Closes #2372

What changed: the loader facet of main-tip's build break. The other facet the
issue named, the schedule test's 11-argument call, landed on main from an
independent find while this row was in review — `08fa2f5aa` (#2395) applies
the same twelve-argument repair — so the rebased branch drops its duplicate
as already applied and carries one fix.

`src/vllm/model_executor/models/glm5_next_weights.cpp` — `KdaHeadCount`'s
else-if chain declared `const GgufValue* v` three times. An if-condition
declaration is visible in the else branch, so the declarations at 223 and
226 shadow the one at 220; MSVC /W4 reports C4456 twice and the Windows
-Werror regime escalates to C2220, reding both `windows-msvc-*` jobs.
gcc/clang do not warn by default, which is why every Linux build stayed
green. The fix renames only the two shadowing declarations and their
immediate uses (`v_group`, `v_inner`); no behavior change.

Evidence: red captured locally before the fix — the loader compile under
the shadow form is what MSVC reded on; after the fix, `gcc -Wshadow` on the
TU flags exactly 223:31/226:31 on the pre-fix form and nothing there after —
the project builds with -Werror but without -Wshadow, which is how this
stayed invisible on Linux. CI on this PR's previous head already proved the
gcc facet of the issue green: `build-test-cpu`, `build-newest-gcc`, and both
`sanitize-cpu` jobs, including the schedule test that the landing of
`08fa2f5aa` now keeps green on main. On the Windows arm, this PR's CI round
shows the compile error gone — no C4456/C2220 anywhere in either
windows-msvc log; the residual red there is a new, distinct defect:
`test_openai_api_server.exe` aborts at runtime (0xC0000409) in 3 of 79
cases, filed as #2403 with the same first-execution exposure as this break
(those binaries could not link until the compile error cleared). Fresh
reviewer verdict: PASS on all six guarantees with each mutation restored
byte-for-byte; its two prose findings (line numbers in the spec and in the
loader commit body) are repaired in-tree.

Remaining red after this lands, out of scope: `windows-msvc-*` (#2403,
owned by the api_server row; not caused by this change) and
`documentation-checkpoint` (#2375, main-only, owned by the gate).

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]
