### PR TITLE
fix(ENG-PREFLIGHT-COMPILES): shrink the runnable pin after the row went PARTIAL (#2401)

### DIFF
--- a/scripts/check-gate-commands.py
+++ b/scripts/check-gate-commands.py
@@ -463,14 +463,18 @@ def audit() -> list[dict]:
 # reachable on this fleet. The credit returns when the row reaches a gate-obliged
 # state, which its W2 does.
 RUNNABLE_BASELINE = frozenset({
-    # 2026-08-31: +ENG-PREFLIGHT-COMPILES. GROWTH, and earned: the row arrives
-    # `ACTIVE` (#2401) and its spec's `## Gates` section names
-    # `python3 tests/scripts/test_check_tree_compiles.py` and
-    # `python3 scripts/check-tree-compiles.py --base origin/main`, both of which
-    # can fail. Re-pinned in the same change that added the row, as the note
-    # above requires, and `test_dropping_preflight_compiles_from_the_pin_breaks_it`
-    # proves the entry was earned rather than added to quiet this gate.
-    "ENG-PREFLIGHT-COMPILES",
+    # 2026-08-31: -ENG-PREFLIGHT-COMPILES. SHRINKAGE, and legitimate: b39f14adb
+    # moved the row `ACTIVE` -> `PARTIAL` when the compile gate landed (#2401),
+    # which takes it out of GATED_STATES and therefore out of this audit's
+    # population. The re-pin belonged in that change and is happening here
+    # instead -- the record edit and the pin repair are two commits, which is
+    # the shape the checker's message exists to make visible, not to prevent:
+    # `check-gate-commands --check` was red on every main checkout in between.
+    # The row's `## Gates` section is untouched; if the row re-enters a gated
+    # state, its two runnable commands re-earn the entry and the baseline
+    # grows back in that change. (The entry arrived earlier the same day,
+    # `274dc7a06`, when the row was still `ACTIVE`; its earned-growth note is
+    # in that commit.)
     # 2026-08-30: +MODEL-TEXT-deepseek-v2-glm-moe-dsa-for-causal-lm. GROWTH, and
     # not because the row gained a gate: it re-entered the AUDITED population
     # when W2 (#2214) moved it `SPIKE` -> `ACTIVE`, and its spec's `### Gates`

--- a/tests/scripts/test_check_gate_commands.py
+++ b/tests/scripts/test_check_gate_commands.py
@@ -987,21 +987,6 @@ class RatchetTests(unittest.TestCase):
         self.assertEqual(runnable - reduced, {"ENG-CUDAGRAPH-BREAK"})
         self.assertEqual(runnable, set(gates.RUNNABLE_BASELINE))
 
-    def test_dropping_preflight_compiles_from_the_pin_breaks_it(self):
-        # ENG-PREFLIGHT-COMPILES (#2401) arrives `ACTIVE` with a `## Gates`
-        # section naming `tests/scripts/test_check_tree_compiles.py` and
-        # `scripts/check-tree-compiles.py --base origin/main`, so it enters the
-        # runnable population and the baseline grows by one. Same shape and same
-        # reason as the two rows above: the exact pin proves the SET agrees,
-        # which holds for any membership and cannot say this row belongs. This
-        # says it -- remove the entry and set equality has to go red.
-        reduced = set(gates.RUNNABLE_BASELINE) - {"ENG-PREFLIGHT-COMPILES"}
-        self.assertNotEqual(reduced, set(gates.RUNNABLE_BASELINE))
-        runnable = {r["id"] for r in gates.audit() if r["verdict"] == "runnable"}
-        self.assertNotEqual(runnable, reduced)
-        self.assertEqual(runnable - reduced, {"ENG-PREFLIGHT-COMPILES"})
-        self.assertEqual(runnable, set(gates.RUNNABLE_BASELINE))
-
     def test_hf_model_download_earns_its_runnable_baseline_entry(self):
         # ENG-HF-MODEL-DOWNLOAD (#1280) arrives at READY, so it enters the gated
         # population for the first time and the baseline grows by one. Same


### PR DESCRIPTION
fix(ENG-PREFLIGHT-COMPILES): shrink the runnable pin after the row went PARTIAL (#2401)

b39f14adb moved the row ACTIVE -> PARTIAL when the compile gate landed,
which takes it out of GATED_STATES and therefore out of the audited
population. The checker's contract requires the RUNNABLE_BASELINE re-pin
in the same change as such a record edit; that re-pin did not happen, so
`check-gate-commands --check` exited 1 ("baseline rows left the gated
population") and 12 assertions of its mutation suite failed on every
main checkout since, preflight included.

This change re-pins by removal: the entry leaves the set under a dated
shrinkage note naming b39f14adb, and the per-entry mutation test whose
premise (the row arrives ACTIVE) is void is retired with it. The
property that test shared -- the pin EQUALS the shipped runnable set, so
neither side moves quietly -- stays enforced by
test_the_baseline_matches_the_shipped_record and the remaining per-entry
dropping cases. The row's `## Gates` section is untouched; a return to a
gated state re-earns the entry in that change.

Red-before: pristine main 6a544bdb8, --check exit 1, suite FAILED
(failures=12). Green-after: --check exit 0, suite 58/58 OK, full
agent-preflight green on this tree.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]

