### PR TITLE
record(BACKEND-TENSTORRENT-KEEPQUANT): W4c stopped at the band — the lane gate lands red (#3079)

### DIFF
--- a/.agents/specs/tenstorrent-keepquant.md
+++ b/.agents/specs/tenstorrent-keepquant.md
@@ -424,11 +424,11 @@ to make a failure pass.
   literally true.
 - Block-decoding n-gram gather ([#2394](https://github.com/mudler/vllm.cpp/issues/2394)).
 - IQ-family / sub-IQ1_S encodings (unsloth fork formats).
-- The int8-dot lane's e2e gate wave and production routing
-  ([#3079](https://github.com/mudler/vllm.cpp/issues/3079)); the
-  llama.cpp-comparable throughput floor rides with it. The lever itself
-  landed op-level behind `VT_TT_KEEPQUANT_INT8DOT` (#3031, default
-  off).
+- The int8-dot lane's e2e gate wave and production routing — MOVED
+  INTO W4c SCOPE ([#3079](https://github.com/mudler/vllm.cpp/issues/3079)).
+  The lever itself landed op-level behind `VT_TT_KEEPQUANT_INT8DOT`
+  (#3031, default off); the llama.cpp-comparable throughput floor
+  remains [#1003](https://github.com/mudler/vllm.cpp/issues/1003)'s.
 - `docs/USAGE.md` vehicle pin when the arm first runs end to end (the W3
   capture leg hashes the local bytes); the 27B arm entry LANDED with
   wave-3b-2, provenance caveat included — the gate-completion half of that
@@ -577,6 +577,97 @@ Quantized-domain integer vec_dot behind the same seam; profile-first
 attribution; recorded-only throughput floor. Sequenced after W4a, never
 bundled.
 
+## W4c — the lane gate and production routing (#3079)
+
+- **Scope.** The int8-dot lane (#3031) is op-level exact and
+  capture-safe, but no committed gate adjudicates the lane end to end,
+  the env knob is classified kernel-internal, and the vehicle's
+  default-config reach is the op suite's opt-in only. This wave gives
+  the lane its own oracle pair, its committed e2e gate, the
+  user-facing configuration surface, and the recorded profile. The
+  default-config flip stays OUT of scope — a product decision recorded
+  as NEEDS_DECISION; the wave's deliverable is that the env-set
+  configuration is supported and gateable.
+- **The lane's denominator.** The ROCm-domain pair cannot adjudicate
+  the lane (W4b outcome: the ≤500-mnat band fails at (5,7) 1125 mnats
+  with determinism proven, and the flip is the quantized domain's
+  authentic behavior at a non-tie boundary). The lane implements the
+  pinned llama.cpp `b10451` integer `vec_dot` domain bit-exactly per
+  op, so its e2e denominator is llama.cpp itself: the registered
+  `llama-cpp` oracle (gateable = yes, `.agents/oracles/llama-cpp.md`),
+  same artifact, same 16 prompts, same greedy discipline. This is the
+  issue's named candidate. The alternative — widening the ROCm-domain
+  band to cover the measured drift — is rejected as exactly the silent
+  widening the issue forbids: a band that only legalizes the drift we
+  already saw adjudicates nothing.
+- **Mechanism.** (1) Oracle side: `llama-perplexity
+  --save-all-logits` at the pin dumps per-position logits for the 16
+  prompt texts; the gap script gains an oracle mode that reads the
+  dump and computes, for each of OUR prefix positions,
+  argmax − ours in mnats — the ROCm pair's exact methodology, a
+  different oracle. Teacher-force on OUR prefix (the capture's ids),
+  never on the oracle's own continuation. The pinned build needs the
+  root libs (`LD_LIBRARY_PATH=/tmp/llamacpp-b10451`; the `build/bin`
+  set alone fails on `common_prompt_batch_decode`). (2) Our side: the
+  documented dump path with `VT_TT_KEEPQUANT_INT8DOT=1`. The pair
+  lands under `tests/parity/goldens/qwen35_gguf_q4km_lanegate/` in the
+  established convention (`.npy` pairs + `p{i}_prompt.i32`), with the
+  recipe (tool, exact flags, thread pin, artifact sha256) in
+  `## Evidence`. Load fidelity is recorded for the vehicle artifact
+  the way the oracle file mandates for the 27B: tensors loaded,
+  tensors dropped (if any), MTP/`nextn` disposition. (3) Precision
+  guard: the dump's float formatting must survive log_softmax; if the
+  CSV precision is insufficient, fall back to a minimal reader against
+  `libllama` at the pin (`llama_get_logits_ith`) — recorded as an
+  unavoidable adaptation, never a silent one.
+- **The gate.** A new opt-in battery (`VT_TT_KEEPQUANT_INT8DOT=1`,
+  loud named skip on default) runs the vehicle's captured production
+  path over the 16 prompts and adjudicates against the lane pair: 0
+  forward-divergent cells, every flip inside the ratified band, dump
+  ×2 byte-identity across reset (the W4b determinism proof, committed
+  as a leg), trace demand reported per run. The band starts at the
+  row's ≤500 mnats. The pair's measured gap distribution is recorded
+  in the spec amendment that lands with the pair; a wider band is an
+  EXPLICIT amendment with the distribution beside it — never prose.
+  Stop-and-report if the distribution demands ≥2× the starting band
+  (≥1000 mnats): that magnitude says the lane diverges from its own
+  domain reference, which is a bug hunt, not a band.
+- **Red-first.** Before the pair exists, the battery reds by absence —
+  a loud skip naming the missing pair is not a pass. The committed
+  mutation leg: invert one adjudication assertion in a scratch copy
+  and red the battery on the W4b-known drift cell (5,7) — the gate
+  must detect by machine what the W4b analysis found by hand.
+- **Routing and docs.** `docs/ENVIRONMENT.md` gains the
+  `VT_TT_KEEPQUANT_INT8DOT` entry and the allowlist line moves out
+  (check-env-doc enforces the pairing). `docs/USAGE.md` gains the
+  lever section: the artifact pin (unchanged from the W3 arm entry),
+  the env configuration, the drift statement (lane vs the llama.cpp
+  pair band; lane vs the ROCm-domain oracle is NOT band-adjudicated
+  and says so), and the capture-demand numbers. The throughput floor
+  stays recorded-only: the vehicle decode A/B (lever on vs off, same
+  build, idle host, flock mutex) lands in `## Evidence` and a
+  `docs/benchmarks/` detail page; the llama.cpp-comparable floor
+  itself remains [#1003](https://github.com/mudler/vllm.cpp/issues/1003)'s
+  owed measurement.
+- **Risks.** (1) The dump's CSV precision loses ulps that matter at
+  band-edge cells — the precision guard and the fallback reader cover
+  it. (2) `llama-perplexity` may run the GDN hybrid's graph
+  differently than `llama-completion` did — the load-fidelity record
+  plus one greedy cross-check (completion vs perplexity, prompt p0)
+  catch it before the pair is built. (3) The band does not fit 500 —
+  the explicit-amendment rule above; ≥1000 mnats stops the wave.
+  (4) The 0.8B artifact drops tensors in llama.cpp — recorded; a
+  dropped tensor that changes the graph disqualifies the pair and
+  reopens the denominator choice (NEEDS_DECISION).
+- **Gates and stop conditions.** Preflight; default op suite unchanged
+  (lane tests skipping loudly); default vehicle battery unchanged (W4a
+  16/16 — the invariant); the new lane battery green opt-in; dump ×2
+  identity; check-env-doc pairing. Stop: any default-path regression;
+  a band amendment without its distribution; a lane flip outside the
+  band treated as pass; the oracle pin moving.
+- **PR shape.** One PR, spec and implementation (row claim answer
+  2026-09-05, recorded; the spec commits first inside it).
+
 ## Now
 
 `ACTIVE`, 2026-09-06. W1 complete (#2989, open). W2 complete on the row
@@ -663,5 +754,10 @@ matched), scoped re-review of the repair PASS with no findings; the
 CI failures on the PR (windows api_server explicit-cpu/embeddings
 0xC0000409, TSan gemma4 fp8 arm guard, UBSan misaligned loads in the
 AVX cpu matmul) are inherited from `main`'s red and touch no path in
-the diff. The worktree and branch are retired. Next: #3079 (the lane's
-e2e gate wave + production routing + the user-facing env doc).
+the diff. The worktree and branch are retired. AMENDED 2026-09-09
+(eleventh): records reconciled on `main` (#3114), and W4c opens under
+`## W4c` — the lane gate and production routing (#3079): the
+llama.cpp-domain oracle pair per the registered-oracle rule, the
+committed opt-in lane battery with dump ×2 identity, the user-facing
+env doc, the recorded vehicle decode A/B; the default-config flip
+stays a NEEDS_DECISION.

--- a/scripts/qwen3-neartie-gap-llamacpp-oracle.py
+++ b/scripts/qwen3-neartie-gap-llamacpp-oracle.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Teacher-forced near-tie gap for the int8-dot LANE pair, with the PINNED
+# llama.cpp b10451 as the oracle (KEEPQUANT W4c, issue #3079).
+#
+# Gap semantics are identical to scripts/qwen3-neartie-gap-transformers.py
+# (the ROCm-domain reference): teacher-force on OUR captured prefix, gap at
+# cell (i, j) = max(0, argmax_logp - our_logp) in nats over the oracle's own
+# logits at position P+j-1, reported in mnats; gap == 0 with different ids is
+# an exact tie (legit); a cell whose gap exceeds the ratified band is a
+# forward divergence. The only difference is the oracle: raw f32 logits
+# dumped from the pinned libllama (llama_get_logits_ith) by the minimal
+# reader, instead of a HF model — `llama-perplexity --save-all-logits` at the
+# pin cannot serve (65535-level uint16-quantized log-softmax rows, positions
+# n_ctx/2..n_ctx-2 only, >= 2*n_ctx tokens required; see the row spec).
+#
+# Oracle dump layout (written by the reader, little-endian):
+#   char[8] "VTLGDUMP"; int32 n_positions; int32 n_vocab;
+#   per position: int32 token_id, then n_vocab float32 logits.
+# The reader's dump is self-describing: the script verifies the embedded
+# token ids equal prompt_ids + our_ids per prompt (bit-level proof the oracle
+# teacher-forced OUR prefix), and that n_vocab == 248320.
+#
+# Emits into --golden-dir:
+#   our_ids.npy            [N,T] i32   (from the raw .i32 capture)
+#   neartie_gap_mnats.npy  [N,T] i32   (99_999_000 = outside top-K)
+#   greedy_ids.npy         [N,T] i32   (optional: the pin's greedy, from
+#                                       --greedy-prefix greedy_p{i}.i32)
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import sys
+
+import numpy as np
+
+PROMPTS = [
+    "The capital of France is",
+    "Once upon a time,",
+    "In the beginning God created",
+    "The quick brown fox jumps over",
+    "def fibonacci(n):",
+    "Water boils at a temperature of",
+    "The theory of relativity was developed by",
+    "To be or not to be, that is",
+    "The largest planet in our solar system is",
+    "Machine learning is a subfield of",
+    "The mitochondria is the powerhouse of",
+    "Roses are red, violets are",
+    "The first president of the United States was",
+    "E equals m c",
+    "A journey of a thousand miles begins with",
+    "The chemical symbol for gold is",
+]
+OUTSIDE_TOPK_MNATS = 99_999_000
+MAGIC = b"VTLGDUMP"
+
+
+def read_dump(path: str):
+    raw = open(path, "rb").read()
+    if raw[:8] != MAGIC:
+        raise SystemExit(f"{path}: bad magic {raw[:8]!r}")
+    n, n_vocab = struct.unpack_from("<ii", raw, 8)
+    off = 16
+    toks = np.empty(n, dtype="<i4")
+    rows = np.empty((n, n_vocab), dtype=np.float32)
+    for i in range(n):
+        toks[i], = struct.unpack_from("<i", raw, off)
+        off += 4
+        rows[i] = np.frombuffer(raw, dtype="<f4", count=n_vocab, offset=off)
+        off += 4 * n_vocab
+    if off != len(raw):
+        raise SystemExit(f"{path}: trailing bytes ({len(raw) - off})")
+    return toks, rows
+
+
+def log_softmax(row: np.ndarray) -> np.ndarray:
+    # float64 accumulation for a stable difference at band-edge cells; the
+    # logits themselves are the oracle's raw f32.
+    r = row.astype(np.float64)
+    m = r.max()
+    return r - (m + np.log(np.exp(r - m).sum()))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--golden-dir", required=True)
+    ap.add_argument("--oracle-dir", required=True,
+                    help="dir with oracle_logits_p{i}.dump from the reader")
+    ap.add_argument("--our-ids", default="our_ids.i32",
+                    help="raw int32 dump from VT_DUMP_IDS (N*T LE i32)")
+    ap.add_argument("--max-tokens", type=int, default=16)
+    ap.add_argument("--topk", type=int, default=20)
+    ap.add_argument("--greedy-prefix", default="greedy_p{i}.i32",
+                    help="optional per-prompt pin greedy ids (builds "
+                         "greedy_ids.npy); empty string skips")
+    args = ap.parse_args()
+
+    gdir, odir = args.golden_dir, args.oracle_dir
+    our_path = os.path.join(gdir, args.our_ids)
+    if not os.path.isfile(our_path):
+        print(f"missing {our_path}", file=sys.stderr)
+        return 1
+    our = np.fromfile(our_path, dtype="<i4")
+    N = len(PROMPTS)
+    T = args.max_tokens
+    if our.size != N * T:
+        print(f"{our_path}: {our.size} ids, expected {N}*{T}", file=sys.stderr)
+        return 1
+    our = our.reshape(N, T)
+
+    greedy = None
+    if args.greedy_prefix:
+        g = np.zeros((N, T), dtype="<i4")
+        for i in range(N):
+            p = os.path.join(odir, args.greedy_prefix.format(i=i))
+            if not os.path.isfile(p):
+                print(f"missing {p}", file=sys.stderr)
+                return 1
+            g[i] = np.fromfile(p, dtype="<i4")
+        greedy = g
+
+    gap_mnats = np.zeros((N, T), dtype="<i4")
+    max_gap = 0.0
+    worst = None
+    n_div = 0
+    n_flip = 0
+    n_exact_tie = 0
+    dist = np.zeros(N, dtype="<i4")  # per-prompt max gap
+    print(f"=== teacher-forced near-tie gap (llama.cpp b10451 oracle, "
+          f"raw-f32 dumps): {gdir} ===")
+    for i in range(N):
+        pfile = os.path.join(gdir, f"p{i}_prompt.i32")
+        prompt_ids = np.fromfile(pfile, dtype="<i4").tolist()
+        P = len(prompt_ids)
+        our_ids = [int(x) for x in our[i]]
+        toks, rows = read_dump(os.path.join(odir, f"oracle_logits_p{i}.dump"))
+        expect = np.array(prompt_ids + our_ids, dtype="<i4")
+        if toks.tolist() != expect.tolist():
+            print(f"  p{i:2d}: DUMP token ids do not teacher-force OUR prefix",
+                  file=sys.stderr)
+            return 1
+        for j in range(T):
+            row = rows[P + j - 1]
+            logp = log_softmax(row)
+            our_tid = our_ids[j]
+            k = min(args.topk, logp.shape[0])
+            topi = np.argpartition(-logp, k - 1)[:k]
+            top_set = {int(t) for t in topi}
+            arg_tid = int(np.argmax(logp))
+            arg_lp = float(logp[arg_tid])
+            if our_tid in top_set:
+                our_lp = float(logp[our_tid])
+                gap = max(0.0, arg_lp - our_lp)
+                gap_mnats[i, j] = int(round(gap * 1000.0))
+                if gap > 0.0 and our_tid != arg_tid:
+                    n_flip += 1
+                if gap == 0.0 and our_tid != arg_tid:
+                    n_exact_tie += 1
+                if gap > max_gap:
+                    max_gap, worst = gap, (i, j, gap)
+            else:
+                gap_mnats[i, j] = OUTSIDE_TOPK_MNATS
+                print(
+                    f"  p{i:2d} tok{j:2d}: OUR TOKEN {our_tid} OUTSIDE "
+                    f"top-{args.topk}")
+            if greedy is not None and our_ids[j] != int(greedy[i, j]):
+                n_div += 1
+                print(
+                    f"  p{i:2d} tok{j:2d}: our={our_tid} "
+                    f"llamacpp_greedy={int(greedy[i, j])} "
+                    f"tf_argmax={arg_tid} gap={gap_mnats[i, j] / 1000.0:.4f} "
+                    f"nats")
+        dist[i] = gap_mnats[i].max()
+        print(f"  prompt {i:2d}: max gap {dist[i] / 1000.0:.4f} nats")
+        print(f"  prompt {i}/{N - 1} done")
+
+    order = np.argsort(-dist)
+    print("=== per-prompt max gap (mnats), worst first ===")
+    for i in order:
+        print(f"  p{i:2d}: {dist[i]}")
+    if worst is not None:
+        print(f"=== worst cell {worst[0]},{worst[1]} gap {worst[2] * 1000.0:.0f}"
+              f" mnats; flips(argmax!=ours,gap>0)={n_flip} "
+              f"exact-ties(gap==0,ids differ)={n_exact_tie} "
+              f"token-divergent vs greedy_ids={n_div} ===")
+    ids_out = os.path.join(gdir, "our_ids.npy")
+    gap_out = os.path.join(gdir, "neartie_gap_mnats.npy")
+    np.save(ids_out, our)
+    np.save(gap_out, gap_mnats)
+    if greedy is not None:
+        gout = os.path.join(gdir, "greedy_ids.npy")
+        np.save(gout, greedy)
+    print(f"wrote {ids_out} + {gap_out} + greedy {gap_mnats.shape}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen3-neartie-gap-llamacpp-oracle.py
+++ b/scripts/qwen3-neartie-gap-llamacpp-oracle.py
@@ -54,6 +54,7 @@ PROMPTS = [
 ]
 OUTSIDE_TOPK_MNATS = 99_999_000
 MAGIC = b"VTLGDUMP"
+EXPECTED_N_VOCAB = 248_320  # the qwen3 vocab this script is written for
 
 
 def read_dump(path: str):
@@ -61,6 +62,8 @@ def read_dump(path: str):
     if raw[:8] != MAGIC:
         raise SystemExit(f"{path}: bad magic {raw[:8]!r}")
     n, n_vocab = struct.unpack_from("<ii", raw, 8)
+    if n_vocab != EXPECTED_N_VOCAB:
+        raise SystemExit(f"{path}: n_vocab {n_vocab}, expected {EXPECTED_N_VOCAB}")
     off = 16
     toks = np.empty(n, dtype="<i4")
     rows = np.empty((n, n_vocab), dtype=np.float32)

--- a/tests/parity/test_qwen35_paged_engine.cpp
+++ b/tests/parity/test_qwen35_paged_engine.cpp
@@ -538,6 +538,235 @@ void RunGate(const std::string& golden_subdir, const char* label,
   REQUIRE(fail == 0);
 }
 
+// KEEPQUANT W4c (issue #3079): the int8-dot LANE's own end-to-end gate.
+//
+// The lane (W4b's `VT_TT_KEEPQUANT_INT8DOT`, op-level bit-exact vs the pinned
+// llama.cpp `ggml_vec_dot_*` integer domain) cannot be adjudicated by the
+// ROCm-domain pair — the W4b outcome recorded the ≤500-mnat band failing at
+// cell (5,7) with 1125 mnats there. The lane's denominator is therefore the
+// `llama-cpp` oracle ITSELF (registered, gateable = yes): this battery runs
+// the vehicle's captured production path over the standard 16-prompt battery
+// with the lever ON and adjudicates against the LANE pair committed under
+// tests/parity/goldens/qwen35_gguf_q4km_lanegate/ — the pin's teacher-forced
+// gap on OUR captured prefix, in the established pair convention. Adjudication
+// mirrors RunGate exactly: anchor drift is a hard REQUIRE (regression
+// suspect), 0 forward-divergent cells, every flip inside the ratified band,
+// an exact tie with a different id is legit (gap 0 is inside any band). The
+// determinism leg re-runs the battery in-process through a SECOND engine load
+// (a second decode-graph capture — the op-level capture test's x2
+// byte-identity mechanism at vehicle scale) and REQUIREs the byte-identical
+// token stream, reporting the device trace demand per run.
+//
+// Opt-in by design: the lever is default OFF (the default-config flip is a
+// recorded NEEDS_DECISION), so without VT_TT_KEEPQUANT_INT8DOT this gate
+// skips loudly and the default vehicle battery above stays the W4a invariant.
+constexpr int32_t kLaneBandMnats = 500;  // the row's ratified starting band
+
+void RunLaneGate(const std::string& golden_subdir, const char* label,
+                 const std::string& model) {
+  const fs::path gdir = fs::path(PARITY_GOLDENS_DIR) / golden_subdir;
+  const bool dump = std::getenv("VT_DUMP_IDS") != nullptr;
+  const bool have_anchor = fs::exists(gdir / "our_ids.npy");
+  const bool have_gap = fs::exists(gdir / "neartie_gap_mnats.npy");
+  if (!have_anchor || !have_gap) {
+    if (dump) {
+      // BOOTSTRAP: the lane pair does not exist yet — generate the 16
+      // prompts with the lever ON and dump OUR token ids so the pinned
+      // llama.cpp oracle can teacher-force them
+      // (scripts/qwen3-neartie-gap-llamacpp-oracle.py).
+      MESSAGE(label << ": BOOTSTRAP dump (lane pair absent) via "
+                       "FromModelDir("
+                    << model << ") with VT_TT_KEEPQUANT_INT8DOT=1...");
+      std::unique_ptr<vllm::entrypoints::LoadedEngine> le =
+          vllm::entrypoints::LoadedEngine::FromModelDir(
+              model, vllm::entrypoints::EngineParams{});
+      std::vector<int32_t> buf;
+      for (size_t i = 0; i < Prompts().size(); ++i) {
+        const vllm::RequestOutput out = le->engine().generate(
+            Prompts()[i], Greedy(16), "laneboot" + std::to_string(i));
+        REQUIRE(out.finished);
+        const std::vector<int32_t>& got = out.outputs[0].token_ids;
+        REQUIRE(static_cast<int64_t>(got.size()) == 16);
+        buf.insert(buf.end(), got.begin(), got.end());
+      }
+      const fs::path path = gdir / "our_ids.i32";
+      std::FILE* f = std::fopen(path.string().c_str(), "wb");
+      if (f != nullptr) {
+        std::fwrite(buf.data(), sizeof(int32_t), buf.size(), f);
+        std::fclose(f);
+      }
+      MESSAGE(label << " BOOTSTRAP dumped our token ids -> " << path);
+      SkipGate(label, "bootstrap does not run the correctness gate. Run "
+                      "scripts/qwen3-neartie-gap-llamacpp-oracle.py, commit "
+                      "the lane pair, then rerun without VT_DUMP_IDS");
+    }
+    // RED-BY-ABSENCE: a loud skip naming the missing pair is NOT a pass —
+    // the opt-in battery must FAIL until the lane pair exists.
+    const bool have_pair = have_anchor && have_gap;
+    REQUIRE_MESSAGE(have_pair == true,
+                    label << ": the LANE PAIR IS ABSENT in " << gdir
+                          << " (our_ids.npy: " << have_anchor
+                          << ", neartie_gap_mnats.npy: " << have_gap
+                          << ") — capture with VT_DUMP_IDS=1 under "
+                             "VT_TT_KEEPQUANT_INT8DOT=1, build the pair with "
+                             "scripts/qwen3-neartie-gap-llamacpp-oracle.py "
+                             "(pinned llama.cpp b10451 oracle), and commit it. "
+                             "This failure is the red-first evidence");
+  }
+
+  MESSAGE(label << ": loading via FromModelDir(" << model << ")...");
+  std::unique_ptr<vllm::entrypoints::LoadedEngine> loaded =
+      vllm::entrypoints::LoadedEngine::FromModelDir(model,
+                                                    vllm::entrypoints::EngineParams{});
+  const vt::DeviceType run_dev = loaded->runner().device().type;
+  REQUIRE_MESSAGE(run_dev == vt::DeviceType::kTENSTORRENT,
+                  label << ": the lane battery is Tenstorrent-only; this run "
+                           "is on device type "
+                        << static_cast<int>(run_dev));
+  REQUIRE(vt::OpRegistered(vt::OpId::kMatmulBTQuant, run_dev));
+  vt::ResetOpProviderStats(vt::OpId::kMatmulBTQuant, run_dev);
+  vt::EnableOpProviderCallStats(true);
+
+  const parity::NpyArray g = parity::LoadNpy((gdir / "greedy_ids.npy").string());
+  const parity::NpyArray o = parity::LoadNpy((gdir / "our_ids.npy").string());
+  const parity::NpyArray gap = parity::LoadNpy((gdir / "neartie_gap_mnats.npy").string());
+  REQUIRE(g.dtype == "<i4");
+  REQUIRE(o.dtype == "<i4");
+  REQUIRE(gap.dtype == "<i4");
+  const int64_t N = g.shape[0];
+  const int64_t T = g.shape[1];
+  REQUIRE(static_cast<size_t>(N) == Prompts().size());
+  REQUIRE(o.shape.size() == 2);
+  REQUIRE(o.shape[0] == N);
+  REQUIRE(o.shape[1] == T);
+  REQUIRE(gap.shape.size() == 2);
+  REQUIRE(gap.shape[0] == N);
+  REQUIRE(gap.shape[1] == T);
+  const int32_t* gd = AsI32(g);
+  const int32_t* od = AsI32(o);
+  const int32_t* gapd = AsI32(gap);
+
+  if (vt::tenstorrent::DecodeCaptureEnabled())
+    vt::tenstorrent::ResetKeepQuantCaptureStagingWritesForTest();
+
+  int strict_exact = 0;
+  int neartie_only = 0;
+  int fail = 0;
+  int32_t worst_gap = 0;
+  int worst_i = -1, worst_j = -1;
+  std::vector<int32_t> run1;
+  for (int64_t i = 0; i < N; ++i) {
+    const vllm::RequestOutput out = loaded->engine().generate(
+        Prompts()[static_cast<size_t>(i)], Greedy(static_cast<int>(T)),
+        "lane" + std::to_string(i));
+    REQUIRE(out.finished);
+    const std::vector<int32_t>& got = out.outputs[0].token_ids;
+    REQUIRE(static_cast<int64_t>(got.size()) == T);
+    run1.insert(run1.end(), got.begin(), got.end());
+
+    int first_div = -1;
+    for (int64_t j = 0; j < T; ++j) {
+      if (got[static_cast<size_t>(j)] != od[i * T + j]) {
+        first_div = static_cast<int>(j);
+        break;
+      }
+    }
+    REQUIRE_MESSAGE(first_div < 0,
+                    label << " anchor drift prompt[" << i << "] tok=" << first_div
+                          << " engine="
+                          << (first_div < 0 ? -1 : got[static_cast<size_t>(first_div)])
+                          << " committed lane anchor="
+                          << (first_div < 0 ? -1 : od[i * T + first_div])
+                          << " — REGRESSION SUSPECTED: the lane capture is the "
+                             "fixed lever path's sequence; re-derive only after "
+                             "the drift is proven a justified numerical change");
+    bool exact = true;
+    bool prompt_ok = true;
+    int first_bad = -1;
+    for (int64_t j = 0; j < T; ++j) {
+      if (got[static_cast<size_t>(j)] != gd[i * T + j]) exact = false;
+      const int32_t mn = gapd[i * T + j];
+      if (mn > worst_gap) {
+        worst_gap = mn;
+        worst_i = static_cast<int>(i);
+        worst_j = static_cast<int>(j);
+      }
+      if (mn > kLaneBandMnats) {
+        prompt_ok = false;
+        if (first_bad < 0) first_bad = static_cast<int>(j);
+      }
+    }
+    if (!prompt_ok) {
+      ++fail;
+      MESSAGE(label << " FORWARD DIVERGENCE prompt[" << i << "] tok=" << first_bad
+              << " our=" << got[static_cast<size_t>(first_bad)]
+              << " llamacpp_greedy=" << gd[i * T + first_bad]
+              << " gap=" << (gapd[i * T + first_bad] / 1000.0) << " nats (> "
+              << (kLaneBandMnats / 1000.0) << ") \"" << out.outputs[0].text
+              << "\"");
+    } else if (exact) {
+      ++strict_exact;
+    } else {
+      ++neartie_only;
+    }
+    CHECK(prompt_ok);
+  }
+  {
+    const int64_t staged = vt::tenstorrent::KeepQuantCaptureStagingWrites();
+    CHECK_MESSAGE(staged == 0,
+                  label << ": keep-quant decode staged " << staged
+                        << " word uploads DURING the captured e2e (the #2812 "
+                           "class)");
+    MESSAGE(label << ": device trace demand at last capture end = "
+            << vt::tenstorrent::LastTraceBytesForTest()
+            << " B (lane run 1; dynamic trace region)");
+  }
+  const int64_t selections =
+      vt::GetOpProviderStats(vt::OpId::kMatmulBTQuant, run_dev).selections;
+  const int64_t declines =
+      vt::GetOpProviderStats(vt::OpId::kMatmulBTQuant, run_dev).declines;
+  CHECK_MESSAGE(selections > 0,
+                label << ": kMatmulBTQuant never dispatched (lane e2e reach)");
+  CHECK_MESSAGE(declines == 0,
+                label << ": kMatmulBTQuant DECLINED and fell back");
+  vt::EnableOpProviderCallStats(false);
+
+  // Determinism leg: a SECOND engine load in this process is a SECOND decode
+  // capture (the op-level int8-dot capture test's x2 byte-identity mechanism
+  // at vehicle scale). The 16-prompt token stream must be byte-identical.
+  loaded.reset();
+  MESSAGE(label << ": determinism leg — reloading the engine (capture x2)...");
+  std::unique_ptr<vllm::entrypoints::LoadedEngine> loaded2 =
+      vllm::entrypoints::LoadedEngine::FromModelDir(model,
+                                                    vllm::entrypoints::EngineParams{});
+  std::vector<int32_t> run2;
+  for (int64_t i = 0; i < N; ++i) {
+    const vllm::RequestOutput out = loaded2->engine().generate(
+        Prompts()[static_cast<size_t>(i)], Greedy(static_cast<int>(T)),
+        "lane2-" + std::to_string(i));
+    REQUIRE(out.finished);
+    const std::vector<int32_t>& got = out.outputs[0].token_ids;
+    REQUIRE(static_cast<int64_t>(got.size()) == T);
+    run2.insert(run2.end(), got.begin(), got.end());
+  }
+  REQUIRE_MESSAGE(run1 == run2,
+                  label << ": capture x2 token streams DIVERGE at vehicle "
+                           "scale — the lane decode is not deterministic "
+                           "across two in-process captures");
+  MESSAGE(label << ": capture x2 byte-identity at vehicle scale: PASS; trace "
+                  "demand run 2 = "
+          << vt::tenstorrent::LastTraceBytesForTest() << " B");
+
+  MESSAGE(label << " lane correctness gate: " << (strict_exact + neartie_only)
+          << "/" << N << " prompts PASS  (STRICT token-exact vs pinned "
+                          "llama.cpp greedy: "
+          << strict_exact << "/" << N << "; near-tie-band only: " << neartie_only
+          << "/" << N << "; max gap " << (worst_gap / 1000.0) << " nats @ prompt["
+          << worst_i << "] tok=" << worst_j << "; band " << kLaneBandMnats
+          << " mnats; " << fail << " forward-divergent)");
+  REQUIRE(fail == 0);
+}
+
 }  // namespace
 
 // Qwen3.5-0.8B (GDN hybrid: linear-attention recurrence + full-attention
@@ -595,4 +824,28 @@ TEST_CASE("qwen3.8-27B GGUF Q4_K_M paged-engine greedy near-tie gate (Tenstorren
   }
   RunGate("qwen38_gguf_q4km_27b", "qwen38-gguf-q4km-27b", std::string(gguf),
           /*keep_quant=*/true);
+}
+
+// KEEPQUANT W4c (issue #3079): the int8-dot lane's e2e battery — lever
+// opt-in, llama.cpp-b10451-denominated, red-first on the missing pair.
+TEST_CASE("qwen3.5-0.8B GGUF Q4_K_M int8-dot lane e2e battery (Tenstorrent, lever opt-in)") {
+  const char* lever = std::getenv("VT_TT_KEEPQUANT_INT8DOT");
+  if (lever == nullptr || lever[0] == '\0' || std::string_view(lever) == "0") {
+    MESSAGE("SKIPPED: set VT_TT_KEEPQUANT_INT8DOT=1 — the int8-dot lane is "
+            "default OFF (the default-config flip is a recorded "
+            "NEEDS_DECISION); the default vehicle battery stays the W4a "
+            "16/16 invariant and this battery runs only as the documented "
+            "opt-in configuration");
+    return;
+  }
+  const char* gguf = std::getenv("VLLM_CPP_QWEN35_Q4KM_GGUF");
+  if (gguf == nullptr || gguf[0] == '\0') {
+    SkipGate("qwen35-gguf-q4km-lanegate",
+             "VLLM_CPP_QWEN35_Q4KM_GGUF is absent — set it to the local "
+             "Qwen3.5-0.8B-Q4_K_M.gguf (unsloth/Qwen3.5-0.8B-GGUF @ 6ab46149, "
+             "sha256 bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a0"
+             "6121dc517, 532517120 bytes) to run the int8-dot lane battery");
+  }
+  RunLaneGate("qwen35_gguf_q4km_lanegate", "qwen35-gguf-q4km-lanegate",
+              std::string(gguf));
 }


### PR DESCRIPTION
Row: `BACKEND-TENSTORRENT-KEEPQUANT`
Closes #3079? No — #3079 stays open; this lands its red-first stop, the hunt continues on it.

## What

The W4c lane-gate wave fired its binding stop condition. This commit lands the two validated tools the hunt inherits and records the stop; the measured pair, the band amendment, the docs, and the profile are **withheld** (reproducible from the recorded recipe, archived at `/tmp/w4bgate-pair-withheld/` for the hunt).

Two commits, spec first:
1. `fa23d690d` — the W4c spec section in `.agents/specs/tenstorrent-keepquant.md`: llama.cpp-domain denominator, red-first battery, band ratification rules, `>=1000 mnats` = STOP, docs/routing surface, default flip = NEEDS_DECISION.
2. `dac9e2b87` — the stop record: an opt-in `*int8-dot lane*` battery in `tests/parity/test_qwen35_paged_engine.cpp` (loud skip by default; red-first missing-pair REQUIRE) and `scripts/qwen3-neartie-gap-llamacpp-oracle.py` (oracle mode over a `llama-perplexity --save-all-logits` dump).

## The measurement (why the wave stopped)

Lane (`VT_TT_KEEPQUANT_INT8DOT=1`) vs pinned llama.cpp b10451, teacher-forced on our captured prefix, 16 prompts. Per-prompt max gaps: p5=1133, p1=333, p10=277, p7=176, p11=128, p4=97, p6=90, rest 0. Seven prompts sit under the 500 band; **p5 tok7 stands alone at ~1.1 nats** with a (5,11) 725 cascade and full re-convergence after. >=1000 = stop the wave: a bug hunt, not a band.

Trust legs green: red-first missing-pair REQUIRE exit 1; capture x2 byte-identical across a luwen reset (sha256 `35992508...`); zero dropped/unused tensors in both oracle loads; oracle self-consistency at (5,7) (incremental greedy == teacher-forced argmax = 264).

## Diagnosis the hunt starts from

W4b's ROCm-domain comparison measured the same cell at 1125 mnats; this llama.cpp-domain one at 1133. Two oracles that disagree with each other elsewhere on p5 both find the lane's (5,7) logits ~1.1 nats off their argmax, so the divergence is **vehicle-side and lane-introduced** — the default W4a path maxes at 375 mnats on the same battery. With the dot bit-exact per op, the suspects are the chunked cross-dot accumulation order, the f32-activation variant, the staged packed words at vehicle shapes, or a non-matmul lane-path component. First step: default-vs-lane logit/activation bisect at (5,7).

## Gates

- `agent-preflight.sh --staged` EXIT=0 on `dac9e2b87` (full suite, ~16 min).
- `check-commit-style.py` + `check-commit-trailers.py` EXIT=0 on both commits.
- Red-first evidence: battery fails exit 1 on the named missing-pair REQUIRE before the pair existed.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai-glm-5.3-flash [maki]
