### PR TITLE
fix(BACKEND-TENSTORRENT-KEEPQUANT): probe the TT DRAM total so the device fit can resolve (#3042)

### DIFF
--- a/src/vllm/platforms/tenstorrent.cpp
+++ b/src/vllm/platforms/tenstorrent.cpp
@@ -39,11 +39,17 @@ class TenstorrentPlatform final : public Platform {
     return {DType::kBF16, DType::kF32};
   }
 
-  // Discrete PCIe device (tenstorrent_backend.cpp UnifiedMemory()==false); no
-  // host-weight-release/pool-cap policy has been worked out for it yet, so the
-  // default (empty) ResidencyPolicy is the honest answer — same non-decision
-  // Vulkan's early skeleton made for the same reason.
-  ResidencyPolicy residency_policy() const override { return {}; }
+  // Discrete PCIe device (tenstorrent_backend.cpp UnifiedMemory()==false).
+  // The residency policy carries the probed DRAM total (banks x capacity):
+  // without it the MoE fit sees budget UNKNOWN and refuses, silently landing
+  // the model on CPU (ISSUE-LOCAL-01M2ACXRJYFW7R7BP2ABQS3VY2) — the empty
+  // policy was the honest answer only while no probe existed.
+  ResidencyPolicy residency_policy() const override {
+    ResidencyPolicy policy;
+    policy.device_memory_total_bytes =
+        static_cast<size_t>(vt::tenstorrent::DeviceDramTotalBytes());
+    return policy;
+  }
 
   // Explicit allow-list of architectures whose full op set is registered for
   // kTENSTORRENT (mirrors MetalPlatform::supports_model_architecture). OPT-125m

--- a/src/vt/tenstorrent/tenstorrent_device.h
+++ b/src/vt/tenstorrent/tenstorrent_device.h
@@ -218,6 +218,9 @@ void ResetAllocTraceForTest();
 // observable — the W1 trace proved the decode planes never return to the
 // allocator; this is the red-first probe the reclaim test asserts on.
 int64_t FreeDeviceDramBytesForTest();
+// Total DRAM across banks (capacity, not free) — the platform's probed
+// total for the placement fit (ISSUE-LOCAL-01M2ACXRJYFW7R7BP2ABQS3VY2).
+int64_t DeviceDramTotalBytes();
 #else
 inline int64_t KeepQuantCaptureStagingWrites() { return 0; }
 inline void ResetKeepQuantCaptureStagingWritesForTest() {}
@@ -231,6 +234,7 @@ inline int64_t AllocTraceSnapshotCountForTest() { return 0; }
 inline int64_t AllocTraceMaxDeltaForTest() { return 0; }
 inline void ResetAllocTraceForTest() {}
 inline int64_t FreeDeviceDramBytesForTest() { return 0; }
+inline int64_t DeviceDramTotalBytes() { return 0; }
 #endif
 
 // ITEM 5 (rope): driver-side warm hook — populate the persistent device

--- a/src/vt/tenstorrent/tenstorrent_ops.cpp
+++ b/src/vt/tenstorrent/tenstorrent_ops.cpp
@@ -8723,6 +8723,18 @@ int64_t FreeDeviceDramBytesForTest() {
   return static_cast<int64_t>(view.num_banks) *
          static_cast<int64_t>(view.total_bytes_free_per_bank);
 }
+
+// Total DRAM across banks — the number the placement fit needs as the
+// platform's probed total (ISSUE-LOCAL-01M2ACXRJYFW7R7BP2ABQS3VY2: without
+// it the budget is UNKNOWN and the MoE fit refuses, landing the model on
+// CPU). Same view the free-bytes helper reads; capacity, not free.
+int64_t DeviceDramTotalBytes() {
+  MeshDevice& device = SharedMeshDevice();
+  const auto view = tt::tt_metal::detail::GetMemoryView(
+      &device, tt::tt_metal::BufferType::DRAM);
+  return static_cast<int64_t>(view.num_banks) *
+         static_cast<int64_t>(view.total_bytes_per_bank);
+}
 void ResetAllocTraceForTest() {
   std::lock_guard<std::mutex> g(AllocTraceSt().mtx);
   AllocTraceSt().snapshot_count = 0;


### PR DESCRIPTION
fix(BACKEND-TENSTORRENT-KEEPQUANT): probe the TT DRAM total so the device fit can resolve (#3042)

The Tenstorrent platform returned an empty ResidencyPolicy, so
device_memory_total_bytes was 0 and the GGUF device fit read the budget
as UNKNOWN — its documented refusal (a zero budget must not mean
"everything fits") — and placed nothing: every qwen3.8 checkpoint
silently landed on CPU, and the 27B never reached the P150. Caught by
the 27B gate's device fail-safe (exit 77, "goldens are
ROCm-oracle-captured; this run is on device type 0") refusing to grade
a CPU capture as a Tenstorrent run; the same refusal, on a TT=ON build,
is the red: "engine: device placement: --fit resolved NO placement: the
device memory budget is UNKNOWN (the platform reports no total)".

The fix mirrors the W4d W2 free-DRAM helper: DeviceDramTotalBytes()
reads the allocator view's num_banks x total_bytes_per_bank
(34359738368 on the Blackhole P150) and
TenstorrentPlatform::residency_policy() now carries it instead of the
empty policy, whose comment already called itself a non-decision "for
the same reason" as Vulkan's early skeleton.

Green: the same 27B gate on a build carrying exactly this probe
(plus unlanded trace instrumentation) resolves onto Tenstorrent —
"running on device type 6 (5=ROCM, 6=TENSTORRENT) — gated against
this device's OWN oracle-backed golden" — and streams the 17 GB
checkpoint to the card. On this clean branch the gate reports its
correct loud skips (missing-golden bootstrap, exit 77), which is the
right state until the capture campaign lands. The run then hits the
separate init-path DRAM OOM (1073725440 B ternary output, banks at 93
percent, ISSUE-LOCAL-01M2AA4ZVD9EWJG5NNQD5DWZXS and
ISSUE-LOCAL-01M2ACXRJYFW7R7BP2ABQS3VY2), which is the next wave's
defect and is deliberately not addressed here: without this change
that hunt cannot even start, because nothing reaches the card.

FOLLOWING_AGENTS_PROTOCOL

Following-Agents-Protocol: true
AI-Assisted: true
Assisted-by: AGENT:zai/glm-5.3-flash [maki]
